### PR TITLE
docs(releases): 4.3.0 + 4.2.4 release notes + runbook step

### DIFF
--- a/docs/releases/4.2.4.md
+++ b/docs/releases/4.2.4.md
@@ -1,0 +1,35 @@
+---
+title: "v4.2.4"
+parent: Release Notes
+nav_order: 4
+---
+
+# v4.2.4
+
+*Released 2026-05-26 · [GitHub release](https://github.com/frame-lang/framec/releases/tag/v4.2.4) · [CHANGELOG](https://github.com/frame-lang/framec/blob/main/CHANGELOG.md#424---2026-05-26)*
+
+A maintenance release: two codegen fixes, plus a large internal change with no effect on
+generated code. framec's own parser and several scanners are now Frame state machines
+(dogfooding), and the compile pipeline is FSM-driven — every internal refactor was verified
+to produce byte-identical output to 4.2.3 except for the two fixes below.
+
+## Highlights
+
+- **`push$ -> $State` codegen fixed (#42).** Inline push-with-transition emitted a call to a
+  non-existent `_transition()` on Python, GDScript, JavaScript, and TypeScript, and the W414
+  reachability check ignored the edge. It now lowers through the compartment model like every
+  other transition, and reachability counts it.
+- **Multi-line `domain:` default literals fixed (#41).** A dict or array default that spanned
+  multiple physical lines was split at the first newline into stray field declarations; it is
+  now captured whole.
+- **The parser is now a Frame state machine (RFC-0039 — Parser as composed Frame state
+  machines).** A `SystemBackbone` Frame system owns and drives parsing, calling the
+  recursive-descent `parse_*` methods as native oracles. framec's own front-end grammar is now
+  expressed in Frame. *No change to generated code.*
+- **The compile pipeline and several scanners are FSM-driven (RFC-0035).** `compile_ast_based`
+  is sequenced by a pipeline FSM (one state per phase), and the `domain:` line scanner, the
+  assembler's call-site lexer, the transition-metadata parser, and the Erlang paren-balance
+  scanner are now Frame FSMs. *No change to generated code.*
+
+Every internal refactor was checked against the code it replaced with the full 17-backend
+matrix and the structural fuzz corpus, both green.

--- a/docs/releases/4.3.0.md
+++ b/docs/releases/4.3.0.md
@@ -1,0 +1,40 @@
+---
+title: "v4.3.0"
+parent: Release Notes
+nav_order: 5
+---
+
+# v4.3.0
+
+*Released 2026-05-27 · [GitHub release](https://github.com/frame-lang/framec/releases/tag/v4.3.0) · [CHANGELOG](https://github.com/frame-lang/framec/blob/main/CHANGELOG.md#430---2026-05-27)*
+
+Brings back the `@@import` directive — removed in 4.2.0 — in a strictly narrower,
+**analysis-only** form, and fixes a composed-child persist-naming bug in both its
+same-file and cross-file forms. Sources that don't use `@@import` generate
+byte-identical output to 4.2.x, so upgrading is safe by default.
+
+## Highlights
+
+- **`@@import "<path>"` returns as an analysis-only directive (RFC-0040 — Re-introduce
+  `@@import` as analysis-only cross-file resolution).** framec reads the referenced
+  Frame source *while compiling the current file* to resolve and check cross-file
+  references, but emits **nothing** for it — no import line and no target code for the
+  imported system. It changes what framec *knows*, never what it *writes*; native host
+  imports remain your own pass-through. This deliberately keeps the emission removal from
+  RFC-0024 while restoring the cross-file analysis that removal had also cost.
+- **Composed-child persist names now resolve — same file (#44).** When a parent composes
+  a child (`domain: child = @@Child()`) and the child renamed its persist ops with
+  `@@[save(name)]` / `@@[load(name)]`, the parent's `save_state` / `restore_state` called
+  the child by the hardcoded target-default name — a runtime `TypeError` that was silent at
+  compile time. The parent now calls the child's *declared* names across all 14 persist
+  backends.
+- **…and across files.** With `@@import`, that same resolution works when the child lives
+  in another file: the parent reads the imported source and calls the child's declared
+  names instead of the default.
+- **Imported `@@[main]` no longer trips E806 (#45).** Importing a Frame source whose primary
+  system carries `@@[main]` no longer fails the importer's single-`@@[main]` check — that
+  rule is correctly scoped to *locally declared* systems.
+
+> Cross-file *argument/type* validation (surfacing imported-call signature mismatches) is a
+> planned RFC-0040 follow-up and does not fire yet — `@@import` currently resolves names and
+> existence, not call shapes.

--- a/docs/rfcs/rfc-0031.md
+++ b/docs/rfcs/rfc-0031.md
@@ -161,10 +161,20 @@ Once the RC bar (Layer 1) is clean and CI (Layer 2) is green:
    raw git log dump. Each entry has: features, fixes,
    breaking-changes, deprecations. Reference RFCs / roadmap
    tasks by number.
-4. **Announce**: when a release page is up on GitHub, link it
+4. **Release notes page**: add `docs/releases/X.Y.Z.md` per the
+   [release-notes style guide](../releases/style-guide.md) — a
+   skimmable, *why-focused* summary (Highlights, plus Breaking
+   changes / Action required when relevant), one page per
+   published release. The section auto-orders newest-first
+   (`child_nav_order: reversed`), so no renumbering is needed.
+   This is the docs-site **Release Notes** section, served from
+   `main` /docs. Also replace the auto-generated GitHub release
+   body (a bare PR-title list) with the same summary so both read
+   well. Skip RC tags and formatting-only point releases.
+5. **Announce**: when a release page is up on GitHub, link it
    from any user-facing channel (org README's release-callout
    section, project-status page, etc.).
-5. **Monitor for 24 hours**: watch GitHub issues + any
+6. **Monitor for 24 hours**: watch GitHub issues + any
    user-facing channels for regression reports. If one lands,
    triage immediately — don't let it sit until "next release."
 


### PR DESCRIPTION
The docs-site **Release Notes** section had no pages for **4.2.4** or **4.3.0** — the step was never in the release runbook, so it got skipped.

- Adds `docs/releases/4.3.0.md` (RFC-0040 analysis-only `@@import` + composed-child persist fixes #44/#45) and `docs/releases/4.2.4.md` (codegen fixes #41/#42 + the RFC-0039/RFC-0035 dogfooding refactor), per the [release-notes style guide](https://github.com/frame-lang/framec/blob/main/docs/releases/style-guide.md).
- Adds a **"Release notes page"** step to **RFC-0031** Layer 3 (release sequence) so future releases always get a notes page + an enriched GitHub release body.

Docs-only — no code touched. Section auto-orders newest-first, no renumbering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)