### PR TITLE
docs(rfcs): exclude RFC-0039 and RFC-0040 from the docs nav

### DIFF
--- a/docs/rfcs/rfc-0039.md
+++ b/docs/rfcs/rfc-0039.md
@@ -1,3 +1,8 @@
+---
+title: "RFC-0039: Parser as composed Frame state machines"
+nav_exclude: true
+---
+
 # RFC-0039: Parser as composed Frame state machines
 
 - **Status:** Accepted — implemented on branch `rfc-0039-parser-fsm` (see [Implementation status](#implementation-status))

--- a/docs/rfcs/rfc-0040.md
+++ b/docs/rfcs/rfc-0040.md
@@ -1,5 +1,6 @@
 ---
 title: "RFC-0040: Analysis-only @@import"
+nav_exclude: true
 ---
 
 # RFC-0040: Re-introduce `@@import` as analysis-only cross-file resolution


### PR DESCRIPTION
RFC-0039 and RFC-0040 were leaking into the docs site's top-level navigation (appearing after **Release Notes**) because they lacked `nav_exclude: true`.

- `rfc-0039.md` had **no frontmatter at all** — add a full block (title + nav_exclude).
- `rfc-0040.md` had a title but **no exclude flag** — add it.

Every other RFC carries `nav_exclude: true`; the section is reached through the RFCs index page (the single `RFCs` nav entry). The live site builds from `main` /docs (classic Pages), so this deploys on merge.

Docs-only — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)