### PR TITLE
docs: discoverability, versioning, Python concurrency & testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,20 @@ The same documentation is also available as source in this repository:
 - [Language Reference](docs/frame_language.md) — complete Frame language reference
 - [Cookbook](docs/frame_cookbook.md) — 111 recipes from traffic lights through EIP patterns, protocol/systems stress tests, deferred event processing, and a scanner/parser pair
 - [Runtime Architecture](docs/frame_runtime.md) — how generated code works
+- [Per-Language Guides](docs/per_language_guides/) — target-specific idioms and gotchas (Python, TypeScript, Rust, Java, …)
+- [Agents Guide](docs/AGENTS_README.md) — orientation for LLM-assisted editing of Frame code
 - [Framepiler Design](docs/framepiler_design.md) — transpiler internals
 - [Contributing](CONTRIBUTING.md) — build from source, run tests, submit PRs
 - [Changelog](CHANGELOG.md) — release history
+
+## Versioning
+
+Frame has two version numbers that move on different schedules:
+
+- **framec semver** (e.g. `4.3.0`) tracks the compiler release line. Patch and minor releases are bug-fix and additive — existing `.fpy` / `.frs` / `.fts` sources continue to compile. Major bumps may require source changes; migration notes ship in [`docs/releases/`](docs/releases/).
+- **Grammar version** (e.g. `v0.30`) tracks the Frame language specification itself, and moves much more slowly than the compiler.
+
+Generated code is de facto byte-stable across patch and minor releases of `framec` for sources that don't use changed features. Each release's `CHANGELOG.md` entry calls out specifically where output differs from the previous version. See [Versioning & Stability](docs/frame_language.md#versioning--stability) in the language reference for the full contract.
 
 ## License
 

--- a/docs/frame_language.md
+++ b/docs/frame_language.md
@@ -27,6 +27,7 @@ Complete reference for the Frame language. For a tutorial introduction, see [Get
 - [Persistence](#persistence)
 - [Async](#async)
 - [System Instantiation](#system-instantiation)
+- [Versioning & Stability](#versioning--stability)
 - [Token Summary](#token-summary)
 - [Error Codes](#error-codes)
 - [Complete Example](#complete-example)
@@ -1039,6 +1040,46 @@ The framepiler validates at the assembler stage:
 - No duplicate named args.
 - No mixing positional and named within a single call.
 - State and enter args have matching declarations on the start state's `$Start(name: type)` and `$>(name: type)` handlers.
+
+---
+
+## Versioning & Stability
+
+Frame has two version numbers that move on different schedules.
+
+| Number | What it tracks | Example |
+|---|---|---|
+| **framec semver** | The compiler release line. Bumps signal CLI/codegen changes. | `4.3.0` |
+| **Grammar version** | The Frame language specification itself. Moves much more slowly. | `v0.30` |
+
+The compiler version on its own does not tell you the language version, and vice versa. A patch release of framec almost never changes the grammar; a grammar bump only happens when the language surface changes (new syntax, removed syntax, semantics change).
+
+### Source compatibility (what `4.x` means for your `.fpy` files)
+
+`framec` follows semver for **source-level** compatibility of `.fpy` / `.frs` / `.fts` / etc. files:
+
+- **Major** (`4.x` → `5.x`) may require source changes — a grammar version bump usually rides with it. Migration notes ship in `docs/releases/<version>-migration.md`.
+- **Minor** (`4.2` → `4.3`) is additive. Existing valid sources continue to compile.
+- **Patch** (`4.2.3` → `4.2.4`) is bug-fix only. No source changes required.
+
+### Generated code stability (will codegen churn on upgrade?)
+
+Frame does **not** offer a formal byte-stability contract across versions, but in practice patch and minor releases are de facto byte-stable for sources that don't use changed features. Each release's CHANGELOG entry calls out the specific cases where output differs from the previous release.
+
+For example, the `4.2.4` entry states:
+
+> Output for files without `@@import` is byte-identical to `4.2.3` except for the two fixes below.
+
+**Practical advice:**
+
+- Treat the CHANGELOG as the authoritative diff between releases. If your repo pins `framec` and commits generated code, a CHANGELOG read is enough to know whether `git diff` after `cargo install framec` is expected.
+- Pin `framec` in CI for reproducible builds. Bump intentionally.
+- The `--debug-output` and `--emit-debug` JSON sidecars (source maps, frame-maps, visitor-maps) are not currently positioned as a stable public schema — useful for tooling but expect churn between minor versions.
+
+### Where to look
+
+- `CHANGELOG.md` — per-release notes, including codegen-affecting changes.
+- `docs/releases/` — long-form release notes and migration guides.
 
 ---
 

--- a/docs/per_language_guides/python.md
+++ b/docs/per_language_guides/python.md
@@ -121,6 +121,85 @@ Python async is mature:
 
 ---
 
+## Concurrency and re-entrancy
+
+Frame does **not** manage concurrency. The Python runtime is
+single-threaded by design — the context stack, compartment, and
+state-variable storage on a system instance are **not** guarded
+by locks or atomics. The intended deployment model is:
+
+> **One system instance per session, driven by a single sequential
+> driver.**
+
+For an automation pipeline, a long-running daemon, or a background
+worker, that typically means one `asyncio` task or one Python
+thread owns each `@@Counter()` instance and serializes events
+through it.
+
+### What's safe
+
+- **Sequential event dispatch on one instance.** Call `s.event_a()`,
+  let it return, call `s.event_b()`. This is the normal usage.
+- **`@@:self.method()` from inside a handler.** Frame's context
+  stack handles re-entry on the same instance — the inner call
+  runs to completion before control returns to the outer handler.
+  Cookbook recipes covering self-call (e.g. transitions triggered
+  from a handler body) rely on this.
+- **Independent instances on independent driver tasks.** Two
+  `Counter()` instances driven by two `asyncio` tasks do not
+  contend.
+
+### What's not safe (without external serialization)
+
+- **External re-entry during `await`.** If interface method `A` is
+  an `async` method and is currently suspended on
+  `await self.cache.get(...)`, calling interface method `B` on the
+  *same* instance from another `asyncio` task will execute `B`
+  against a partially-progressed context stack. The runtime does
+  not detect this.
+- **Multi-threaded access to one instance.** Frame's generated
+  Python code has no `threading.Lock` around dispatch. Two OS
+  threads calling methods on the same instance race on the
+  compartment and state vars.
+
+### Pattern: serialize external events
+
+If your driver has multiple sources that can fire events into the
+same instance (HTTP handlers, scheduler ticks, signal handlers),
+put a per-instance `asyncio.Queue` (or `queue.Queue` for threaded
+drivers) in front of the system and drain it from a single
+consumer task:
+
+```python
+import asyncio
+
+async def driver(system, inbox: asyncio.Queue):
+    while True:
+        event, args = await inbox.get()
+        await getattr(system, event)(*args)
+        inbox.task_done()
+
+system = Counter()
+inbox = asyncio.Queue()
+asyncio.create_task(driver(system, inbox))
+
+# Producers (handlers, schedulers, sockets) only enqueue.
+await inbox.put(("bump", ()))
+```
+
+This keeps the "one driver per instance" invariant while letting
+many producers fire events.
+
+### Persistence under concurrency
+
+`save_state()` requires the system to be **quiescent** — no event
+in flight, `_context_stack` empty. Calling it from inside a
+handler raises `RuntimeError("E700: system not quiescent")`. In a
+queued-driver design, save between drains (after `inbox.get()`
+returns and before the next event runs) or with the driver paused.
+
+---
+
 ## Cross-system fields: direct instantiation
 
 `var counter: Counter = @@Counter()` lowers to an instance
@@ -271,6 +350,63 @@ Python on `restore_state()`.
 JSON-based persist that closes this hole; it's deferred pending
 customer feedback. See `docs/rfcs/rfc-0012.md` "Python: switch
 from pickle to JSON-based persist."
+
+---
+
+## Testing a Frame system
+
+Frame's canonical test pattern is **white-box assertion through
+operations**, documented in detail as
+[Cookbook Recipe 32 — Test Harness](../frame_cookbook.md#32-test-harness--white-box-testing-with-operations).
+The shape:
+
+1. Read state via `@@:system.state` inside an operation. It returns
+   the current state name as a string (no `$` prefix) and is
+   read-only — assignment is a parse error.
+2. Expose any state-variable values you need to assert on through
+   additional operations (operations don't dispatch events, so
+   they're safe inspection points).
+3. Drive the system through events in your `pytest` / `unittest`
+   driver and assert against those operations.
+
+```frame
+@@system Counter {
+    interface:
+        tick()
+    machine:
+        $Idle {
+            tick() { $.ticks = $.ticks + 1; -> $Running }
+        }
+        $Running {
+            tick() { $.ticks = $.ticks + 1 }
+
+            $.ticks: int = 0
+        }
+    operations:
+        current_state(): str { @@:(@@:system.state) }
+        tick_count(): int    { @@:($.ticks) }
+}
+```
+
+```python
+def test_counter_advances_to_running():
+    c = Counter()
+    assert c.current_state() == "Idle"
+    c.tick()
+    assert c.current_state() == "Running"
+    assert c.tick_count() == 1
+```
+
+For deeper introspection (compartment, state stack), generated
+Python exposes `obj._compartment.state`,
+`obj._compartment.state_vars`, etc. These are not part of the
+documented stable surface — operations are the supported route.
+
+**Per-event tracing / mocking actions:** Frame does not currently
+provide a built-in transition-trace callback or action-stub mode.
+If you need to suppress side effects in unit tests today, write
+thin actions that delegate to injectable callables and replace
+them in the test fixture.
 
 ---
 


### PR DESCRIPTION
## Summary

Driven by pilot-user feedback (Python automation pipeline):

- **README**: link `AGENTS_README.md` and `per_language_guides/` from the Documentation block; add a Versioning section explaining framec semver vs grammar version and de facto codegen byte-stability across patch/minor releases.
- **frame_language.md**: new *Versioning & Stability* section formalizing source-compat semver and the CHANGELOG-as-diff contract.
- **per_language_guides/python.md**: new *Concurrency and re-entrancy* section documenting the single-threaded one-instance-per-driver model, self-call safety, external re-entry hazards under await, and a per-instance `asyncio.Queue` serialization pattern; new *Testing a Frame system* section pointing at Cookbook Recipe 32 with a minimal pytest example and a note on tracing/stubbing gaps.

Closes the cheap items from the user feedback (B2, B3, Q2, Q3, Q4). Wishlist #1 (trace hook), #2 (no-op test mode), and #3 (stable model-export schema) remain RFC-shaped.

## Test plan

- [x] `scripts/validate_doc_samples.py` — all 118 samples pass
- [x] `cargo fmt --check`, `cargo build`, `cargo clippy -- -D warnings` — clean (doc-only change)
- [ ] Render the docs site locally and visually verify the new sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)