### PR TITLE
docs: add GoatCounter analytics

### DIFF
--- a/docs/_includes/head_custom.html
+++ b/docs/_includes/head_custom.html
@@ -53,3 +53,8 @@
   else document.addEventListener("DOMContentLoaded", ready);
 })();
 </script>
+
+<!-- GoatCounter analytics (cookieless; auto-skips localhost, so local
+     previews aren't counted). Dashboard: https://frame-lang-org.goatcounter.com -->
+<script data-goatcounter="https://frame-lang-org.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>


### PR DESCRIPTION
Adds a cookieless GoatCounter snippet to `head_custom.html` for visit tracking on docs.frame-lang.org. Auto-skips localhost (local previews aren't counted). No GA / Google dependency. Dashboard: frame-lang-org.goatcounter.com