### PR TITLE
chore(release): 4.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,56 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [4.2.4] - 2026-05-26
+
+A maintenance release. Two user-visible codegen fixes; the bulk is internal —
+framec's own parser and several scanners are now Frame state machines
+(dogfooding), and the compile pipeline is FSM-driven. **Generated output is
+byte-identical to 4.2.3 except for the two fixes below** — every internal
+refactor was verified against the code it replaced (17-backend matrix +
+full structural fuzz, both green).
+
+### Fixed
+
+- **`push$ -> $State` codegen (#42).** Inline push-with-transition emitted a
+  call to a non-existent `_transition()` on Python, GDScript, JavaScript, and
+  TypeScript, and the W414 reachability check didn't count `push$ -> $State`
+  edges. It now lowers through the compartment model (`__prepareEnter` +
+  `__transition`) like every other transition, and reachability counts the edge.
+- **Multi-line `domain:` default literals (#41).** A dict/array default that
+  spanned multiple physical lines was split at the first newline into stray
+  field declarations; it is now captured whole (via the dogfooded
+  `ExprScannerFsm`).
+
+### Changed
+
+Internal architecture — no change to generated code:
+
+- **The parser is now a Frame state machine (RFC-0039).** A `SystemBackbone`
+  Frame system owns and drives parsing, calling the recursive-descent
+  `parse_*` methods as native oracles; the lexer was made lifetime-free so the
+  backbone can hold it. framec's own front-end grammar is now expressed in Frame.
+- **The compile pipeline is FSM-driven (RFC-0035 Round 8).** `compile_ast_based`
+  was carved into phase functions sequenced by a `PipelineFsm` (one state per
+  phase: segment → parse → module-gates → graphviz → validate+codegen →
+  assemble); the previous observational supervisor was replaced by one that
+  actually controls the flow.
+- **Scanners converted to Frame FSMs (RFC-0035 Rounds 9–12):** the `domain:`
+  line scanner, the assembler's `@@SystemName(args)` call-site lexer, the
+  transition-string metadata parser, and the Erlang paren-balance lexical
+  scanner. Several inline delimiter scans now reuse the existing dogfooded
+  `ExprScannerFsm` / `AttributeScannerFsm` (#372/#373).
+
+### Added
+
+- **Frame Syntax Taxonomy** — a standard-compiler-terminology appendix in the
+  language guide, anchored by behavioral tests, a compile-time exhaustiveness
+  guard over the token + statement enums, and a horizontal-whitespace
+  invariance generator.
+- **RFC-0039** (parser as composed Frame state machines), Accepted; **RFC-0035**
+  dogfooding roadmap Rounds 8–13; glossary "backbone" / "oracle" terms; a
+  Release Notes section + style guide.
+
 ## [4.2.3] - 2026-05-24
 
 Type-name passthrough is now total, and statically-typed targets enforce

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "framec"
-version = "4.2.3"
+version = "4.2.4"
 dependencies = [
  "chrono",
  "clap",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "framec-wasm"
-version = "4.2.3"
+version = "4.2.4"
 dependencies = [
  "framec",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["framec", "framec-wasm"]
 
 [workspace.package]
-version = "4.2.3"
+version = "4.2.4"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/frame-lang/framec"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![CI](https://github.com/frame-lang/framec/actions/workflows/ci.yml/badge.svg)
 ![License](https://img.shields.io/badge/license-Apache--2.0-blue)
-![Version](https://img.shields.io/badge/version-4.2.3-green)
+![Version](https://img.shields.io/badge/version-4.2.4-green)
 
 framec (aka the **framepiler**) — is the transpiler for the Frame language. Currently framec supports output to 17 target languges + Graphviz. Frame is a domain-specific language for specifying state machines that transpiles to production code in multiple target languages. You write `@@system` blocks inside your native source files, and the framepiler expands them into full state machine implementations. All native code passes through unchanged — your native compiler handles everything outside the `@@system` blocks and other `@@` tagged pragmas and statements.
 


### PR DESCRIPTION
Patch release. Bumps version 4.2.3 → 4.2.4 (Cargo.toml + Cargo.lock + README badge) and adds the CHANGELOG `[4.2.4]` entry.

**User-visible fixes:** #41 (multi-line `domain:` default literals captured whole), #42 (`push$ -> $State` lowers through the compartment model on py/gdscript/js/ts; W414 counts the edge).

**Internal (byte-identical codegen):** RFC-0039 parser-as-Frame backbone + RFC-0035 R8–R12 FSM dogfooding (pipeline supervisor drives `compile_ast_based`; domain / call-site / transition-meta / paren-balance scanner FSMs).

RC bar green: `cargo test --release`, `clippy -D warnings`, `fmt`, doc-samples (118/118), `cargo package`; 17-backend matrix 17/17; full structural fuzz all phases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)