### PR TITLE
fix(codegen): push$ -> $State emitted a non-existent _transition() on the dynamic backends

### DIFF
--- a/framec/src/frame_c/compiler/codegen/frame_expansion/stack.rs
+++ b/framec/src/frame_c/compiler/codegen/frame_expansion/stack.rs
@@ -47,9 +47,12 @@ pub(super) fn expand_stack_push(
         TargetLanguage::Python3 => {
             let push_code = format!("{}self._state_stack.append(self.__compartment)", indent_str);
             if !target.is_empty() {
+                // Compartment model (matches a normal transition + `-> pop$`).
+                // The runtime has no `_transition(name, …)` method — only
+                // `__transition(compartment)`. See FRAMEC_BUGS Issue #42.
                 format!(
-                    "{}\n{}self._transition(\"{}\", None, None)",
-                    push_code, indent_str, target
+                    "{}\n{}__compartment = self.__prepareEnter(\"{}\", [], [])\n{}self.__transition(__compartment)\n{}return",
+                    push_code, indent_str, target, indent_str, indent_str
                 )
             } else {
                 push_code
@@ -58,9 +61,12 @@ pub(super) fn expand_stack_push(
         TargetLanguage::GDScript => {
             let push_code = format!("{}self._state_stack.append(self.__compartment)", indent_str);
             if !target.is_empty() {
+                // Compartment model (matches a normal transition + `-> pop$`).
+                // The runtime has no `_transition(name, …)` func — only
+                // `__transition(next_compartment)`. See FRAMEC_BUGS Issue #42.
                 format!(
-                    "{}\n{}self._transition(\"{}\", null, null)",
-                    push_code, indent_str, target
+                    "{}\n{}var __compartment = self.__prepareEnter(\"{}\", [], [])\n{}self.__transition(__compartment)\n{}return",
+                    push_code, indent_str, target, indent_str, indent_str
                 )
             } else {
                 push_code

--- a/framec/src/frame_c/compiler/codegen/frame_expansion/stack.rs
+++ b/framec/src/frame_c/compiler/codegen/frame_expansion/stack.rs
@@ -69,9 +69,14 @@ pub(super) fn expand_stack_push(
         TargetLanguage::TypeScript | TargetLanguage::JavaScript => {
             let push_code = format!("{}this._state_stack.push(this.__compartment);", indent_str);
             if !target.is_empty() {
+                // Transition the same way a normal transition does (compartment
+                // model: __prepareEnter + __transition + return). The JS/TS
+                // runtime has no `_transition(name, …)` method — only
+                // `__transition(compartment)` — so the old form threw at
+                // runtime. See FRAMEC_BUGS Issue #42.
                 format!(
-                    "{}\n{}this._transition(\"{}\", null, null);",
-                    push_code, indent_str, target
+                    "{}\n{}const __compartment = this.__prepareEnter(\"{}\", [], []);\n{}this.__transition(__compartment);\n{}return;",
+                    push_code, indent_str, target, indent_str, indent_str
                 )
             } else {
                 push_code

--- a/framec/src/frame_c/compiler/frame_ast.rs
+++ b/framec/src/frame_c/compiler/frame_ast.rs
@@ -448,6 +448,13 @@ pub struct StackPushAst {
     pub span: Span,
     /// Source indentation level (for proper code generation)
     pub indent: usize,
+    /// Target state of a `push$ -> $State` (push-with-transition), or `None`
+    /// for a bare `push$`. The parser leaves this `None`; it's filled by
+    /// `enrich_handler_body_metadata` from the scanner segment (like a
+    /// Transition's args). Exposes the edge to AST-based passes such as the
+    /// W414 reachability walker. (Codegen reads the target from the scanner
+    /// metadata directly.)
+    pub transition_target: Option<String>,
 }
 
 /// Stack pop (pop$)

--- a/framec/src/frame_c/compiler/frame_validator.rs
+++ b/framec/src/frame_c/compiler/frame_validator.rs
@@ -1325,6 +1325,77 @@ mod tests {
         // In this case both are terminals so only the last matters
     }
 
+    /// W414: a `push$ -> $State` reaches its target — the push-with-transition
+    /// edge must be followed by the reachability walker (regression for the
+    /// false positive that flagged `$Paused`/`$Hyperspace` etc.). A genuinely
+    /// orphaned state is still flagged.
+    #[test]
+    fn test_w414_push_transition_target_reachable() {
+        use std::collections::HashMap;
+        let sp = || Span::new(0, 0);
+        let handler = |event: &str, stmts: Vec<Statement>| HandlerAst {
+            event: event.to_string(),
+            params: vec![],
+            return_type: None,
+            return_init: None,
+            body: HandlerBody {
+                statements: stmts,
+                span: sp(),
+            },
+            leading_comments: vec![],
+            attributes: vec![],
+            span: sp(),
+        };
+        let state = |name: &str, handlers: Vec<HandlerAst>| StateAst {
+            name: name.to_string(),
+            params: vec![],
+            parent: None,
+            state_vars: vec![],
+            handlers,
+            enter: None,
+            exit: None,
+            default_forward: false,
+            leading_comments: vec![],
+            span: sp(),
+            body_span: sp(),
+        };
+
+        // $Active { pause() { push$ -> $Paused } }  $Paused { ... }  $Orphan { }
+        let active = state(
+            "Active",
+            vec![handler(
+                "pause",
+                vec![Statement::StackPush(StackPushAst {
+                    span: sp(),
+                    indent: 0,
+                    transition_target: Some("Paused".to_string()),
+                })],
+            )],
+        );
+        let paused = state("Paused", vec![]);
+        let orphan = state("Orphan", vec![]);
+
+        let machine = MachineAst {
+            states: vec![active, paused, orphan],
+            span: sp(),
+        };
+        let state_map: HashMap<String, &StateAst> =
+            machine.states.iter().map(|s| (s.name.clone(), s)).collect();
+
+        let mut v = FrameValidator::new();
+        v.validate_reachable_states("Sys", &machine, &state_map);
+        let warned: Vec<String> = v.warnings.iter().map(|w| w.message.clone()).collect();
+
+        assert!(
+            !warned.iter().any(|m| m.contains("'Paused'")),
+            "push$ -> $Paused target must be reachable, not W414: {warned:?}"
+        );
+        assert!(
+            warned.iter().any(|m| m.contains("'Orphan'")),
+            "a genuinely unreachable state must still be W414: {warned:?}"
+        );
+    }
+
     #[test]
     fn test_validate_with_arcanum() {
         // Happy-path arcanum-backed validation: a system with valid

--- a/framec/src/frame_c/compiler/frame_validator/machine.rs
+++ b/framec/src/frame_c/compiler/frame_validator/machine.rs
@@ -104,10 +104,18 @@ impl FrameValidator {
         let mut edges: HashMap<String, Vec<String>> = HashMap::new();
         let collect_body = |body: &HandlerBody, out: &mut Vec<String>| {
             for stmt in &body.statements {
-                if let Statement::Transition(trans) = stmt {
-                    if trans.target != "pop$" {
+                match stmt {
+                    Statement::Transition(trans) if trans.target != "pop$" => {
                         out.push(trans.target.clone());
                     }
+                    // `push$ -> $State` reaches $State just like a normal
+                    // transition (the push only saves the current compartment).
+                    Statement::StackPush(push) => {
+                        if let Some(target) = &push.transition_target {
+                            out.push(target.clone());
+                        }
+                    }
+                    _ => {}
                 }
             }
         };

--- a/framec/src/frame_c/compiler/native_region_scanner/mod.rs
+++ b/framec/src/frame_c/compiler/native_region_scanner/mod.rs
@@ -219,9 +219,16 @@ pub fn regions_to_statements(
                         }));
                     }
                     FrameSegmentKind::StackPush => {
+                        let transition_target = match metadata {
+                            SegmentMetadata::StackPush { transition_target } => {
+                                transition_target.clone()
+                            }
+                            _ => None,
+                        };
                         stmts.push(Statement::StackPush(StackPushAst {
                             span: seg_span,
                             indent: *indent,
+                            transition_target,
                         }));
                     }
                     FrameSegmentKind::StackPop => {
@@ -501,6 +508,34 @@ pub fn enrich_handler_body_metadata(
                 }
             }
             scanner_idx += 1;
+        }
+    }
+
+    // Patch push-with-transition targets onto StackPush statements, in source
+    // order (parallel to the Transition arg patching above). The parser leaves
+    // `transition_target` None; the scanner computes it. This surfaces the
+    // `push$ -> $State` edge to AST passes (e.g. the W414 reachability walker).
+    let scanner_pushes: Vec<&SegmentMetadata> = scan_result
+        .regions
+        .iter()
+        .filter_map(|r| match r {
+            Region::FrameSegment {
+                kind: FrameSegmentKind::StackPush,
+                metadata,
+                ..
+            } => Some(metadata),
+            _ => None,
+        })
+        .collect();
+    let mut push_idx = 0usize;
+    for stmt in body.statements.iter_mut() {
+        if let Statement::StackPush(p) = stmt {
+            if let Some(SegmentMetadata::StackPush { transition_target }) =
+                scanner_pushes.get(push_idx).copied()
+            {
+                p.transition_target = transition_target.clone();
+            }
+            push_idx += 1;
         }
     }
 }

--- a/framec/src/frame_c/compiler/pipeline_parser/mod.rs
+++ b/framec/src/frame_c/compiler/pipeline_parser/mod.rs
@@ -931,6 +931,7 @@ impl<'a> Parser<'a> {
                     statements.push(Statement::StackPush(StackPushAst {
                         span: tok.span,
                         indent: 0,
+                        transition_target: None,
                     }));
                 }
 

--- a/framec/tests/gdscript_snapshots.rs
+++ b/framec/tests/gdscript_snapshots.rs
@@ -6,11 +6,42 @@
 
 mod common;
 
-use common::compile_fixture;
+use common::{compile_fixture, compile_source};
 
 #[test]
 fn linear_fsm() {
     insta::assert_snapshot!(compile_fixture("01_linear_fsm", "gdscript"));
+}
+
+/// Regression for the `push$ -> $State` codegen bug (Issue #42): the
+/// with-transition form must use the compartment model (`__prepareEnter` +
+/// `__transition`), not the removed `_transition()`. The `05_pushpop` fixture
+/// only covers bare `push$` + a separate transition.
+#[test]
+fn push_transition() {
+    let src = r#"
+@@system PushTransition {
+    interface:
+        go()
+        back()
+    machine:
+        $A { go() { push$ -> $B } }
+        $B { back() { -> pop$ } }
+}
+"#;
+    let out = compile_source(src, "gdscript");
+    assert!(
+        out.contains("self._state_stack.append(self.__compartment)"),
+        "push$ -> $State must push the current compartment:\n{out}"
+    );
+    assert!(
+        out.contains("self.__transition(__compartment)"),
+        "push$ -> $State must transition via the compartment model:\n{out}"
+    );
+    assert!(
+        !out.contains("self._transition("),
+        "push$ -> $State must not call the non-existent _transition():\n{out}"
+    );
 }
 
 #[test]

--- a/framec/tests/javascript_snapshots.rs
+++ b/framec/tests/javascript_snapshots.rs
@@ -6,8 +6,40 @@
 
 mod common;
 
-use common::{compile_check_all, compile_fixture, find_tool};
+use common::{compile_check_all, compile_fixture, compile_source, find_tool};
 use std::process::Command;
+
+/// Regression for the JS/TS `push$ -> $State` codegen bug: the with-transition
+/// form must use the compartment model (`__prepareEnter` + `__transition`), not
+/// the removed `_transition()`, which threw at runtime. The `05_pushpop` fixture
+/// only covers bare `push$` followed by a separate transition, so this asserts
+/// the push-with-transition path directly.
+#[test]
+fn push_transition() {
+    let src = r#"
+@@system PushTransition {
+    interface:
+        go()
+        back()
+    machine:
+        $A { go() { push$ -> $B } }
+        $B { back() { -> pop$ } }
+}
+"#;
+    let out = compile_source(src, "javascript");
+    assert!(
+        out.contains("this._state_stack.push(this.__compartment)"),
+        "push$ -> $State must push the current compartment onto the stack:\n{out}"
+    );
+    assert!(
+        out.contains("this.__transition(__compartment)"),
+        "push$ -> $State must transition via the compartment model:\n{out}"
+    );
+    assert!(
+        !out.contains("this._transition("),
+        "push$ -> $State must not call the non-existent _transition():\n{out}"
+    );
+}
 
 /// RFC-0034: every canonical fixture's framec-emitted JavaScript
 /// output must parse cleanly under `node --check`. Closes the

--- a/framec/tests/python_snapshots.rs
+++ b/framec/tests/python_snapshots.rs
@@ -19,6 +19,37 @@ mod common;
 use common::{compile_check_all, compile_fixture, compile_source, find_tool};
 use std::process::Command;
 
+/// Regression for the `push$ -> $State` codegen bug (Issue #42): the
+/// with-transition form must use the compartment model (`__prepareEnter` +
+/// `__transition`), not the removed `_transition()`. The `05_pushpop` fixture
+/// only covers bare `push$` + a separate transition.
+#[test]
+fn push_transition() {
+    let src = r#"
+@@system PushTransition {
+    interface:
+        go()
+        back()
+    machine:
+        $A { go() { push$ -> $B } }
+        $B { back() { -> pop$ } }
+}
+"#;
+    let out = compile_source(src, "python_3");
+    assert!(
+        out.contains("self._state_stack.append(self.__compartment)"),
+        "push$ -> $State must push the current compartment:\n{out}"
+    );
+    assert!(
+        out.contains("self.__transition(__compartment)"),
+        "push$ -> $State must transition via the compartment model:\n{out}"
+    );
+    assert!(
+        !out.contains("self._transition("),
+        "push$ -> $State must not call the non-existent _transition():\n{out}"
+    );
+}
+
 #[test]
 fn linear_fsm() {
     insta::assert_snapshot!(compile_fixture("01_linear_fsm", "python_3"));


### PR DESCRIPTION
## Problem

`push$ -> $State` (push-with-transition) was broken on the **dynamic backends**
(JavaScript, TypeScript, Python, GDScript). Each emitted a call to a
`_transition(name, …)` method the runtime doesn't define — it uses the
compartment model (`__prepareEnter` + `__transition(compartment)`):

```js
this._state_stack.push(this.__compartment);
this._transition("X", null, null);   // ❌ throws: _transition is not a function
```

So any `push$ -> $State` threw at runtime (`TypeError` / `AttributeError` /
Godot error). Normal transitions and `-> pop$` were already correct.

Found while porting the arcade games to Phaser/JS. Logged as Issue #42.

## Scope — verified all 17 backends

| Backend | Status |
|---|---|
| JavaScript, TypeScript, **Python, GDScript** | ❌ broken → **fixed here** |
| Dart, Rust, C, C++, Java, Kotlin, Swift, Go, C#, PHP, Ruby, Lua, Erlang | ✅ never affected (already call the real `__transition(...)`) |

The bug was confined to the four dynamic backends.

## Fixes

**1. Codegen** — `expand_stack_push`'s JS/TS/Python/GDScript arms now emit the
compartment model (`__prepareEnter` + `__transition` + return) after the stack
push, mirroring a normal transition and each backend's own `-> pop$`.

**2. W414 reachability (was a follow-up; now included)** — states only entered
via `push$ -> $State` (e.g. `$Paused`) were wrongly flagged
*"not reachable from start state."* The reachability walker built edges from
`Transition` statements only, and the parser drops the push target (recovered
later by the scanner for codegen). Fix: `StackPushAst` gains a
`transition_target` field, `enrich_handler_body_metadata` populates it from the
scanner segment (parallel to Transition-arg enrichment), and the W414 edge
builder follows it. Target-agnostic. A genuinely orphaned state is still flagged.

## Why it slipped through

`fixtures/_canonical/05_pushpop.frm` only exercises **bare `push$`** + a
*separate* `-> $Nested` transition — never the single-segment `push$ -> $State`
form. Added regression tests for both the codegen and the W414 reachability.

## Test plan

- [x] `cargo test -p framec --lib` — 481 pass (incl. new `test_w414_push_transition_target_reachable`)
- [x] javascript/python/gdscript snapshot suites — pass incl. new `push_transition` (no drift)
- [x] Manual runtime round-trip (state preserved across the stack) in Node + Python
- [x] W414 verified gone for `push$ -> $State` on JS/Python/GDScript; still fires for a true orphan
- [ ] CI: full snapshot + 17-backend matrix