### PR TITLE
docs: add Release Notes section

### DIFF
--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -146,8 +146,9 @@ lands on a clean, self-describing commit.
 
 - **Migration guide** — required for any **breaking change** (any
   Major bump, and Minor bumps that change wire formats or remove
-  syntax). Add `docs/migration/<from>_to_<to>.md` following the
-  shape of [`4.1_to_4.2.md`](../migration/4.1_to_4.2.md): a
+  syntax). Add a `docs/releases/<version>-migration.md` page nested
+  under that release (see the [Release Notes style guide](../releases/style-guide.md)),
+  following the shape of [`4.2.0-migration.md`](../releases/4.2.0-migration.md): a
   break-by-break table (symptom → fix scope) plus a worked
   before/after for each. Link it from the release notes.
 

--- a/docs/releases/4.2.0-migration.md
+++ b/docs/releases/4.2.0-migration.md
@@ -1,6 +1,8 @@
 ---
-title: "Migrating from framec 4.1.x to 4.2.0"
-nav_order: 8
+title: "Migration: 4.1.x → 4.2.0"
+parent: "v4.2.0"
+grand_parent: "Release Notes"
+nav_order: 1
 ---
 
 # Migrating from framec 4.1.x to 4.2.0

--- a/docs/releases/4.2.0.md
+++ b/docs/releases/4.2.0.md
@@ -1,0 +1,42 @@
+---
+title: "v4.2.0"
+parent: Release Notes
+nav_order: 1
+has_children: true
+---
+
+# v4.2.0
+
+*Released 2026-05-21 · [GitHub release](https://github.com/frame-lang/framec/releases/tag/v4.2.0) · [CHANGELOG](https://github.com/frame-lang/framec/blob/main/CHANGELOG.md#420---2026-05-21)*
+
+A large release: `no_std` Rust support, cross-file composition via the Oceans
+Model, and **four breaking changes**. Upgrading from 4.1.x? Read the
+**[Migration: 4.1.x → 4.2.0](4.2.0-migration.md)** child page — it walks each
+break with fix-its.
+
+## Highlights
+
+- **`no_std` support for the Rust target (#31, #33)** — generated Rust can run
+  in `no_std` / embedded / interrupt contexts.
+- **Cross-file composition via the Oceans Model (RFC-0022 → RFC-0024)** —
+  multi-system Frame projects now compose through the host language's own
+  imports rather than a Frame-level `@@import`.
+- **RFC-0017 init decoupling** — the per-backend initialization mechanism was
+  reworked (breaking; see migration).
+- **Quality & test infrastructure** — RFC-0027 in-tree snapshot tests (insta),
+  property-based tests for codegen invariants, and the RFC-0031 post-release
+  process.
+
+## Breaking changes
+
+Four user-visible breaks — each surfaces as a clear compile error or wire-format
+mismatch. Full walk-throughs in the **[Migration guide](4.2.0-migration.md)**:
+
+- **`@@import` removed (RFC-0024)** — `E823`; replace with the target language's
+  native import syntax.
+- **`@@codegen { ... }` removed (RFC-0032)** — `E824`; delete the block
+  (auto-inference replaces it).
+- **Enter/exit cascade removed (RFC-0019)** — ancestor `$>` / `<$` no longer run
+  implicitly; forward explicitly with `=> $^`.
+- **Persist wire-format changes** — Python / Lua / Erlang blobs saved by 4.1.x
+  need a one-time migration.

--- a/docs/releases/4.2.1.md
+++ b/docs/releases/4.2.1.md
@@ -1,0 +1,26 @@
+---
+title: "v4.2.1"
+parent: Release Notes
+nav_order: 2
+---
+
+# v4.2.1
+
+*Released 2026-05-22 · [GitHub release](https://github.com/frame-lang/framec/releases/tag/v4.2.1) · [CHANGELOG](https://github.com/frame-lang/framec/blob/main/CHANGELOG.md#421---2026-05-22)*
+
+Rust-target codegen fixes. No surface-syntax or wire-format changes; the other
+16 backends are unaffected.
+
+## Highlights
+
+- **Typed lifecycle args (RFC-0025.1, #34/#35)** — Rust `$>` / `<$` enter/exit
+  args now ride the typed per-state `StateContext` instead of a stringified
+  `Vec<String>` + `parse::<T>()`. Fixes silent default-on-parse-miss and the
+  hard break on compound types (`Vec<i64>: FromStr`); includes start-state `<$`
+  binding and decorated `pop$` args.
+- **Fixed `E0124` collisions** — a state named `$Empty` (the no-context
+  sentinel is now `__NoContext`) and a state var sharing a name with a
+  lifecycle/state param no longer emit duplicate Rust identifiers.
+- **Validator E115** — state names beginning with the reserved `__` prefix are
+  rejected, guaranteeing user state names never collide with framec-synthesized
+  identifiers on any backend.

--- a/docs/releases/4.2.3.md
+++ b/docs/releases/4.2.3.md
@@ -1,0 +1,39 @@
+---
+title: "v4.2.3"
+parent: Release Notes
+nav_order: 3
+---
+
+# v4.2.3
+
+*Released 2026-05-24 · [GitHub release](https://github.com/frame-lang/framec/releases/tag/v4.2.3) · [CHANGELOG](https://github.com/frame-lang/framec/blob/main/CHANGELOG.md#423---2026-05-24)*
+
+Type-name passthrough is now total, and statically-typed targets enforce typed
+parameters. Surface syntax is unchanged; the behavior change affects only
+sources that relied on the old portable-alias translation.
+
+## Highlights
+
+- **Type names pass through verbatim on every target (#37)** — framec no longer
+  rewrites a portable alias to a per-backend native type (`int`→`i64`,
+  `str`→`String`, …); it copies the type name you write straight into the
+  output, honoring Frame's "no type system — type names pass through" contract.
+  Structural transforms (Rust borrow→owned widening, Kotlin `void`→`Unit`, C
+  runtime containers) are unaffected.
+- **E606 — statically-typed targets require typed parameters (#37)** — on C,
+  C++, Java, Go, Rust, C#, Kotlin, and Swift, an untyped event / handler /
+  state / lifecycle parameter is now a hard error with a fix-it.
+- **Default-target warning + `FRAMEC_DEFAULT_TARGET` (#36)** — framec warns once
+  before falling back to `python_3`, and the env var sets the implicit target.
+- **WASM build / `@frame-lang/framec-wasm`** — the library builds for `wasm32`;
+  the wasm-bindgen entry point lives in a separate `framec-wasm` crate.
+
+## Action required
+
+**Statically-typed targets** (C, C++, Java, Go, Rust, C#, Kotlin, Swift): write
+your target's own type names instead of portable aliases — e.g. `x: i64`
+(Rust), `x: long` (Java), `x: std::string` (C++). **Dynamic targets** (Python,
+JS, TS, Ruby, Lua, PHP, Dart, GDScript) are unaffected.
+
+> 4.2.2 was tagged but never released — its commit tripped the CI formatting
+> gate; 4.2.3 is the same content cut from a clean commit.

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -1,0 +1,17 @@
+---
+title: Release Notes
+nav_order: 13
+has_children: true
+child_nav_order: reversed
+---
+
+# Release Notes
+
+Per-release notes for `framec`, newest first. Each page summarizes **what
+changed and why**; breaking-change and migration details are attached to the
+release that introduced them.
+
+- Exhaustive, detailed record: [`CHANGELOG.md`](https://github.com/frame-lang/framec/blob/main/CHANGELOG.md)
+- Downloadable binaries: [GitHub Releases](https://github.com/frame-lang/framec/releases)
+
+Writing a release page? Follow the [Style Guide](style-guide.md).

--- a/docs/releases/style-guide.md
+++ b/docs/releases/style-guide.md
@@ -1,0 +1,64 @@
+---
+title: Style Guide
+parent: Release Notes
+nav_order: 0
+---
+
+# Release Notes — Style Guide
+
+How to write a page in this section. Keep pages **skimmable and why-focused**;
+[`CHANGELOG.md`](https://github.com/frame-lang/framec/blob/main/CHANGELOG.md)
+remains the exhaustive, line-level record — release pages summarize and link to
+it, they don't replace it.
+
+## File & front matter
+
+One page per **published** release at `docs/releases/X.Y.Z.md`:
+
+```yaml
+---
+title: "vX.Y.Z"
+parent: Release Notes
+nav_order: <next integer, one higher than the current newest>
+---
+```
+
+- The section sets `child_nav_order: reversed`, so the highest `nav_order`
+  shows first — **new releases never require renumbering**.
+- Skip release-candidate tags (`*-rcN`) and formatting-only point releases with
+  no CHANGELOG entry.
+
+## Page structure
+
+1. **`# vX.Y.Z`** heading.
+2. A one-line meta line:
+   `*Released YYYY-MM-DD · [GitHub release](…) · [CHANGELOG](…)*`
+3. **One short paragraph** — the headline in plain language: what changed and
+   who's affected.
+4. **`## Highlights`** — 3–6 bullets. Lead each with a **bold subject**, then
+   one sentence of *what + why*. Draw from the `## [X.Y.Z]` CHANGELOG section;
+   don't copy it wholesale.
+5. **`## Breaking changes`** *(only if any)* — one bullet per break with its
+   error code and the one-line fix.
+6. **`## Action required`** *(optional)* — concrete upgrade steps, if short.
+
+## Migration content
+
+Breaking-change walk-throughs live **with the release that introduced them**, as
+a child page of that release:
+
+- File: `docs/releases/X.Y.Z-migration.md`
+- Front matter: `parent: "vX.Y.Z"`, `grand_parent: "Release Notes"`
+- Mark the release page's parent `has_children: true`, and link to the
+  migration page from its **Breaking changes** section.
+
+See [v4.2.0](4.2.0.md) and its [Migration guide](4.2.0-migration.md) for a
+worked example.
+
+## Tone
+
+- Write for someone deciding **whether and how to upgrade**, not for a commit
+  log.
+- Prefer *why it changed* over *what line changed*.
+- Link out (GitHub release, CHANGELOG, RFCs) rather than duplicating detail.
+- Plain language over jargon; expand an RFC number on first mention.


### PR DESCRIPTION
## Summary

Adds a **Release Notes** section to the docs site, organized by release.

- New section `docs/releases/` (nav: bottom, newest-first via `child_nav_order: reversed`).
- Per-release pages **v4.2.0 / v4.2.1 / v4.2.3** — short narrative + Highlights + links to the GitHub release and `CHANGELOG.md` (kept as the canonical detailed record).
- The **4.1.x → 4.2.0 migration guide** is moved out of the top-level nav and **nested under v4.2.0** (3-level nav), so migration info lives with the release that introduced the breaks.
- A **Style Guide** page documenting how to format release + migration pages.
- Releasing runbook (`contributing/releasing.md`) link updated to the new migration path.

## Test plan

- [x] `jekyll build` clean; doc-sample validator **118/118**
- [x] Section renders: Release Notes → v4.2.3, v4.2.1, v4.2.0 (→ Migration), Style Guide
- [x] Old `/migration/4.1_to_4.2.html` path removed (404); new pages 200
- [ ] visual pass on the live site after merge