### PR TITLE
docs(readme): link to the published docs site (docs.frame-lang.org)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ framec --help
 
 ## Documentation
 
+📖 **Full documentation site: [docs.frame-lang.org](https://docs.frame-lang.org)** — rendered and searchable.
+
+The same documentation is also available as source in this repository:
+
 - [Getting Started](docs/frame_getting_started.md) — learn Frame from scratch
 - [Language Reference](docs/frame_language.md) — complete Frame language reference
 - [Cookbook](docs/frame_cookbook.md) — 111 recipes from traffic lights through EIP patterns, protocol/systems stress tests, deferred event processing, and a scanner/parser pair


### PR DESCRIPTION
Adds a link to the published documentation site (https://docs.frame-lang.org) at the top of the README's **Documentation** section.

The section previously linked only to the in-repo Markdown sources; the rendered, searchable site is now the lead, and the file links are reframed as the in-repo source.

Docs-only change — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)