### PR TITLE
RFC-0040: analysis-only @@import + cross-file persist resolution (4.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [4.2.5] - 2026-05-26
+
+A maintenance release. One user-visible codegen fix; **generated output is
+byte-identical to 4.2.4 except for composing systems that rename their persist
+ops** (the case the fix targets).
+
+### Fixed
+
+- **Composed-child persist method names (#44).** When a parent system composes a
+  child via `domain: child = @@Child()` and the child renamed its persist ops
+  with `@@[save(name)]` / `@@[load(name)]`, the parent's generated
+  `save_state` / `restore_state` called the child by the hardcoded
+  target-default name instead of the child's declared name — a `TypeError` at
+  runtime, silent at compile time. The parent now resolves the child's declared
+  names (mirroring how a system's own persist methods are already resolved),
+  across all 14 backends. Also corrects a latent Go case where the new-contract
+  nested-restore branch called a non-existent `LoadState`.
+
 ## [4.2.4] - 2026-05-26
 
 A maintenance release. Two user-visible codegen fixes; the bulk is internal —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,23 +6,47 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
-## [4.2.5] - 2026-05-26
+## [4.3.0] - 2026-05-27
 
-A maintenance release. One user-visible codegen fix; **generated output is
-byte-identical to 4.2.4 except for composing systems that rename their persist
-ops** (the case the fix targets).
+Re-introduces the `@@import` directive (removed in 4.2.0 by RFC-0024) in a
+strictly narrower, **analysis-only** form per RFC-0040, and fixes the
+composed-child persist-naming bug in both its same-file and cross-file forms.
+
+### Added
+
+- **`@@import "<path>"` as an analysis directive (RFC-0040).** framec reads the
+  referenced Frame source *while compiling the current file* to resolve and
+  check cross-file references — but emits **nothing** for it (no import line, no
+  target code for the imported system). Native host imports remain the user's
+  own Oceans Model pass-through. The directive changes what framec *knows*,
+  never what it *writes*. Imported systems are **analysis-visible but
+  emission-excluded** — present in the symbol table and the cross-system
+  codegen registries, never generated into the importer's output.
 
 ### Fixed
 
-- **Composed-child persist method names (#44).** When a parent system composes a
-  child via `domain: child = @@Child()` and the child renamed its persist ops
-  with `@@[save(name)]` / `@@[load(name)]`, the parent's generated
+- **Composed-child persist method names — same-file (#44).** When a parent
+  composes a child via `domain: child = @@Child()` and the child renamed its
+  persist ops with `@@[save(name)]` / `@@[load(name)]`, the parent's generated
   `save_state` / `restore_state` called the child by the hardcoded
   target-default name instead of the child's declared name — a `TypeError` at
   runtime, silent at compile time. The parent now resolves the child's declared
-  names (mirroring how a system's own persist methods are already resolved),
-  across all 14 backends. Also corrects a latent Go case where the new-contract
-  nested-restore branch called a non-existent `LoadState`.
+  names across all 14 backends. Also corrects a latent Go case where the
+  new-contract nested-restore branch called a non-existent `LoadState`.
+- **Composed-child persist method names — cross-file.** With `@@import`, the
+  same resolution now works when the child lives in another file: the parent
+  reads the imported source and calls the child's declared names instead of the
+  target default.
+- **Imported `@@[main]` no longer trips E806 (#45).** A file that `@@import`s
+  another Frame source whose primary system carries `@@[main]` no longer fails
+  the importer's single-`@@[main]` check — that rule is scoped to locally
+  declared systems, as it should be.
+
+### Notes
+
+- Output for files without `@@import` is byte-identical to 4.2.x.
+- Cross-file *argument/type* validation (surfacing imported-call mismatches) is
+  a planned follow-up under RFC-0040; it does not yet fire.
 
 ## [4.2.4] - 2026-05-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "framec"
-version = "4.2.4"
+version = "4.2.5"
 dependencies = [
  "chrono",
  "clap",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "framec-wasm"
-version = "4.2.4"
+version = "4.2.5"
 dependencies = [
  "framec",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "framec"
-version = "4.2.5"
+version = "4.3.0"
 dependencies = [
  "chrono",
  "clap",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "framec-wasm"
-version = "4.2.5"
+version = "4.3.0"
 dependencies = [
  "framec",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["framec", "framec-wasm"]
 
 [workspace.package]
-version = "4.2.5"
+version = "4.3.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/frame-lang/framec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["framec", "framec-wasm"]
 
 [workspace.package]
-version = "4.2.4"
+version = "4.2.5"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/frame-lang/framec"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![CI](https://github.com/frame-lang/framec/actions/workflows/ci.yml/badge.svg)
 ![License](https://img.shields.io/badge/license-Apache--2.0-blue)
-![Version](https://img.shields.io/badge/version-4.2.5-green)
+![Version](https://img.shields.io/badge/version-4.3.0-green)
 
 framec (aka the **framepiler**) — is the transpiler for the Frame language. Currently framec supports output to 17 target languges + Graphviz. Frame is a domain-specific language for specifying state machines that transpiles to production code in multiple target languages. You write `@@system` blocks inside your native source files, and the framepiler expands them into full state machine implementations. All native code passes through unchanged — your native compiler handles everything outside the `@@system` blocks and other `@@` tagged pragmas and statements.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![CI](https://github.com/frame-lang/framec/actions/workflows/ci.yml/badge.svg)
 ![License](https://img.shields.io/badge/license-Apache--2.0-blue)
-![Version](https://img.shields.io/badge/version-4.2.4-green)
+![Version](https://img.shields.io/badge/version-4.2.5-green)
 
 framec (aka the **framepiler**) — is the transpiler for the Frame language. Currently framec supports output to 17 target languges + Graphviz. Frame is a domain-specific language for specifying state machines that transpiles to production code in multiple target languages. You write `@@system` blocks inside your native source files, and the framepiler expands them into full state machine implementations. All native code passes through unchanged — your native compiler handles everything outside the `@@system` blocks and other `@@` tagged pragmas and statements.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -423,6 +423,20 @@ a resource handle, which the user reattaches explicitly). Applies only to
 [compartment](#compartment) bookkeeping, which is always persisted. Specified in
 [RFC-0016.1](rfcs/rfc-0016-1.md); see also [persist contract](#persist-contract).
 
+### `@@import`
+
+Module-level **analysis directive** naming a Frame source file —
+`@@import "./other.frm"`. It tells framec where a referenced [system](#system)'s
+source lives so framec can read it *while compiling the current file*: to check
+this file's use of that system (argument arity/types, existence) and to resolve
+cross-file facts code generation needs (notably a [composed](#composed-system)
+child's [save](#save) / [load](#load) method names). It is **not** a
+code-generation directive — framec emits no import line and no target code for an
+imported system; native host imports remain [Oceans Model](#oceans-model)
+pass-through. Removed by [RFC-0024](rfcs/rfc-0024.md) (which deleted the original
+analysis-*and*-emission directive); re-introduced in analysis-only form by
+[RFC-0040](rfcs/rfc-0040.md).
+
 ### `@@SystemName(args)`
 
 Instantiation expression: construct a [system](#system) instance by calling its

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -37,7 +37,7 @@ numbers are not re-used.
 | [0022](rfc-0022.md) | Cross-file `@@import` directive | **Superseded by [0024](rfc-0024.md)** | historical |
 | [0022.1](rfc-0022-1.md) | `@@import` semantics on Java/C#/Go | **Superseded by [0024](rfc-0024.md)** | historical |
 | 0023 | — | (unassigned) | numbering reserved; no document |
-| [0024](rfc-0024.md) | Remove `@@import` — host-language imports via Oceans Model | Accepted; shipped in 4.2.0 | supersedes [0022](rfc-0022.md), [0022.1](rfc-0022-1.md); breaking change |
+| [0024](rfc-0024.md) | Remove `@@import` — host-language imports via Oceans Model | Accepted; shipped in 4.2.0 | supersedes [0022](rfc-0022.md), [0022.1](rfc-0022-1.md); breaking change; **analysis half amended by [0040](rfc-0040.md)** (emission removal stands) |
 | [0025](rfc-0025.md) | Quality remediation — structured errors + typed compartment payload | Accepted; shipped (Rust target) in 4.2.0 | companion to [0026](rfc-0026.md), [0027](rfc-0027.md) |
 | [0025.1](rfc-0025-1.md) | Typed lifecycle args — close the stringify gap in the typed-payload contract | Accepted (2026-05-21); shipped in 4.2.1 | amends [0025](rfc-0025.md); resolves FRAMEC_BUGS #34 |
 | [0026](rfc-0026.md) | Oceans Model as calculus — pre-backend normalization, preservation theorem, formal grammar | Draft (Exploration) | companion to [0025](rfc-0025.md), [0027](rfc-0027.md); no execution commitment |
@@ -54,6 +54,7 @@ numbers are not re-used.
 | [0037](rfc-0037.md) | Reserved identifier namespace — the `__` prefix (validator E115) | Accepted | builds on [0025](rfc-0025.md) / [0025.1](rfc-0025-1.md); resolves the #40 residual edge |
 | [0038](rfc-0038.md) | Deferred dispatch — `@@[cast]` interface methods, addressing, bring-your-own executor | Draft | builds on [0020](rfc-0020.md), [0025](rfc-0025.md); companion to [0036](rfc-0036.md), [0026](rfc-0026.md) |
 | [0039](rfc-0039.md) | Parser as composed Frame state machines | Accepted | builds on [0035](rfc-0035.md) |
+| [0040](rfc-0040.md) | Re-introduce `@@import` as analysis-only cross-file resolution | Draft | amends [0024](rfc-0024.md) (analysis half only); builds on [0012](rfc-0012.md), [0015](rfc-0015.md) |
 
 ## Other documents in this directory
 

--- a/docs/rfcs/rfc-0040.md
+++ b/docs/rfcs/rfc-0040.md
@@ -1,0 +1,296 @@
+---
+title: "RFC-0040: Analysis-only @@import"
+---
+
+# RFC-0040: Re-introduce `@@import` as analysis-only cross-file resolution
+
+- **Status:** Draft
+- **Author:** Mark Truluck <mark.truluck@cogiton.com>
+- **Created:** 2026-05-27
+- **Builds on:** RFC-0012, RFC-0015
+- **Amends:** RFC-0024 (the analysis half only; RFC-0024's removal of import *emission* stands)
+
+The key words **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY** are
+to be interpreted as described in RFC 2119.
+
+## Summary
+
+Re-introduce the `@@import "<path>"` directive, but with a strictly narrower
+meaning than the directive [RFC-0024](rfc-0024.md) removed. The new `@@import` is
+an **analysis directive, not a code-generation directive**: it tells framec where
+a referenced [system](../glossary.md#system)'s Frame source lives so framec can
+read it *while compiling the current file* — to check that this file uses the
+referenced system correctly, and to resolve the cross-file facts code generation
+needs. framec emits **nothing** for an `@@import`: it produces no import line and
+no target code for the imported system. Native host imports remain the user's
+responsibility, written as [Oceans Model](../glossary.md#oceans-model)
+pass-through, exactly as today.
+
+## Motivation
+
+framec compiles one file at a time and treats every cross-file reference as an
+opaque name. A [composed system](../glossary.md#composed-system) that holds a
+child declared in another file — `domain: child = @@Child()` where `Child` lives
+in `child.frm` — is lowered using only the literal string `"Child"`. framec never
+reads `child.frm`, so it knows nothing about `Child` beyond its name.
+
+That opacity is silently lossy in two ways.
+
+**It cannot check that this file uses the other system correctly.** A handler
+that constructs or transitions to a cross-file system with the wrong number of
+arguments, or arguments of the wrong type, compiles without complaint. framec has
+no signature to check against, so it passes the arguments through verbatim and
+hopes. When the mistake is caught at all, it is caught later — by the host
+compiler, or not until runtime.
+
+**It cannot resolve cross-file facts that code generation genuinely needs.** The
+[persist contract](../glossary.md#persist-contract) is the sharpest example. A
+persisted system names its save and load methods with
+[`@@[save(<name>)]` / `@@[load(<name>)]`](../glossary.md#savename--loadname); the
+names are the author's to choose. When a parent serializes a composed child, the
+generated parent code must call the child's save/load methods *by the child's
+chosen names*. For a child in the **same file**, framec reads those names from
+the child's declaration and emits the right call. For a child in **another
+file**, framec has no declaration to read — so it falls back to the target
+language's default spelling. If the imported child chose a non-default name, the
+parent calls a method that does not exist.
+
+This last case deserves emphasis because it refutes the assumption that
+cross-file checking is redundant with the host compiler. Consider a parent whose
+`save_state` serializes an imported child, where the child named its save method
+`save_state` (snake_case, mirroring another target's idiom) while the host target
+spells its default `saveState` (camelCase). The generated parent calls
+`this.child.saveState()`. That code **compiles cleanly and links cleanly** on the
+host — `saveState` is a perfectly well-formed method name, the import resolves,
+nothing is missing. It fails only at **runtime**, with a "method is not a
+function" error, the first time the parent is saved. The host compiler never
+catches it, because there is nothing for the host compiler to catch: the error is
+that framec generated a call to the wrong name, and only framec — had it read the
+child's source — was in a position to know the right one.
+
+RFC-0024 removed `@@import` for good reasons, but those reasons were about
+*emission* — having framec generate each target's native import statement, which
+requires host packaging information framec does not have, and which split the
+backends into "framec emits the import" versus "the user writes it." Removing the
+emission role was correct. But `@@import` also had an *analysis* role — letting
+framec see the imported source to validate and resolve against it — and that role
+was removed as collateral, not because it was the problem. RFC-0024's own
+Drawbacks acknowledge the loss ("Loses early validation"; "Loss of project-wide
+dependency view"), and its rejected Alternative C ("keep `@@import` as pure
+validation") is precisely the design this RFC revives — now with a concrete case
+showing the early-validation benefit is not small.
+
+A fix needs to let framec read a referenced system's source to check usage and
+resolve cross-file facts, **without** reintroducing import emission and without
+requiring the whole program to be present to compile one file.
+
+## The contract
+
+### What `@@import` means
+
+`@@import "<path>"` is a module-level directive naming a Frame source file. It is
+an **analysis directive**. When framec compiles a file containing
+`@@import "<path>"`, it:
+
+1. **MUST** resolve `<path>` relative to the importing file's directory and read
+   the referenced Frame source.
+2. **MUST** parse the systems declared in that source and make them visible —
+   for the duration of the current compilation only — to the same checks and
+   resolution that apply to systems declared in the current file.
+3. **MUST NOT** emit any target code for an imported system. An imported system
+   is present for analysis and is then discarded; generating its target code is
+   the responsibility of *its own* compilation.
+4. **MUST NOT** emit any import statement, in any target. Cross-file linkage is
+   expressed by the user in the host language's native syntax as
+   [Oceans Model](../glossary.md#oceans-model) pass-through, unchanged from
+   RFC-0024.
+
+An imported system is therefore **known for analysis but external for code
+generation**. Its declaration informs the checks and the cross-file facts
+framec resolves, but references to it lower exactly as a cross-file reference
+lowers today — as a name the host's native import resolves — and framec produces
+no class, method, or other target artifact for it. The visibility an `@@import`
+grants and the emission it withholds are two separate things, and framec **MUST**
+keep them separate: making an imported system visible to validation **MUST NOT**
+cause framec to emit it, nor to change how references to it are lowered.
+
+In short: `@@import` changes what framec *knows*, never what framec *writes*. A
+file's generated output is byte-for-byte identical whether or not its `@@import`
+lines are present — **except** where knowing the imported system corrects a call
+framec would otherwise have emitted wrongly (a wrong persist-method name being
+the motivating case).
+
+### Cross-file checking
+
+With imported systems visible, the checks framec already performs for same-file
+references **MUST** apply to references resolved through an `@@import`:
+construction and transition argument arity and types, and existence of the
+referenced system. A file that calls an imported system incorrectly is reported
+at framec-compile time, in the file that contains the mistake, rather than
+surfacing later at host-compile or at runtime.
+
+To avoid breaking existing multi-file programs that compile today only because
+cross-file references go unchecked, this stricter checking **SHOULD** be phased
+in: newly-surfaced cross-file violations **SHOULD** be reported as warnings in
+the release that introduces analysis `@@import`, and **MAY** be promoted to
+errors in a later release. (The exact mechanism — a strictness setting, or a
+fixed release in which promotion happens — is left to Unresolved questions.)
+
+### The open-world boundary
+
+`@@import` resolves what framec can read: a Frame source file. A composed child
+**MAY** instead be a hand-written host class, or a system shipped in a
+precompiled package with no accompanying Frame source. framec cannot read what
+isn't there. For such a reference there is simply no `@@import`, framec has no
+declaration to resolve against, and the reference falls back to today's behavior
+— arguments pass through verbatim, and persist method names take the target's
+default spelling. Authors composing such a system across a file boundary **MUST**
+give it persist names matching the target default, because framec cannot discover
+otherwise. This is the *open-world* fallback; `@@import` is the *closed-world*
+path. The two compose: `@@import` raises correctness wherever the source is
+available, and changes nothing where it isn't.
+
+## Examples
+
+A parent composing a child defined in another file, where the child renames its
+persist methods. Without the `@@import`, framec would generate the parent's save
+using the target's default method name and the call would fail at runtime; with
+it, framec reads the child and emits the child's chosen name.
+
+`counter.fjs`:
+
+```frame
+@@[persist(string)]
+@@[save(snapshot)]
+@@[load(restore)]
+@@system Counter {
+    interface:
+        bump()
+    machine:
+        $Active { bump() { self.n = self.n + 1 } }
+    domain:
+        n: int = 0
+}
+```
+
+`app.fjs`:
+
+```frame
+// Native host import — Oceans Model pass-through; framec emits this verbatim.
+import { Counter } from "./counter.machine.js"
+
+// Analysis import — framec reads counter.fjs to resolve `Counter`.
+// It is NOT emitted; it only tells framec where the source lives.
+@@import "./counter.fjs"
+
+@@[persist(string)]
+@@[save(snapshot)]
+@@[load(restore)]
+@@system App {
+    interface:
+        run()
+    machine:
+        $Running { run() { } }
+    domain:
+        counter: Counter = @@Counter()
+}
+```
+
+`App`'s generated `snapshot` serializes `counter` by calling the child's chosen
+`snapshot()` (read from `counter.fjs`), not the target default. The `import { … }`
+line is the user's native import, passed through unchanged; the `@@import` line
+produces no output.
+
+Calling an imported system incorrectly is now reported against `app.fjs`:
+
+```frame
+@@import "./counter.fjs"
+// ...
+        // Counter's interface declares bump() with no parameters;
+        // passing an argument is now a framec-compile-time diagnostic
+        // instead of a host-compile or runtime surprise.
+        $Running { run() { self.counter.bump(42) } }
+```
+
+## Alternatives
+
+**Leave cross-file composition opaque; document the constraint.** Keep today's
+behavior and tell authors that a cross-file composed child must use the target
+default persist name, optionally warning when a persisted field is a cross-file
+reference. This was the contained option. It is rejected as the *primary* answer
+because it permanently forecloses cross-file checking of arguments and types, not
+just persist names — it accepts the opacity rather than closing it. The
+documented constraint survives only as the *open-world fallback* above, for
+references framec genuinely cannot read.
+
+**A reserved, fixed-name internal persist entry point.** Have every persisted
+system also expose an internal, framework-named save/load method that composition
+always calls, so a parent never needs the child's chosen public name. This solves
+the persist case without reading the child, and it is appealing in isolation. It
+is rejected because it is persist-specific: it does nothing for argument or type
+checking across files, and it adds a second, hidden naming scheme to the persist
+contract solely to work around framec's inability to see the child. Reading the
+child solves the general problem once.
+
+**Restore `@@import` as it was under RFC-0022 (analysis *and* emission).** Bring
+back the full directive, including framec generating each target's native import.
+Rejected for exactly the reasons RFC-0024 gives: the host's import vocabulary
+needs packaging information framec does not have, and emission splits the backends
+into haves and have-nots. This RFC deliberately keeps emission removed and revives
+only analysis.
+
+**RFC-0024 Alternative C, on its original reasoning.** RFC-0024 considered keeping
+`@@import` as pure validation and rejected it, judging that "the host compiler
+already catches missing imports" so the early-detection benefit was small. That
+reasoning holds for *missing imports* and does not hold for the class of error
+this RFC targets: a cross-file persist-name mismatch produces code that the host
+compiler accepts and links, and that fails only at runtime. The host compiler
+cannot catch it because there is nothing malformed for it to catch. This RFC
+adopts Alternative C's shape while correcting the premise that motivated its
+rejection.
+
+**Whole-program compilation driven by a project manifest.** Discover every Frame
+source in a project from a build manifest or directory crawl and compile them
+with a shared view, rather than naming dependencies in-source. This is a coherent
+larger direction and is not foreclosed by this RFC; an in-source `@@import` and a
+manifest-driven file set are complementary discovery mechanisms. `@@import` is
+chosen here as the direct, explicit, in-source declaration of intent that also
+works for a single-file invocation. A manifest layer is left to a future RFC.
+
+## Migration
+
+Source-additive. `@@import "<path>"` parsed to a hard error after RFC-0024; under
+this RFC it is a valid analysis directive again. Existing multi-file programs use
+the host language's native imports and continue to compile unchanged — analysis
+`@@import` is optional and additive; a program adds it only where it wants framec
+to check and resolve against an imported Frame source. The stricter cross-file
+checking that an `@@import` enables is phased in as warnings first (see *The
+contract*), so adding an import surfaces latent cross-file mistakes without
+turning them into immediate build breaks.
+
+## References
+
+- [RFC-0024](rfc-0024.md) — removed `@@import`; this RFC amends it, reviving the
+  analysis role while leaving the emission removal in force.
+- [RFC-0022](rfc-0022.md) — the original `@@import` (analysis and emission).
+- [RFC-0012](rfc-0012.md), [RFC-0015](rfc-0015.md) — the persist contract and the
+  `@@[save]` / `@@[load]` naming whose cross-file resolution motivates this RFC.
+- [Frame language reference](../frame_language.md)
+- [Glossary](../glossary.md) — `@@import`, [Oceans Model](../glossary.md#oceans-model),
+  [composed system](../glossary.md#composed-system),
+  [persist contract](../glossary.md#persist-contract).
+- `CHANGELOG.md`
+
+## Unresolved questions
+
+- **Phase-in mechanism.** Whether newly-surfaced cross-file violations are gated
+  by a strictness setting, by a fixed release in which warnings become errors, or
+  both.
+- **Import path target.** `@@import` names a Frame *source* path. Whether to also
+  accept resolving a source from a host-import module path (so a single line can
+  serve both roles) is deferred — it risks coupling analysis to output layout.
+- **Transitive imports.** Whether an `@@import`ed file's own `@@import`s are
+  followed (a dependency reads its dependencies) or only direct imports are
+  resolved.
+- **Diagnostic for a stale import.** Whether an `@@import` whose file is
+  unreadable, or which surfaces no systems, is an error or a warning.

--- a/docs/rfcs/rfc-0040.md
+++ b/docs/rfcs/rfc-0040.md
@@ -4,7 +4,7 @@ title: "RFC-0040: Analysis-only @@import"
 
 # RFC-0040: Re-introduce `@@import` as analysis-only cross-file resolution
 
-- **Status:** Draft
+- **Status:** Accepted — implemented in framec 4.3.0 (cross-file persist-name resolution; cross-file arg/type validation phase-in pending)
 - **Author:** Mark Truluck <mark.truluck@cogiton.com>
 - **Created:** 2026-05-27
 - **Builds on:** RFC-0012, RFC-0015

--- a/framec/src/frame_c/compiler/attribute_scanner/attribute_scanner.frs
+++ b/framec/src/frame_c/compiler/attribute_scanner/attribute_scanner.frs
@@ -15,10 +15,12 @@
 //   2. Bare form (legacy + still-supported keywords): `@@<name> <value?>`
 //      Examples: `@@run-expect 42`, `@@skip-if windows`
 //      RFC-0013 hard-cut: bare `@@persist` and `@@target` now error
-//      (E803 / E804). RFC-0024 hard-cut: `@@import` now errors (E823).
-//      RFC-0032 hard-cut: `@@codegen { ... }` now errors (E824).
-//      All four pass through this scanner as Other and the pipeline
-//      reports the migration error downstream.
+//      (E803 / E804). RFC-0032 hard-cut: `@@codegen { ... }` now errors
+//      (E824). (`@@import` was removed by RFC-0024 but reinstated by
+//      RFC-0040 as an analysis-only directive — it is accepted again and
+//      handled in `do_parse`, not an error here.)
+//      The bare error-forms pass through this scanner as Other and the
+//      pipeline reports the migration error downstream.
 //
 // The scanner returns: name span (`name_start`/`name_end`), optional
 // args span (bracket form only — `args_start`/`args_end`), optional

--- a/framec/src/frame_c/compiler/attribute_scanner/attribute_scanner.gen.rs
+++ b/framec/src/frame_c/compiler/attribute_scanner/attribute_scanner.gen.rs
@@ -14,10 +14,12 @@
 //   2. Bare form (legacy + still-supported keywords): `@@<name> <value?>`
 //      Examples: `@@run-expect 42`, `@@skip-if windows`
 //      RFC-0013 hard-cut: bare `@@persist` and `@@target` now error
-//      (E803 / E804). RFC-0024 hard-cut: `@@import` now errors (E823).
-//      RFC-0032 hard-cut: `@@codegen { ... }` now errors (E824).
-//      All four pass through this scanner as Other and the pipeline
-//      reports the migration error downstream.
+//      (E803 / E804). RFC-0032 hard-cut: `@@codegen { ... }` now errors
+//      (E824). (`@@import` was removed by RFC-0024 but reinstated by
+//      RFC-0040 as an analysis-only directive — it is accepted again and
+//      handled in `do_parse`, not an error here.)
+//      The bare error-forms pass through this scanner as Other and the
+//      pipeline reports the migration error downstream.
 //
 // The scanner returns: name span (`name_start`/`name_end`), optional
 // args span (bracket form only — `args_start`/`args_end`), optional
@@ -501,4 +503,3 @@ mod _attribute_scanner_fsm_framec {
     }
 }
 pub use _attribute_scanner_fsm_framec::*;
-

--- a/framec/src/frame_c/compiler/codegen/interface_gen.rs
+++ b/framec/src/frame_c/compiler/codegen/interface_gen.rs
@@ -18,8 +18,9 @@ use dart_types::{dart_conv_expr, parse_dart_type, render_dart_type, DartTypeNode
 use utility::{frame_return_default, is_dynamic_target};
 
 pub use nested_registry::{
-    get_nested_system_domain_params, nested_uses_new_contract, set_local_systems,
-    set_nested_system_domain_params, set_new_contract_systems,
+    child_persist_names, get_nested_system_domain_params, nested_uses_new_contract,
+    set_local_systems, set_nested_system_domain_params, set_nested_system_persist_names,
+    set_new_contract_systems,
 };
 
 use std::collections::{HashMap, HashSet};

--- a/framec/src/frame_c/compiler/codegen/interface_gen/nested_registry.rs
+++ b/framec/src/frame_c/compiler/codegen/interface_gen/nested_registry.rs
@@ -42,6 +42,15 @@ thread_local! {
 
     static NESTED_SYSTEM_DOMAIN_PARAMS: RefCell<HashMap<String, Vec<(String, String)>>> =
         RefCell::new(HashMap::new());
+
+    /// `system_name → (declared @@[save] name, declared @@[load] name)`.
+    /// `None` where the system didn't declare a custom name. Lets a
+    /// *composing* parent's persist codegen call a child's save/load by
+    /// the child's DECLARED name rather than the language default
+    /// (FRAMEC_BUGS Issue #44 — the parent hardcoded `saveState` etc.,
+    /// breaking when the child declared a non-default name).
+    static NESTED_SYSTEM_PERSIST_NAMES: RefCell<HashMap<String, (Option<String>, Option<String>)>> =
+        RefCell::new(HashMap::new());
 }
 
 /// Set the names of systems using the new persist contract. Called
@@ -96,4 +105,32 @@ pub fn nested_uses_new_contract(name: &str) -> bool {
 /// empty Vec if the system isn't registered or has no Domain params.
 pub fn get_nested_system_domain_params(name: &str) -> Vec<(String, String)> {
     NESTED_SYSTEM_DOMAIN_PARAMS.with(|s| s.borrow().get(name).cloned().unwrap_or_default())
+}
+
+/// Set each system's declared `@@[save]` / `@@[load]` method names
+/// (`None` where not declared). Called once per compilation, before
+/// per-system codegen runs. FRAMEC_BUGS Issue #44.
+pub fn set_nested_system_persist_names(map: HashMap<String, (Option<String>, Option<String>)>) {
+    NESTED_SYSTEM_PERSIST_NAMES.with(|s| *s.borrow_mut() = map);
+}
+
+/// Resolve the save/load method names to use when a *parent* serializes
+/// a composed child of type `child_type`. Returns the child's declared
+/// `@@[save]` / `@@[load]` names, falling back to the caller's language
+/// defaults when the child declared none (or isn't a local system —
+/// cross-file children are assumed to use the target's default). This is
+/// the composition counterpart to a system's own `save_op_name()` /
+/// `load_op_name()` resolution. FRAMEC_BUGS Issue #44.
+pub fn child_persist_names(
+    child_type: &str,
+    default_save: &str,
+    default_load: &str,
+) -> (String, String) {
+    NESTED_SYSTEM_PERSIST_NAMES.with(|s| {
+        let (save, load) = s.borrow().get(child_type).cloned().unwrap_or((None, None));
+        (
+            save.unwrap_or_else(|| default_save.to_string()),
+            load.unwrap_or_else(|| default_load.to_string()),
+        )
+    })
 }

--- a/framec/src/frame_c/compiler/codegen/interface_gen/persist/c.rs
+++ b/framec/src/frame_c/compiler/codegen/interface_gen/persist/c.rs
@@ -23,7 +23,7 @@
 use crate::frame_c::compiler::codegen::ast::{CodegenNode, Param, Visibility};
 use crate::frame_c::compiler::frame_ast::SystemAst;
 
-use super::super::{extract_tagged_system_name, nested_uses_new_contract};
+use super::super::{child_persist_names, extract_tagged_system_name, nested_uses_new_contract};
 
 pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
     system: &SystemAst,
@@ -314,9 +314,10 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
         }
         let init = var.initializer_text.as_deref().unwrap_or("");
         if let Some(child_sys) = extract_tagged_system_name(init) {
+            let (child_save, _) = child_persist_names(child_sys, "save_state", "restore_state");
             save_body.push_str(&format!(
                 "if (self->{name}) {{\n\
-                 \x20   char* __child_json_{name} = {child}_save_state(self->{name});\n\
+                 \x20   char* __child_json_{name} = {child}_{save}(self->{name});\n\
                  \x20   cJSON* __child_obj_{name} = cJSON_Parse(__child_json_{name});\n\
                  \x20   cJSON_AddItemToObject(root, \"{name}\", __child_obj_{name});\n\
                  \x20   free(__child_json_{name});\n\
@@ -324,7 +325,8 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
                  \x20   cJSON_AddNullToObject(root, \"{name}\");\n\
                  }}\n",
                 name = var.name,
-                child = child_sys
+                child = child_sys,
+                save = child_save
             ));
             continue;
         }
@@ -412,6 +414,7 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
         }
         let init = var.initializer_text.as_deref().unwrap_or("");
         if let Some(child_sys) = extract_tagged_system_name(init) {
+            let (_, child_load) = child_persist_names(child_sys, "save_state", "restore_state");
             let body = if nested_uses_new_contract(child_sys) {
                 format!(
                     "{{\n\
@@ -419,7 +422,7 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
                      \x20   if (__child_obj_{name} && !cJSON_IsNull(__child_obj_{name})) {{\n\
                      \x20       char* __child_json_{name} = cJSON_PrintUnformatted(__child_obj_{name});\n\
                      \x20       {tgt}->{name} = {child}_new();\n\
-                     \x20       {child}_restore_state({tgt}->{name}, __child_json_{name});\n\
+                     \x20       {child}_{load}({tgt}->{name}, __child_json_{name});\n\
                      \x20       free(__child_json_{name});\n\
                      \x20   }} else {{\n\
                      \x20       {tgt}->{name} = NULL;\n\
@@ -427,7 +430,8 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
                      }}\n",
                     tgt = target,
                     name = var.name,
-                    child = child_sys
+                    child = child_sys,
+                    load = child_load
                 )
             } else {
                 format!(
@@ -435,7 +439,7 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
                      \x20   cJSON* __child_obj_{name} = cJSON_GetObjectItem(root, \"{name}\");\n\
                      \x20   if (__child_obj_{name} && !cJSON_IsNull(__child_obj_{name})) {{\n\
                      \x20       char* __child_json_{name} = cJSON_PrintUnformatted(__child_obj_{name});\n\
-                     \x20       {tgt}->{name} = {child}_restore_state(__child_json_{name});\n\
+                     \x20       {tgt}->{name} = {child}_{load}(__child_json_{name});\n\
                      \x20       free(__child_json_{name});\n\
                      \x20   }} else {{\n\
                      \x20       {tgt}->{name} = NULL;\n\
@@ -443,7 +447,8 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
                      }}\n",
                     tgt = target,
                     name = var.name,
-                    child = child_sys
+                    child = child_sys,
+                    load = child_load
                 )
             };
             restore_body.push_str(&body);

--- a/framec/src/frame_c/compiler/codegen/interface_gen/persist/cpp.rs
+++ b/framec/src/frame_c/compiler/codegen/interface_gen/persist/cpp.rs
@@ -17,7 +17,7 @@ use crate::frame_c::compiler::codegen::ast::{CodegenNode, Param, Visibility};
 use crate::frame_c::compiler::codegen::codegen_utils::cpp_map_type;
 use crate::frame_c::compiler::frame_ast::SystemAst;
 
-use super::super::{extract_tagged_system_name, nested_uses_new_contract};
+use super::super::{child_persist_names, extract_tagged_system_name, nested_uses_new_contract};
 
 pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
     system: &SystemAst,
@@ -204,10 +204,11 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
             continue;
         }
         let init = var.initializer_text.as_deref().unwrap_or("");
-        if extract_tagged_system_name(init).is_some() {
+        if let Some(child_sys) = extract_tagged_system_name(init) {
+            let (child_save, _) = child_persist_names(child_sys, "save_state", "restore_state");
             save_body.push_str(&format!(
-                "__j[\"{0}\"] = {0} ? nlohmann::json::parse({0}->save_state()) : nlohmann::json(nullptr);\n",
-                var.name
+                "__j[\"{0}\"] = {0} ? nlohmann::json::parse({0}->{1}()) : nlohmann::json(nullptr);\n",
+                var.name, child_save
             ));
         } else {
             save_body.push_str(&format!("__j[\"{}\"] = {};\n", var.name, var.name));
@@ -338,15 +339,16 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
         }
         let init = var.initializer_text.as_deref().unwrap_or("");
         if let Some(child_sys) = extract_tagged_system_name(init) {
+            let (_, child_load) = child_persist_names(child_sys, "save_state", "restore_state");
             if nested_uses_new_contract(child_sys) {
                 restore_body.push_str(&format!(
-                    "if (__j.contains(\"{0}\") && !__j[\"{0}\"].is_null()) {{ {tgt}.{0} = std::make_shared<{1}>(); {tgt}.{0}->restore_state(__j[\"{0}\"].dump()); }}\n",
-                    var.name, child_sys, tgt = target
+                    "if (__j.contains(\"{0}\") && !__j[\"{0}\"].is_null()) {{ {tgt}.{0} = std::make_shared<{1}>(); {tgt}.{0}->{load}(__j[\"{0}\"].dump()); }}\n",
+                    var.name, child_sys, tgt = target, load = child_load
                 ));
             } else {
                 restore_body.push_str(&format!(
-                    "if (__j.contains(\"{0}\") && !__j[\"{0}\"].is_null()) {{ {tgt}.{0} = std::make_shared<{1}>({1}::restore_state(__j[\"{0}\"].dump())); }}\n",
-                    var.name, child_sys, tgt = target
+                    "if (__j.contains(\"{0}\") && !__j[\"{0}\"].is_null()) {{ {tgt}.{0} = std::make_shared<{1}>({1}::{load}(__j[\"{0}\"].dump())); }}\n",
+                    var.name, child_sys, tgt = target, load = child_load
                 ));
             }
         } else {

--- a/framec/src/frame_c/compiler/codegen/interface_gen/persist/csharp.rs
+++ b/framec/src/frame_c/compiler/codegen/interface_gen/persist/csharp.rs
@@ -15,7 +15,7 @@ use crate::frame_c::compiler::codegen::ast::{CodegenNode, Param, Visibility};
 use crate::frame_c::compiler::codegen::codegen_utils::csharp_map_type;
 use crate::frame_c::compiler::frame_ast::SystemAst;
 
-use super::super::{extract_tagged_system_name, nested_uses_new_contract};
+use super::super::{child_persist_names, extract_tagged_system_name, nested_uses_new_contract};
 
 pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
     system: &SystemAst,
@@ -266,10 +266,11 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
             continue;
         }
         let init = var.initializer_text.as_deref().unwrap_or("");
-        if extract_tagged_system_name(init).is_some() {
+        if let Some(child_sys) = extract_tagged_system_name(init) {
+            let (child_save, _) = child_persist_names(child_sys, "SaveState", "RestoreState");
             save_body.push_str(&format!(
-                "__j[\"{0}\"] = {0} != null ? System.Text.Json.JsonDocument.Parse({0}.SaveState()).RootElement.Clone() : (object)null;\n",
-                var.name
+                "__j[\"{0}\"] = {0} != null ? System.Text.Json.JsonDocument.Parse({0}.{1}()).RootElement.Clone() : (object)null;\n",
+                var.name, child_save
             ));
         } else {
             save_body.push_str(&format!("__j[\"{}\"] = {};\n", var.name, var.name));
@@ -334,19 +335,22 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
         }
         let init = var.initializer_text.as_deref().unwrap_or("");
         if let Some(child_sys) = extract_tagged_system_name(init) {
+            let (_, child_load) = child_persist_names(child_sys, "SaveState", "RestoreState");
             let body = if nested_uses_new_contract(child_sys) {
                 format!(
-                    "if (__root.TryGetProperty(\"{name}\", out var __{name})) {{ if (__{name}.ValueKind != System.Text.Json.JsonValueKind.Null) {{ {tgt}.{name} = new {child}(); {tgt}.{name}.RestoreState(__{name}.GetRawText()); }} }}\n",
+                    "if (__root.TryGetProperty(\"{name}\", out var __{name})) {{ if (__{name}.ValueKind != System.Text.Json.JsonValueKind.Null) {{ {tgt}.{name} = new {child}(); {tgt}.{name}.{load}(__{name}.GetRawText()); }} }}\n",
                     tgt = target,
                     name = var.name,
-                    child = child_sys
+                    child = child_sys,
+                    load = child_load
                 )
             } else {
                 format!(
-                    "if (__root.TryGetProperty(\"{name}\", out var __{name})) {{ if (__{name}.ValueKind != System.Text.Json.JsonValueKind.Null) {{ {tgt}.{name} = {child}.RestoreState(__{name}.GetRawText()); }} }}\n",
+                    "if (__root.TryGetProperty(\"{name}\", out var __{name})) {{ if (__{name}.ValueKind != System.Text.Json.JsonValueKind.Null) {{ {tgt}.{name} = {child}.{load}(__{name}.GetRawText()); }} }}\n",
                     tgt = target,
                     name = var.name,
-                    child = child_sys
+                    child = child_sys,
+                    load = child_load
                 )
             };
             restore_body.push_str(&body);

--- a/framec/src/frame_c/compiler/codegen/interface_gen/persist/dart.rs
+++ b/framec/src/frame_c/compiler/codegen/interface_gen/persist/dart.rs
@@ -17,7 +17,8 @@ use crate::frame_c::compiler::codegen::ast::{CodegenNode, Param, Visibility};
 use crate::frame_c::compiler::frame_ast::SystemAst;
 
 use super::super::{
-    dart_conv_expr, extract_tagged_system_name, nested_uses_new_contract, parse_dart_type,
+    child_persist_names, dart_conv_expr, extract_tagged_system_name, nested_uses_new_contract,
+    parse_dart_type,
 };
 
 pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
@@ -74,10 +75,11 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
             continue;
         }
         let init = var.initializer_text.as_deref().unwrap_or("");
-        if extract_tagged_system_name(init).is_some() {
+        if let Some(child_sys) = extract_tagged_system_name(init) {
+            let (child_save, _) = child_persist_names(child_sys, "saveState", "restoreState");
             save_body.push_str(&format!(
-                "    '{0}': this.{0} != null ? jsonDecode(this.{0}.saveState()) : null,\n",
-                var.name
+                "    '{0}': this.{0} != null ? jsonDecode(this.{0}.{1}()) : null,\n",
+                var.name, child_save
             ));
         } else {
             save_body.push_str(&format!("    '{}': this.{},\n", var.name, var.name));
@@ -208,16 +210,17 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
         }
         let init = var.initializer_text.as_deref().unwrap_or("");
         if let Some(child_sys) = extract_tagged_system_name(init) {
+            let (_, child_load) = child_persist_names(child_sys, "saveState", "restoreState");
             if nested_uses_new_contract(child_sys) {
                 restore_body.push_str(&format!(
-                    "{0}.{1} = {2}(); if (_parsed['{1}'] != null) {0}.{1}.restoreState(jsonEncode(_parsed['{1}']));\n",
-                    target, var.name, child_sys
+                    "{0}.{1} = {2}(); if (_parsed['{1}'] != null) {0}.{1}.{3}(jsonEncode(_parsed['{1}']));\n",
+                    target, var.name, child_sys, child_load
                 ));
                 continue;
             }
             restore_body.push_str(&format!(
-                "{0}.{1} = _parsed['{1}'] != null ? {2}.restoreState(jsonEncode(_parsed['{1}'])) : {2}();\n",
-                target, var.name, child_sys
+                "{0}.{1} = _parsed['{1}'] != null ? {2}.{3}(jsonEncode(_parsed['{1}'])) : {2}();\n",
+                target, var.name, child_sys, child_load
             ));
         } else {
             let ty = match &var.var_type {

--- a/framec/src/frame_c/compiler/codegen/interface_gen/persist/gdscript.rs
+++ b/framec/src/frame_c/compiler/codegen/interface_gen/persist/gdscript.rs
@@ -20,7 +20,7 @@
 use crate::frame_c::compiler::codegen::ast::{CodegenNode, Param, Visibility};
 use crate::frame_c::compiler::frame_ast::SystemAst;
 
-use super::super::{extract_tagged_system_name, nested_uses_new_contract};
+use super::super::{child_persist_names, extract_tagged_system_name, nested_uses_new_contract};
 
 pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
     system: &SystemAst,
@@ -78,12 +78,13 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
             continue;
         }
         let init = var.initializer_text.as_deref().unwrap_or("");
-        if extract_tagged_system_name(init).is_some() {
+        if let Some(child_sys) = extract_tagged_system_name(init) {
             // Nested child returns Godot-binary PackedByteArray
             // (var_to_bytes shape). Decode to Variant before embedding.
+            let (child_save, _) = child_persist_names(child_sys, "save_state", "restore_state");
             save_body.push_str(&format!(
-                "state_data[\"{0}\"] = bytes_to_var(self.{0}.save_state()) if self.{0} != null else null\n",
-                var.name
+                "state_data[\"{0}\"] = bytes_to_var(self.{0}.{1}()) if self.{0} != null else null\n",
+                var.name, child_save
             ));
         } else {
             save_body.push_str(&format!(
@@ -167,15 +168,16 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
                 "var __raw_{0} = state_data.get(\"{0}\", null)\n",
                 var.name
             ));
+            let (_, child_load) = child_persist_names(child_sys, "save_state", "restore_state");
             if nested_uses_new_contract(child_sys) {
                 restore_body.push_str(&format!(
-                    "if __raw_{1} != null:\n    {0}.{1} = {2}.new()\n    {0}.{1}.restore_state(var_to_bytes(__raw_{1}))\nelse:\n    {0}.{1} = null\n",
-                    target, var.name, child_sys
+                    "if __raw_{1} != null:\n    {0}.{1} = {2}.new()\n    {0}.{1}.{3}(var_to_bytes(__raw_{1}))\nelse:\n    {0}.{1} = null\n",
+                    target, var.name, child_sys, child_load
                 ));
             } else {
                 restore_body.push_str(&format!(
-                    "{0}.{1} = {2}.restore_state(var_to_bytes(__raw_{1})) if __raw_{1} != null else null\n",
-                    target, var.name, child_sys
+                    "{0}.{1} = {2}.{3}(var_to_bytes(__raw_{1})) if __raw_{1} != null else null\n",
+                    target, var.name, child_sys, child_load
                 ));
             }
         } else {

--- a/framec/src/frame_c/compiler/codegen/interface_gen/persist/go.rs
+++ b/framec/src/frame_c/compiler/codegen/interface_gen/persist/go.rs
@@ -16,7 +16,7 @@ use crate::frame_c::compiler::codegen::ast::{CodegenNode, Param, Visibility};
 use crate::frame_c::compiler::codegen::codegen_utils::go_map_type;
 use crate::frame_c::compiler::frame_ast::SystemAst;
 
-use super::super::{extract_tagged_system_name, nested_uses_new_contract};
+use super::super::{child_persist_names, extract_tagged_system_name, nested_uses_new_contract};
 
 pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
     system: &SystemAst,
@@ -74,10 +74,12 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
             continue;
         }
         let init = var.initializer_text.as_deref().unwrap_or("");
-        if extract_tagged_system_name(init).is_some() {
+        if let Some(child_sys) = extract_tagged_system_name(init) {
+            let (child_save, _) =
+                child_persist_names(child_sys, "SaveState", &format!("Restore{}", child_sys));
             save_body.push_str(&format!(
-                "    \"{0}\": func() interface{{}} {{ var __raw interface{{}}; _ = json.Unmarshal([]byte(s.{0}.SaveState()), &__raw); return __raw }}(),\n",
-                var.name
+                "    \"{0}\": func() interface{{}} {{ var __raw interface{{}}; _ = json.Unmarshal([]byte(s.{0}.{1}()), &__raw); return __raw }}(),\n",
+                var.name, child_save
             ));
         } else {
             save_body.push_str(&format!("    \"{}\": s.{},\n", var.name, var.name));
@@ -257,15 +259,19 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
         }
         let init = var.initializer_text.as_deref().unwrap_or("");
         if let Some(child_sys) = extract_tagged_system_name(init) {
+            let (_, child_load) =
+                child_persist_names(child_sys, "SaveState", &format!("Restore{}", child_sys));
             if nested_uses_new_contract(child_sys) {
+                // New-contract child: construct, then call the child's
+                // declared (instance) load op — `Restore<Child>` by default.
                 restore_body.push_str(&format!(
-                    "if __raw_{1}, err_{1} := json.Marshal(_parsed[\"{1}\"]); err_{1} == nil {{ {0}.{1} = New{2}(); {0}.{1}.LoadState(string(__raw_{1})) }}\n",
-                    target, var.name, child_sys
+                    "if __raw_{1}, err_{1} := json.Marshal(_parsed[\"{1}\"]); err_{1} == nil {{ {0}.{1} = New{2}(); {0}.{1}.{3}(string(__raw_{1})) }}\n",
+                    target, var.name, child_sys, child_load
                 ));
             } else {
                 restore_body.push_str(&format!(
-                    "if __raw_{1}, err_{1} := json.Marshal(_parsed[\"{1}\"]); err_{1} == nil {{ {0}.{1} = Restore{2}(string(__raw_{1})) }}\n",
-                    target, var.name, child_sys
+                    "if __raw_{1}, err_{1} := json.Marshal(_parsed[\"{1}\"]); err_{1} == nil {{ {0}.{1} = {2}(string(__raw_{1})) }}\n",
+                    target, var.name, child_load
                 ));
             }
         } else {

--- a/framec/src/frame_c/compiler/codegen/interface_gen/persist/java.rs
+++ b/framec/src/frame_c/compiler/codegen/interface_gen/persist/java.rs
@@ -11,7 +11,7 @@ use crate::frame_c::compiler::codegen::ast::{CodegenNode, Param, Visibility};
 use crate::frame_c::compiler::codegen::codegen_utils::java_map_type;
 use crate::frame_c::compiler::frame_ast::SystemAst;
 
-use super::super::{extract_tagged_system_name, nested_uses_new_contract};
+use super::super::{child_persist_names, extract_tagged_system_name, nested_uses_new_contract};
 
 pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
     system: &SystemAst,
@@ -183,10 +183,11 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
             continue;
         }
         let init = var.initializer_text.as_deref().unwrap_or("");
-        if extract_tagged_system_name(init).is_some() {
+        if let Some(child_sys) = extract_tagged_system_name(init) {
+            let (child_save, _) = child_persist_names(child_sys, "save_state", "restore_state");
             save_body.push_str(&format!(
-                "try {{ __j.put(\"{0}\", {0} != null ? mapper.readTree({0}.save_state()) : null); }} catch (Exception e) {{ throw new RuntimeException(e); }}\n",
-                var.name
+                "try {{ __j.put(\"{0}\", {0} != null ? mapper.readTree({0}.{1}()) : null); }} catch (Exception e) {{ throw new RuntimeException(e); }}\n",
+                var.name, child_save
             ));
         } else {
             save_body.push_str(&format!("__j.put(\"{}\", {});\n", var.name, var.name));
@@ -236,19 +237,22 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
         }
         let init = var.initializer_text.as_deref().unwrap_or("");
         if let Some(child_sys) = extract_tagged_system_name(init) {
+            let (_, child_load) = child_persist_names(child_sys, "save_state", "restore_state");
             if nested_uses_new_contract(child_sys) {
                 restore_body.push_str(&format!(
-                    "if (__j.has(\"{name}\") && !__j.get(\"{name}\").isNull()) {{ {tgt}.{name} = new {child}(); {tgt}.{name}.restore_state(__j.get(\"{name}\").toString()); }}\n",
+                    "if (__j.has(\"{name}\") && !__j.get(\"{name}\").isNull()) {{ {tgt}.{name} = new {child}(); {tgt}.{name}.{load}(__j.get(\"{name}\").toString()); }}\n",
                     tgt = target,
                     name = var.name,
-                    child = child_sys
+                    child = child_sys,
+                    load = child_load
                 ));
             } else {
                 restore_body.push_str(&format!(
-                    "if (__j.has(\"{name}\") && !__j.get(\"{name}\").isNull()) {tgt}.{name} = {child}.restore_state(__j.get(\"{name}\").toString());\n",
+                    "if (__j.has(\"{name}\") && !__j.get(\"{name}\").isNull()) {tgt}.{name} = {child}.{load}(__j.get(\"{name}\").toString());\n",
                     tgt = target,
                     name = var.name,
-                    child = child_sys
+                    child = child_sys,
+                    load = child_load
                 ));
             }
             continue;

--- a/framec/src/frame_c/compiler/codegen/interface_gen/persist/javascript.rs
+++ b/framec/src/frame_c/compiler/codegen/interface_gen/persist/javascript.rs
@@ -18,7 +18,7 @@
 use crate::frame_c::compiler::codegen::ast::{CodegenNode, Param, Visibility};
 use crate::frame_c::compiler::frame_ast::SystemAst;
 
-use super::super::{extract_tagged_system_name, nested_uses_new_contract};
+use super::super::{child_persist_names, extract_tagged_system_name, nested_uses_new_contract};
 
 pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
     system: &SystemAst,
@@ -83,10 +83,11 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
             continue;
         }
         let init = var.initializer_text.as_deref().unwrap_or("");
-        if extract_tagged_system_name(init).is_some() {
+        if let Some(child_sys) = extract_tagged_system_name(init) {
+            let (child_save, _) = child_persist_names(child_sys, "saveState", "restoreState");
             save_body.push_str(&format!(
-                "    {0}: this.{0} ? JSON.parse(this.{0}.saveState()) : null,\n",
-                var.name
+                "    {0}: this.{0} ? JSON.parse(this.{0}.{1}()) : null,\n",
+                var.name, child_save
             ));
         } else {
             save_body.push_str(&format!("    {}: this.{},\n", var.name, var.name));
@@ -173,15 +174,16 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
         }
         let init = var.initializer_text.as_deref().unwrap_or("");
         if let Some(child_sys) = extract_tagged_system_name(init) {
+            let (_, child_load) = child_persist_names(child_sys, "saveState", "restoreState");
             if nested_uses_new_contract(child_sys) {
                 restore_body.push_str(&format!(
-                    "if (_parsed.{1} != null) {{ {0}.{1} = new {2}(); {0}.{1}.restoreState(JSON.stringify(_parsed.{1})); }} else {{ {0}.{1} = null; }}\n",
-                    target, var.name, child_sys
+                    "if (_parsed.{1} != null) {{ {0}.{1} = new {2}(); {0}.{1}.{3}(JSON.stringify(_parsed.{1})); }} else {{ {0}.{1} = null; }}\n",
+                    target, var.name, child_sys, child_load
                 ));
             } else {
                 restore_body.push_str(&format!(
-                    "{0}.{1} = _parsed.{1} != null ? {2}.restoreState(JSON.stringify(_parsed.{1})) : null;\n",
-                    target, var.name, child_sys
+                    "{0}.{1} = _parsed.{1} != null ? {2}.{3}(JSON.stringify(_parsed.{1})) : null;\n",
+                    target, var.name, child_sys, child_load
                 ));
             }
         } else {

--- a/framec/src/frame_c/compiler/codegen/interface_gen/persist/kotlin.rs
+++ b/framec/src/frame_c/compiler/codegen/interface_gen/persist/kotlin.rs
@@ -11,7 +11,7 @@ use crate::frame_c::compiler::codegen::ast::{CodegenNode, Param, Visibility};
 use crate::frame_c::compiler::codegen::codegen_utils::kotlin_map_type;
 use crate::frame_c::compiler::frame_ast::SystemAst;
 
-use super::super::{extract_tagged_system_name, nested_uses_new_contract};
+use super::super::{child_persist_names, extract_tagged_system_name, nested_uses_new_contract};
 
 pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
     system: &SystemAst,
@@ -186,10 +186,11 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
             continue;
         }
         let init = var.initializer_text.as_deref().unwrap_or("");
-        if extract_tagged_system_name(init).is_some() {
+        if let Some(child_sys) = extract_tagged_system_name(init) {
+            let (child_save, _) = child_persist_names(child_sys, "save_state", "restore_state");
             save_body.push_str(&format!(
-                "j[\"{0}\"] = if ({0} != null) mapper.readTree({0}.save_state()) else null\n",
-                var.name
+                "j[\"{0}\"] = if ({0} != null) mapper.readTree({0}.{1}()) else null\n",
+                var.name, child_save
             ));
         } else {
             save_body.push_str(&format!("j[\"{}\"] = {}\n", var.name, var.name));
@@ -235,19 +236,22 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
         }
         let init = var.initializer_text.as_deref().unwrap_or("");
         if let Some(child_sys) = extract_tagged_system_name(init) {
+            let (_, child_load) = child_persist_names(child_sys, "save_state", "restore_state");
             let body = if nested_uses_new_contract(child_sys) {
                 format!(
-                    "if (_parsed.has(\"{name}\") && !_parsed.get(\"{name}\").isNull) {{ {tgt}.{name} = {child}(); {tgt}.{name}.restore_state(_parsed.get(\"{name}\").toString()) }}\n",
+                    "if (_parsed.has(\"{name}\") && !_parsed.get(\"{name}\").isNull) {{ {tgt}.{name} = {child}(); {tgt}.{name}.{load}(_parsed.get(\"{name}\").toString()) }}\n",
                     tgt = target,
                     name = var.name,
-                    child = child_sys
+                    child = child_sys,
+                    load = child_load
                 )
             } else {
                 format!(
-                    "if (_parsed.has(\"{name}\") && !_parsed.get(\"{name}\").isNull) {tgt}.{name} = {child}.restore_state(_parsed.get(\"{name}\").toString())\n",
+                    "if (_parsed.has(\"{name}\") && !_parsed.get(\"{name}\").isNull) {tgt}.{name} = {child}.{load}(_parsed.get(\"{name}\").toString())\n",
                     tgt = target,
                     name = var.name,
-                    child = child_sys
+                    child = child_sys,
+                    load = child_load
                 )
             };
             restore_body.push_str(&body);

--- a/framec/src/frame_c/compiler/codegen/interface_gen/persist/lua.rs
+++ b/framec/src/frame_c/compiler/codegen/interface_gen/persist/lua.rs
@@ -16,7 +16,7 @@
 use crate::frame_c::compiler::codegen::ast::{CodegenNode, Param, Visibility};
 use crate::frame_c::compiler::frame_ast::SystemAst;
 
-use super::super::{extract_tagged_system_name, nested_uses_new_contract};
+use super::super::{child_persist_names, extract_tagged_system_name, nested_uses_new_contract};
 
 pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
     system: &SystemAst,
@@ -71,10 +71,11 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
             continue;
         }
         let init = var.initializer_text.as_deref().unwrap_or("");
-        if extract_tagged_system_name(init).is_some() {
+        if let Some(child_sys) = extract_tagged_system_name(init) {
+            let (child_save, _) = child_persist_names(child_sys, "save_state", "restore_state");
             save_body.push_str(&format!(
-                "result.{0} = (self.{0} ~= nil) and (select(2, serpent.load(self.{0}:save_state()))) or nil\n",
-                var.name
+                "result.{0} = (self.{0} ~= nil) and (select(2, serpent.load(self.{0}:{1}()))) or nil\n",
+                var.name, child_save
             ));
         } else {
             save_body.push_str(&format!("result.{} = self.{}\n", var.name, var.name));
@@ -146,15 +147,16 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
         }
         let init = var.initializer_text.as_deref().unwrap_or("");
         if let Some(child_sys) = extract_tagged_system_name(init) {
+            let (_, child_load) = child_persist_names(child_sys, "save_state", "restore_state");
             if nested_uses_new_contract(child_sys) {
                 restore_body.push_str(&format!(
-                    "if _parsed.{1} ~= nil then {0}.{1} = {2}:new(); {0}.{1}:restore_state(serpent.dump(_parsed.{1})) else {0}.{1} = nil end\n",
-                    target, var.name, child_sys
+                    "if _parsed.{1} ~= nil then {0}.{1} = {2}:new(); {0}.{1}:{3}(serpent.dump(_parsed.{1})) else {0}.{1} = nil end\n",
+                    target, var.name, child_sys, child_load
                 ));
             } else {
                 restore_body.push_str(&format!(
-                    "if _parsed.{1} ~= nil then {0}.{1} = {2}.restore_state(serpent.dump(_parsed.{1})) else {0}.{1} = nil end\n",
-                    target, var.name, child_sys
+                    "if _parsed.{1} ~= nil then {0}.{1} = {2}.{3}(serpent.dump(_parsed.{1})) else {0}.{1} = nil end\n",
+                    target, var.name, child_sys, child_load
                 ));
             }
             continue;

--- a/framec/src/frame_c/compiler/codegen/interface_gen/persist/php.rs
+++ b/framec/src/frame_c/compiler/codegen/interface_gen/persist/php.rs
@@ -11,7 +11,7 @@
 use crate::frame_c::compiler::codegen::ast::{CodegenNode, Param, Visibility};
 use crate::frame_c::compiler::frame_ast::SystemAst;
 
-use super::super::{extract_tagged_system_name, nested_uses_new_contract};
+use super::super::{child_persist_names, extract_tagged_system_name, nested_uses_new_contract};
 
 pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
     system: &SystemAst,
@@ -100,10 +100,11 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
             continue;
         }
         let init = var.initializer_text.as_deref().unwrap_or("");
-        if extract_tagged_system_name(init).is_some() {
+        if let Some(child_sys) = extract_tagged_system_name(init) {
+            let (child_save, _) = child_persist_names(child_sys, "save_state", "restore_state");
             save_body.push_str(&format!(
-                "$j['{0}'] = $this->{0} !== null ? json_decode($this->{0}->save_state(), true) : null;\n",
-                var.name
+                "$j['{0}'] = $this->{0} !== null ? json_decode($this->{0}->{1}(), true) : null;\n",
+                var.name, child_save
             ));
         } else {
             save_body.push_str(&format!("$j['{}'] = $this->{};\n", var.name, var.name));
@@ -159,15 +160,16 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
         }
         let init = var.initializer_text.as_deref().unwrap_or("");
         if let Some(child_sys) = extract_tagged_system_name(init) {
+            let (_, child_load) = child_persist_names(child_sys, "save_state", "restore_state");
             if nested_uses_new_contract(child_sys) {
                 restore_body.push_str(&format!(
-                    "if (isset($_parsed['{1}']) && $_parsed['{1}'] !== null) {{ {0}->{1} = new {2}(); {0}->{1}->restore_state(json_encode($_parsed['{1}'])); }}\n",
-                    target, var.name, child_sys
+                    "if (isset($_parsed['{1}']) && $_parsed['{1}'] !== null) {{ {0}->{1} = new {2}(); {0}->{1}->{3}(json_encode($_parsed['{1}'])); }}\n",
+                    target, var.name, child_sys, child_load
                 ));
             } else {
                 restore_body.push_str(&format!(
-                    "if (isset($_parsed['{1}']) && $_parsed['{1}'] !== null) {0}->{1} = {2}::restore_state(json_encode($_parsed['{1}']));\n",
-                    target, var.name, child_sys
+                    "if (isset($_parsed['{1}']) && $_parsed['{1}'] !== null) {0}->{1} = {2}::{3}(json_encode($_parsed['{1}']));\n",
+                    target, var.name, child_sys, child_load
                 ));
             }
         } else {

--- a/framec/src/frame_c/compiler/codegen/interface_gen/persist/python.rs
+++ b/framec/src/frame_c/compiler/codegen/interface_gen/persist/python.rs
@@ -18,7 +18,7 @@
 use crate::frame_c::compiler::codegen::ast::{CodegenNode, Param, Visibility};
 use crate::frame_c::compiler::frame_ast::SystemAst;
 
-use super::super::{extract_tagged_system_name, nested_uses_new_contract};
+use super::super::{child_persist_names, extract_tagged_system_name, nested_uses_new_contract};
 
 pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
     system: &SystemAst,
@@ -60,12 +60,14 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
             continue;
         }
         let init = var.initializer_text.as_deref().unwrap_or("");
-        if extract_tagged_system_name(init).is_some() {
+        if let Some(child_sys) = extract_tagged_system_name(init) {
             // Nested @@SystemName(): round-trip via the child's
-            // save_state (which itself returns UTF-8 JSON bytes).
+            // save op (which itself returns UTF-8 JSON bytes) —
+            // by the child's DECLARED name (FRAMEC_BUGS #44).
+            let (child_save, _) = child_persist_names(child_sys, "save_state", "restore_state");
             save_body.push_str(&format!(
-                "state_data[\"{0}\"] = json.loads(self.{0}.save_state()) if self.{0} is not None else None\n",
-                var.name
+                "state_data[\"{0}\"] = json.loads(self.{0}.{1}()) if self.{0} is not None else None\n",
+                var.name, child_save
             ));
         } else {
             save_body.push_str(&format!("state_data[\"{0}\"] = self.{0}\n", var.name));
@@ -132,15 +134,16 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
         }
         let init = var.initializer_text.as_deref().unwrap_or("");
         if let Some(child_sys) = extract_tagged_system_name(init) {
+            let (_, child_load) = child_persist_names(child_sys, "save_state", "restore_state");
             if nested_uses_new_contract(child_sys) {
                 restore_body.push_str(&format!(
-                    "if _parsed.get(\"{1}\") is not None:\n    {0}.{1} = {2}()\n    {0}.{1}.restore_state(json.dumps(_parsed[\"{1}\"]).encode(\"utf-8\"))\nelse:\n    {0}.{1} = None\n",
-                    target, var.name, child_sys
+                    "if _parsed.get(\"{1}\") is not None:\n    {0}.{1} = {2}()\n    {0}.{1}.{3}(json.dumps(_parsed[\"{1}\"]).encode(\"utf-8\"))\nelse:\n    {0}.{1} = None\n",
+                    target, var.name, child_sys, child_load
                 ));
             } else {
                 restore_body.push_str(&format!(
-                    "{0}.{1} = {2}.restore_state(json.dumps(_parsed[\"{1}\"]).encode(\"utf-8\")) if _parsed.get(\"{1}\") is not None else None\n",
-                    target, var.name, child_sys
+                    "{0}.{1} = {2}.{3}(json.dumps(_parsed[\"{1}\"]).encode(\"utf-8\")) if _parsed.get(\"{1}\") is not None else None\n",
+                    target, var.name, child_sys, child_load
                 ));
             }
         } else {

--- a/framec/src/frame_c/compiler/codegen/interface_gen/persist/ruby.rs
+++ b/framec/src/frame_c/compiler/codegen/interface_gen/persist/ruby.rs
@@ -13,7 +13,7 @@
 use crate::frame_c::compiler::codegen::ast::{CodegenNode, Param, Visibility};
 use crate::frame_c::compiler::frame_ast::SystemAst;
 
-use super::super::{extract_tagged_system_name, nested_uses_new_contract};
+use super::super::{child_persist_names, extract_tagged_system_name, nested_uses_new_contract};
 
 pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
     system: &SystemAst,
@@ -104,10 +104,11 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
             continue;
         }
         let init = var.initializer_text.as_deref().unwrap_or("");
-        if extract_tagged_system_name(init).is_some() {
+        if let Some(child_sys) = extract_tagged_system_name(init) {
+            let (child_save, _) = child_persist_names(child_sys, "save_state", "restore_state");
             save_body.push_str(&format!(
-                "j[\"{0}\"] = @{0}.nil? ? nil : JSON.parse(@{0}.save_state)\n",
-                var.name
+                "j[\"{0}\"] = @{0}.nil? ? nil : JSON.parse(@{0}.{1})\n",
+                var.name, child_save
             ));
         } else {
             save_body.push_str(&format!("j[\"{}\"] = @{}\n", var.name, var.name));
@@ -148,15 +149,16 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
             }
             let init = var.initializer_text.as_deref().unwrap_or("");
             if let Some(child_sys) = extract_tagged_system_name(init) {
+                let (_, child_load) = child_persist_names(child_sys, "save_state", "restore_state");
                 if nested_uses_new_contract(child_sys) {
                     restore_body.push_str(&format!(
-                        "if _parsed.key?(\"{0}\") && !_parsed[\"{0}\"].nil? then @{0} = {1}.new; @{0}.restore_state(JSON.generate(_parsed[\"{0}\"])) end\n",
-                        var.name, child_sys
+                        "if _parsed.key?(\"{0}\") && !_parsed[\"{0}\"].nil? then @{0} = {1}.new; @{0}.{2}(JSON.generate(_parsed[\"{0}\"])) end\n",
+                        var.name, child_sys, child_load
                     ));
                 } else {
                     restore_body.push_str(&format!(
-                        "if _parsed.key?(\"{0}\") then @{0} = _parsed[\"{0}\"].nil? ? nil : {1}.restore_state(JSON.generate(_parsed[\"{0}\"])) end\n",
-                        var.name, child_sys
+                        "if _parsed.key?(\"{0}\") then @{0} = _parsed[\"{0}\"].nil? ? nil : {1}.{2}(JSON.generate(_parsed[\"{0}\"])) end\n",
+                        var.name, child_sys, child_load
                     ));
                 }
             } else {
@@ -182,9 +184,10 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
             }
             let init = var.initializer_text.as_deref().unwrap_or("");
             if let Some(child_sys) = extract_tagged_system_name(init) {
+                let (_, child_load) = child_persist_names(child_sys, "save_state", "restore_state");
                 restore_body.push_str(&format!(
-                    "if _parsed.key?(\"{0}\") then instance.{0} = _parsed[\"{0}\"].nil? ? nil : {1}.restore_state(JSON.generate(_parsed[\"{0}\"])) end\n",
-                    var.name, child_sys
+                    "if _parsed.key?(\"{0}\") then instance.{0} = _parsed[\"{0}\"].nil? ? nil : {1}.{2}(JSON.generate(_parsed[\"{0}\"])) end\n",
+                    var.name, child_sys, child_load
                 ));
             } else {
                 restore_body.push_str(&format!(

--- a/framec/src/frame_c/compiler/codegen/interface_gen/persist/swift.rs
+++ b/framec/src/frame_c/compiler/codegen/interface_gen/persist/swift.rs
@@ -10,7 +10,7 @@ use crate::frame_c::compiler::codegen::ast::{CodegenNode, Param, Visibility};
 use crate::frame_c::compiler::codegen::codegen_utils::swift_map_type;
 use crate::frame_c::compiler::frame_ast::SystemAst;
 
-use super::super::{extract_tagged_system_name, nested_uses_new_contract};
+use super::super::{child_persist_names, extract_tagged_system_name, nested_uses_new_contract};
 
 pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
     system: &SystemAst,
@@ -109,10 +109,11 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
             continue;
         }
         let init = var.initializer_text.as_deref().unwrap_or("");
-        if extract_tagged_system_name(init).is_some() {
+        if let Some(child_sys) = extract_tagged_system_name(init) {
+            let (child_save, _) = child_persist_names(child_sys, "saveState", "restoreState");
             save_body.push_str(&format!(
-                "if let __raw_{0} = {0}.saveState().data(using: .utf8), let __nested_{0} = try? JSONSerialization.jsonObject(with: __raw_{0}) {{ j[\"{0}\"] = __nested_{0} }}\n",
-                var.name
+                "if let __raw_{0} = {0}.{1}().data(using: .utf8), let __nested_{0} = try? JSONSerialization.jsonObject(with: __raw_{0}) {{ j[\"{0}\"] = __nested_{0} }}\n",
+                var.name, child_save
             ));
         } else {
             save_body.push_str(&format!("j[\"{}\"] = {}\n", var.name, var.name));
@@ -161,15 +162,16 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
         }
         let init = var.initializer_text.as_deref().unwrap_or("");
         if let Some(child_sys) = extract_tagged_system_name(init) {
+            let (_, child_load) = child_persist_names(child_sys, "saveState", "restoreState");
             if nested_uses_new_contract(child_sys) {
                 restore_body.push_str(&format!(
-                    "if let __raw_{1} = _parsed[\"{1}\"], let __data_{1} = try? JSONSerialization.data(withJSONObject: __raw_{1}), let __json_{1} = String(data: __data_{1}, encoding: .utf8) {{ {0}.{1} = {2}(); {0}.{1}.restoreState(__json_{1}) }}\n",
-                    target, var.name, child_sys
+                    "if let __raw_{1} = _parsed[\"{1}\"], let __data_{1} = try? JSONSerialization.data(withJSONObject: __raw_{1}), let __json_{1} = String(data: __data_{1}, encoding: .utf8) {{ {0}.{1} = {2}(); {0}.{1}.{3}(__json_{1}) }}\n",
+                    target, var.name, child_sys, child_load
                 ));
             } else {
                 restore_body.push_str(&format!(
-                    "if let __raw_{1} = _parsed[\"{1}\"], let __data_{1} = try? JSONSerialization.data(withJSONObject: __raw_{1}), let __json_{1} = String(data: __data_{1}, encoding: .utf8) {{ {0}.{1} = {2}.restoreState(__json_{1}) }}\n",
-                    target, var.name, child_sys
+                    "if let __raw_{1} = _parsed[\"{1}\"], let __data_{1} = try? JSONSerialization.data(withJSONObject: __raw_{1}), let __json_{1} = String(data: __data_{1}, encoding: .utf8) {{ {0}.{1} = {2}.{3}(__json_{1}) }}\n",
+                    target, var.name, child_sys, child_load
                 ));
             }
         } else {

--- a/framec/src/frame_c/compiler/pipeline/compiler.rs
+++ b/framec/src/frame_c/compiler/pipeline/compiler.rs
@@ -1005,6 +1005,28 @@ pub(crate) fn do_validate_codegen(c: &mut PipelineCtx) -> Option<CompileResult> 
         crate::frame_c::compiler::codegen::interface_gen::set_nested_system_domain_params(map);
     }
 
+    // FRAMEC_BUGS.md Issue #44: register each system's DECLARED
+    // `@@[save]` / `@@[load]` method names (`None` where the system
+    // used the language default). A *composing* parent's persist
+    // codegen reads this so it calls a child's save/load by the
+    // child's declared name instead of hardcoding the target default
+    // (which broke when the child renamed its persist ops).
+    {
+        let map: std::collections::HashMap<String, (Option<String>, Option<String>)> = system_asts
+            .iter()
+            .map(|s| {
+                (
+                    s.name.clone(),
+                    (
+                        s.save_op_name().map(str::to_string),
+                        s.load_op_name().map(str::to_string),
+                    ),
+                )
+            })
+            .collect();
+        crate::frame_c::compiler::codegen::interface_gen::set_nested_system_persist_names(map);
+    }
+
     for system_ast in &mut system_asts {
         // Validate with shared arcanum (all sibling systems visible).
         // Validation runs on the *unfiltered* AST so attribute-shape

--- a/framec/src/frame_c/compiler/pipeline/compiler.rs
+++ b/framec/src/frame_c/compiler/pipeline/compiler.rs
@@ -127,6 +127,15 @@ pub(crate) struct PipelineCtx {
     module_imports: Vec<crate::frame_c::compiler::frame_ast::Import>,
     /// Imported `@@system` names carrying the new persist contract (bug #8).
     imported_new_contract_names: Vec<String>,
+    /// RFC-0040: systems parsed from `@@import`ed files, present for analysis
+    /// (validation + cross-file metadata resolution) only. They are merged into
+    /// the arcanum and the codegen registries but **never emitted** — see
+    /// `imported_systems` for the emission exclusion set.
+    imported_system_asts: Vec<crate::frame_c::compiler::frame_ast::SystemAst>,
+    /// RFC-0040: names of the systems in `imported_system_asts`. Codegen emits
+    /// only local systems; a name in this set is analysis-visible but
+    /// emission-excluded, and references to it lower as cross-file.
+    imported_systems: std::collections::HashSet<String>,
     /// RFC-0022 strict-mode import errors, surfaced at the end of the run.
     strict_import_errors: Vec<CompileError>,
     /// Shared arcanum (all systems visible to each other), built once after parse.
@@ -147,6 +156,8 @@ impl PipelineCtx {
             system_asts: Vec::new(),
             module_imports: Vec::new(),
             imported_new_contract_names: Vec::new(),
+            imported_system_asts: Vec::new(),
+            imported_systems: std::collections::HashSet::new(),
             strict_import_errors: Vec::new(),
             arcanum: None,
             generated_systems: Vec::new(),
@@ -287,37 +298,15 @@ pub(crate) fn do_segment(c: &mut PipelineCtx) -> Option<CompileResult> {
                     });
                 }
             }
-            // RFC-0024: @@import removed entirely. Cross-file
-            // dependencies are expressed in the target language's
-            // native syntax (`from .x import Y` for Python, `use
-            // crate::x::Y;` for Rust, `const Y = preload(...)` for
-            // GDScript, etc.) written as Oceans Model pass-through.
-            if trimmed.starts_with("@@import") {
-                let after = &trimmed[8..];
-                let next = after.chars().next();
-                let is_import_directive = match next {
-                    None => true,
-                    Some(c) => c.is_whitespace() || c == '"',
-                };
-                if is_import_directive {
-                    return Some(CompileResult {
-                        code: String::new(),
-                        errors: vec![CompileError::new(
-                            "E823",
-                            "`@@import \"<path>\"` is no longer accepted (RFC-0024). \
-                             Write the target language's native import syntax outside \
-                             any `@@system` block instead — `from .other import X` for \
-                             Python, `use crate::other::X;` for Rust, `const X = \
-                             preload(\"res://other.gd\")` for GDScript, `#include \
-                             \"other.h\"` for C/C++, etc. framec passes the line \
-                             through unchanged (Oceans Model). See RFC-0024 for the \
-                             full per-target migration table.",
-                        )],
-                        warnings: vec![],
-                        source_map: None,
-                    });
-                }
-            }
+            // RFC-0040: `@@import "<path>"` is accepted again as an
+            // *analysis-only* directive (RFC-0024 removed the
+            // analysis-and-emission form; RFC-0040 revives analysis
+            // alone). framec reads the referenced Frame source to
+            // resolve and check cross-file references but emits nothing
+            // for it — native host imports stay Oceans Model
+            // pass-through. The directive is handled in `do_parse`
+            // (collected into `module_imports`, then resolved into
+            // analysis-only systems); no rejection here.
         }
     }
 
@@ -325,15 +314,25 @@ pub(crate) fn do_segment(c: &mut PipelineCtx) -> Option<CompileResult> {
     None
 }
 
-/// Pass 1: parse each `@@system` segment into a `SystemAst`, attaching
-/// lifecycle pragmas/attributes and collecting module `@@import` metadata.
-/// Populates `system_asts` / `module_imports` / `imported_new_contract_names`
-/// / `strict_import_errors`. Returns `Some` on the first parse/structure error.
-pub(crate) fn do_parse(c: &mut PipelineCtx) -> Option<CompileResult> {
-    let source_map = c.source_map.as_ref().unwrap();
-    let has_persist = c.has_persist;
-    let config = &c.config;
+/// One module's parse output — the systems it declares plus its `@@import`
+/// metadata. Produced by [`parse_module_segments`] for the primary source and,
+/// under RFC-0040, for each imported file.
+struct ParsedModule {
+    system_asts: Vec<crate::frame_c::compiler::frame_ast::SystemAst>,
+    module_imports: Vec<crate::frame_c::compiler::frame_ast::Import>,
+    imported_new_contract_names: Vec<String>,
+    strict_import_errors: Vec<CompileError>,
+}
 
+/// Parse one module's segments into systems + import metadata, attaching
+/// lifecycle pragmas/attributes to the systems they precede. Shared by
+/// `do_parse` (primary source) and RFC-0040 import resolution (each imported
+/// file). Returns `Err(result)` on the first parse/structure error.
+fn parse_module_segments(
+    source_map: &segmenter::SourceMap,
+    config: &PipelineConfig,
+    has_persist: bool,
+) -> Result<ParsedModule, CompileResult> {
     // Pass 1: Parse all systems into ASTs.
     //
     // Walk segments in source order so module-level lifecycle pragmas
@@ -522,7 +521,7 @@ pub(crate) fn do_parse(c: &mut PipelineCtx) -> Option<CompileResult> {
             ) {
                 Ok(ast) => ast,
                 Err(e) => {
-                    return Some(CompileResult {
+                    return Err(CompileResult {
                         code: String::new(),
                         errors: vec![CompileError::new(
                             "E002",
@@ -543,7 +542,7 @@ pub(crate) fn do_parse(c: &mut PipelineCtx) -> Option<CompileResult> {
                 match pipeline_parser::parse_system_header_params(&source_map.source, ast_hp_span) {
                     Ok(params) => system_ast.params = params,
                     Err(e) => {
-                        return Some(CompileResult {
+                        return Err(CompileResult {
                             code: String::new(),
                             errors: vec![CompileError::new(
                                 "E002",
@@ -560,7 +559,7 @@ pub(crate) fn do_parse(c: &mut PipelineCtx) -> Option<CompileResult> {
             system_ast.bases = bases.clone();
             // Validate and attach visibility from `@@system private Foo` syntax
             if visibility.as_deref() == Some("public") {
-                return Some(CompileResult {
+                return Err(CompileResult {
                     code: String::new(),
                     errors: vec![CompileError::new(
                         "E408",
@@ -585,7 +584,7 @@ pub(crate) fn do_parse(c: &mut PipelineCtx) -> Option<CompileResult> {
                         | TargetLanguage::Erlang
                 );
                 if unsupported {
-                    return Some(CompileResult {
+                    return Err(CompileResult {
                         code: String::new(),
                         errors: vec![CompileError::new(
                             "E409",
@@ -684,7 +683,7 @@ pub(crate) fn do_parse(c: &mut PipelineCtx) -> Option<CompileResult> {
                     .into_iter()
                     .map(|e| CompileError::new(&e.code, &e.message))
                     .collect();
-                return Some(CompileResult {
+                return Err(CompileResult {
                     code: String::new(),
                     errors,
                     warnings: vec![],
@@ -712,11 +711,84 @@ pub(crate) fn do_parse(c: &mut PipelineCtx) -> Option<CompileResult> {
         }
     }
 
-    c.system_asts = system_asts;
-    c.module_imports = module_imports;
-    c.imported_new_contract_names = imported_new_contract_names;
-    c.strict_import_errors = strict_import_errors;
+    Ok(ParsedModule {
+        system_asts,
+        module_imports,
+        imported_new_contract_names,
+        strict_import_errors,
+    })
+}
+
+/// Pass 1 driver: parse the primary source, then (RFC-0040) resolve any
+/// `@@import`ed files into analysis-only systems. Returns `Some` on the first
+/// parse/structure error.
+pub(crate) fn do_parse(c: &mut PipelineCtx) -> Option<CompileResult> {
+    let parsed = {
+        let source_map = c.source_map.as_ref().unwrap();
+        match parse_module_segments(source_map, &c.config, c.has_persist) {
+            Ok(p) => p,
+            Err(res) => return Some(res),
+        }
+    };
+    c.system_asts = parsed.system_asts;
+    c.module_imports = parsed.module_imports;
+    c.imported_new_contract_names = parsed.imported_new_contract_names;
+    c.strict_import_errors = parsed.strict_import_errors;
+
+    // RFC-0040: `@@import "<path>"` is an analysis directive. For each import,
+    // parse the referenced file's systems into analysis-only `SystemAst`s —
+    // visible to validation and the cross-system codegen registries, but never
+    // emitted (see `imported_systems` and the codegen emit loop). Unreadable
+    // imports are skipped silently here (open-world fallback); strict-mode
+    // readability errors are still collected by the peek during parsing.
+    let local_names: std::collections::HashSet<String> =
+        c.system_asts.iter().map(|s| s.name.clone()).collect();
+    let mut imported_asts: Vec<crate::frame_c::compiler::frame_ast::SystemAst> = Vec::new();
+    let mut imported_names: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let import_paths: Vec<String> = c.module_imports.iter().map(|i| i.module.clone()).collect();
+    for path in import_paths {
+        let resolved = resolve_import_path(&path, c.config.source_path.as_deref());
+        let content = match std::fs::read_to_string(&resolved) {
+            Ok(s) => s,
+            Err(_) => continue, // open-world: not a readable Frame source — skip.
+        };
+        let imported_map = match segmenter::segment_source(content.as_bytes(), c.config.target) {
+            Ok(sm) => sm,
+            Err(_) => continue,
+        };
+        let imported_has_persist = imported_map.persist_pragma().is_some();
+        // Parse the imported file's systems. Discard its own imports
+        // (transitive resolution is out of scope) and any structure error
+        // (the imported file is validated by its own compilation, not here).
+        if let Ok(pm) = parse_module_segments(&imported_map, &c.config, imported_has_persist) {
+            for ast in pm.system_asts {
+                if local_names.contains(&ast.name) || !imported_names.insert(ast.name.clone()) {
+                    continue; // local systems win; dedup repeated imports.
+                }
+                imported_asts.push(ast);
+            }
+        }
+    }
+    c.imported_system_asts = imported_asts;
+    c.imported_systems = imported_names;
     None
+}
+
+/// Resolve an `@@import` path relative to the importing file's directory (or
+/// the current directory when the importer's path is unknown). Mirrors the
+/// resolution the import peek performs.
+fn resolve_import_path(
+    import_path: &str,
+    importer_path: Option<&std::path::Path>,
+) -> std::path::PathBuf {
+    let buf = std::path::PathBuf::from(import_path);
+    if buf.is_absolute() {
+        buf
+    } else if let Some(dir) = importer_path.and_then(|p| p.parent()) {
+        dir.join(buf)
+    } else {
+        buf
+    }
 }
 
 /// Module-level structure gates + shared arcanum construction. Rejects
@@ -783,10 +855,16 @@ pub(crate) fn do_module_gates(c: &mut PipelineCtx) -> Option<CompileResult> {
         }
     }
 
-    // Build a shared arcanum containing ALL systems so they can reference each other
+    // Build a shared arcanum containing ALL systems so they can reference
+    // each other. RFC-0040: this includes `@@import`-resolved systems —
+    // present so the validator and the cross-system codegen registries can
+    // resolve and check cross-file references. They are analysis-only;
+    // codegen emits the local systems alone (see `do_validate_codegen`).
+    let mut arcanum_systems = system_asts.clone();
+    arcanum_systems.extend(c.imported_system_asts.iter().cloned());
     let module_ast = FrameAst::Module(ModuleAst {
         name: String::new(),
-        systems: system_asts.clone(),
+        systems: arcanum_systems,
         imports: module_imports.clone(),
         span: AstSpan::new(0, 0),
     });
@@ -796,9 +874,22 @@ pub(crate) fn do_module_gates(c: &mut PipelineCtx) -> Option<CompileResult> {
     // multi-system files (E805 zero, E806 multiple). Runs once per
     // module, before either codegen path forks. Single-system files
     // are exempt.
+    //
+    // RFC-0040: `@@[main]` is a module-primary / emission concern, so it is
+    // checked against the **locally-declared** systems only. An
+    // `@@import`ed system carries its own `@@[main]` for its own
+    // compilation; counting it here would spuriously trip E806 in the
+    // importer. (The arcanum above keeps the imported systems for
+    // cross-file resolution; only this main-attr scope is local.)
     {
+        let local_module_ast = FrameAst::Module(ModuleAst {
+            name: String::new(),
+            systems: system_asts.clone(),
+            imports: module_imports.clone(),
+            span: AstSpan::new(0, 0),
+        });
         let mut module_validator = FrameValidator::new();
-        if let Err(errs) = module_validator.validate_module_main_attr(&module_ast) {
+        if let Err(errs) = module_validator.validate_module_main_attr(&local_module_ast) {
             let errors = errs
                 .iter()
                 .map(|e| CompileError::new(&e.code, &e.message))
@@ -930,6 +1021,13 @@ pub(crate) fn do_validate_codegen(c: &mut PipelineCtx) -> Option<CompileResult> 
     let arcanum = c.arcanum.as_ref().unwrap();
     let mut system_asts = std::mem::take(&mut c.system_asts);
     let imported_new_contract_names = std::mem::take(&mut c.imported_new_contract_names);
+    // RFC-0040: `@@import`-resolved systems. They feed the cross-system
+    // registries below (so cross-file persist names, domain params, and
+    // contract shape resolve) and the arcanum (already merged in
+    // `do_module_gates`), but they are NOT in `system_asts` and so are
+    // never reached by the per-system emit loop — analysis-visible,
+    // emission-excluded.
+    let imported_system_asts = std::mem::take(&mut c.imported_system_asts);
 
     // Pass 2: Validate + codegen each system with the shared arcanum
     let backend = get_backend(config.target);
@@ -956,6 +1054,7 @@ pub(crate) fn do_validate_codegen(c: &mut PipelineCtx) -> Option<CompileResult> 
     {
         let mut new_contract: std::collections::HashSet<String> = system_asts
             .iter()
+            .chain(imported_system_asts.iter())
             .filter(|s| s.uses_new_persist_contract())
             .map(|s| s.name.clone())
             .collect();
@@ -970,8 +1069,16 @@ pub(crate) fn do_validate_codegen(c: &mut PipelineCtx) -> Option<CompileResult> 
         // reference" when a name misses the new-contract set.
         // Cross-file references default to new contract; local
         // legacy references default to the legacy emit.
-        let local: std::collections::HashSet<String> =
-            system_asts.iter().map(|s| s.name.clone()).collect();
+        // RFC-0040: imported systems are resolved (their contract is known
+        // from the parsed AST), so register them here too — a legacy
+        // imported system then resolves as legacy rather than defaulting to
+        // the cross-file new-contract assumption. Truly unknown (open-world,
+        // un-imported) names still fall through to that default.
+        let local: std::collections::HashSet<String> = system_asts
+            .iter()
+            .chain(imported_system_asts.iter())
+            .map(|s| s.name.clone())
+            .collect();
         crate::frame_c::compiler::codegen::interface_gen::set_local_systems(local);
     }
 
@@ -985,7 +1092,7 @@ pub(crate) fn do_validate_codegen(c: &mut PipelineCtx) -> Option<CompileResult> 
         use crate::frame_c::compiler::frame_ast::ParamKind;
         let mut map: std::collections::HashMap<String, Vec<(String, String)>> =
             std::collections::HashMap::new();
-        for s in &system_asts {
+        for s in system_asts.iter().chain(imported_system_asts.iter()) {
             let domain_params: Vec<(String, String)> = s
                 .params
                 .iter()
@@ -1014,6 +1121,7 @@ pub(crate) fn do_validate_codegen(c: &mut PipelineCtx) -> Option<CompileResult> 
     {
         let map: std::collections::HashMap<String, (Option<String>, Option<String>)> = system_asts
             .iter()
+            .chain(imported_system_asts.iter())
             .map(|s| {
                 (
                     s.name.clone(),
@@ -1213,10 +1321,18 @@ pub(crate) fn do_assemble(c: &mut PipelineCtx) -> CompileResult {
     // RFC-0022: ask the backend to translate `@@import` directives into
     // its native form. Default impl returns empty (no emission); per-
     // backend overrides translate per target.
-    let module_imports_emitted = backend.emit_module_imports(&module_imports);
-    // Imported `@@system` names — surfaced by the Phase 1 peek. The
-    // assembler accepts these as resolvable targets for `@@SystemName()`
-    // call sites in handler bodies and module-scope native code.
+    //
+    // RFC-0040: `@@import` is analysis-only and emits NOTHING — native
+    // host imports are the user's own Oceans Model pass-through. So the
+    // emitted-imports list is always empty regardless of backend; the
+    // directive's effect is confined to analysis/resolution. (The peeked
+    // names are still surfaced below so cross-file `@@SystemName()` call
+    // sites lower as external references rather than erroring.)
+    let module_imports_emitted: Vec<String> = Vec::new();
+    let _ = &module_imports; // analysis metadata only; never emitted (RFC-0040).
+                             // Imported `@@system` names — surfaced by the Phase 1 peek. The
+                             // assembler accepts these as resolvable targets for `@@SystemName()`
+                             // call sites in handler bodies and module-scope native code.
     let imported_system_names: Vec<String> = module_imports
         .iter()
         .flat_map(|imp| imp.symbols.iter().cloned())

--- a/framec/tests/python_snapshots.rs
+++ b/framec/tests/python_snapshots.rs
@@ -50,6 +50,55 @@ fn push_transition() {
     );
 }
 
+/// Regression for FRAMEC_BUGS Issue #44: when a parent composes a child
+/// system that renamed its persist ops via `@@[save(name)]` /
+/// `@@[load(name)]`, the parent's save/restore must call the child by its
+/// DECLARED name — not the hardcoded language default (`save_state` /
+/// `restore_state`), which doesn't exist on the renamed child and crashed
+/// at runtime.
+#[test]
+fn nested_child_custom_persist_name() {
+    let src = r#"
+@@[persist(str)]
+@@[save(persist_me)]
+@@[load(unpersist_me)]
+@@system Child {
+    interface:
+        ping()
+    machine:
+        $Idle { ping() { self.hits = self.hits + 1 } }
+    domain:
+        hits = 0
+}
+
+@@[main]
+@@[persist(str)]
+@@[save(save_state)]
+@@[load(restore_state)]
+@@system Parent {
+    interface:
+        poke()
+    machine:
+        $Run { poke() { self.child.ping() } }
+    domain:
+        child = @@Child()
+}
+"#;
+    let out = compile_source(src, "python_3");
+    assert!(
+        out.contains("self.child.persist_me()"),
+        "parent save must call the child's declared @@[save] name:\n{out}"
+    );
+    assert!(
+        out.contains("self.child.unpersist_me("),
+        "parent restore must call the child's declared @@[load] name:\n{out}"
+    );
+    assert!(
+        !out.contains("self.child.save_state()") && !out.contains("self.child.restore_state("),
+        "parent must not call the language-default persist names on the renamed child:\n{out}"
+    );
+}
+
 #[test]
 fn linear_fsm() {
     insta::assert_snapshot!(compile_fixture("01_linear_fsm", "python_3"));

--- a/framec/tests/rfc0040_import.rs
+++ b/framec/tests/rfc0040_import.rs
@@ -1,0 +1,166 @@
+//! RFC-0040 — analysis-only `@@import` cross-file resolution.
+//!
+//! These exercise the cross-file path, so they write two Frame files to a
+//! temp dir and compile the importer *with its path* (so `@@import`'s
+//! relative resolution works) via `compile_module_with_path`.
+
+use framec::frame_c::compiler::{compile_module_with_path, TargetLanguage};
+use std::fs;
+use std::path::PathBuf;
+
+/// Fresh, unique temp dir for one test's two-file fixture.
+fn scratch(tag: &str) -> PathBuf {
+    let mut d = std::env::temp_dir();
+    d.push(format!("framec_rfc0040_{}_{}", tag, std::process::id()));
+    let _ = fs::remove_dir_all(&d);
+    fs::create_dir_all(&d).unwrap();
+    d
+}
+
+fn js() -> TargetLanguage {
+    TargetLanguage::try_from("javascript").unwrap()
+}
+
+/// A composing parent that `@@import`s a child which renamed its persist ops
+/// to snake_case (NON-default for JS, whose default is camelCase) must call the
+/// child's DECLARED names — resolved by reading the imported source. This is
+/// the cross-file half of the composed-child persist fix.
+#[test]
+fn cross_file_persist_names_resolve_through_import() {
+    let dir = scratch("resolve");
+    fs::write(
+        dir.join("child.fjs"),
+        r#"@@[persist(string)]
+@@[save(save_state)]
+@@[load(restore_state)]
+@@system Child {
+    interface:
+        ping()
+    machine:
+        $Idle { ping() { self.hits = self.hits + 1 } }
+    domain:
+        hits: int = 0
+}
+"#,
+    )
+    .unwrap();
+    let parent = r#"import { Child } from "./child.machine.js"
+@@import "./child.fjs"
+@@[main]
+@@[persist(string)]
+@@[save(save_state)]
+@@[load(restore_state)]
+@@system Parent {
+    interface:
+        poke()
+    machine:
+        $Run { poke() { self.child.ping() } }
+    domain:
+        child: Child = @@Child()
+}
+"#;
+    let parent_path = dir.join("parent.fjs");
+    fs::write(&parent_path, parent).unwrap();
+
+    let out = compile_module_with_path(parent, js(), Some(parent_path))
+        .expect("parent.fjs should compile");
+
+    assert!(
+        out.contains("this.child.save_state()"),
+        "parent must call the imported child's DECLARED save name:\n{out}"
+    );
+    assert!(
+        out.contains("this.child.restore_state("),
+        "parent must call the imported child's DECLARED load name:\n{out}"
+    );
+    assert!(
+        !out.contains("this.child.saveState()"),
+        "parent must not fall back to the JS-default name on a renamed imported child:\n{out}"
+    );
+    // Emission-excluded: the imported system is analysis-visible but never
+    // generated into the importer's output.
+    assert!(
+        !out.contains("class Child"),
+        "imported system must not be emitted into the importer:\n{out}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// Regression for FRAMEC_BUGS #45: an imported file's own `@@[main]` must not
+/// count toward the importer's single-`@@[main]` rule. Both files carry
+/// `@@[main]` (each is its own module's primary); the importer must still
+/// compile — `@@[main]` is a local/module-primary concern, not a cross-file one.
+#[test]
+fn imported_main_attr_does_not_trip_e806() {
+    let dir = scratch("main");
+    fs::write(
+        dir.join("lib.fjs"),
+        r#"@@[main]
+@@system Lib {
+    interface:
+        go()
+    machine:
+        $A { go() { } }
+}
+"#,
+    )
+    .unwrap();
+    let app = r#"import { Lib } from "./lib.machine.js"
+@@import "./lib.fjs"
+@@[main]
+@@system App {
+    interface:
+        run()
+    machine:
+        $S { run() { } }
+    domain:
+        lib: Lib = @@Lib()
+}
+"#;
+    let app_path = dir.join("app.fjs");
+    fs::write(&app_path, app).unwrap();
+
+    let out = compile_module_with_path(app, js(), Some(app_path))
+        .expect("app.fjs should compile — imported @@[main] must not trip E806");
+    // The imported system stays emission-excluded.
+    assert!(
+        !out.contains("class Lib"),
+        "imported system must not be emitted into the importer:\n{out}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// Negative control: without the `@@import`, framec can't see the child's
+/// renamed ops and falls back to the JS default — confirming it's the
+/// `@@import` that supplies the cross-file knowledge.
+#[test]
+fn without_import_falls_back_to_default_name() {
+    let dir = scratch("noimport");
+    let parent = r#"import { Child } from "./child.machine.js"
+@@[main]
+@@[persist(string)]
+@@[save(save_state)]
+@@[load(restore_state)]
+@@system Parent {
+    interface:
+        poke()
+    machine:
+        $Run { poke() { self.child.ping() } }
+    domain:
+        child: Child = @@Child()
+}
+"#;
+    let parent_path = dir.join("parent.fjs");
+    fs::write(&parent_path, parent).unwrap();
+
+    let out = compile_module_with_path(parent, js(), Some(parent_path))
+        .expect("parent.fjs should compile");
+    assert!(
+        out.contains("this.child.saveState()"),
+        "without @@import, the cross-file child uses the JS default name:\n{out}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
Re-introduces `@@import` as an **analysis-only** directive (RFC-0040): framec reads the
referenced Frame source while compiling the importer to resolve and check cross-file
references, but emits nothing for it — native host imports stay Oceans Model pass-through.
Imported systems are analysis-visible but emission-excluded.

Consolidates everything for 4.3.0:
- **#44** composed-child persist names (same-file) — parent calls the child's declared
  `@@[save]`/`@@[load]` name, not the target default.
- **RFC-0040** `@@import` — the same resolution now works cross-file.
- **#45** an imported file's own `@@[main]` no longer trips E806 in the importer.

Gates: 17-backend Docker matrix 0 failures; full fuzz 20/20 phases PASS; Rust suite
(486 + snapshots + 3 new cross-file tests in `tests/rfc0040_import.rs`); clippy `-D warnings`,
fmt, doc-samples clean.

Cross-file argument/type validation (warnings-first phase-in) is a documented RFC-0040
follow-up; it does not yet fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)