### PR TITLE
docs(codegen): document why Rust and Erlang have dedicated pipelines

### DIFF
--- a/docs/codegen_pipeline.md
+++ b/docs/codegen_pipeline.md
@@ -59,12 +59,57 @@ backends/<lang>.rs LanguageBackend::emit  →  source text
 Output file
 ```
 
-**Erlang** follows a parallel path through `erlang_system.rs` because
-the gen_statem callback model does not match the class-based primitive
-set.
+### Why two backends have dedicated pipelines
 
-**Rust** uses Rust-specific helpers in `rust_system.rs` for kernel
-signature and borrow-checker workarounds (see RFC-0020 §Exceptions).
+Of the seventeen targets framec supports, fifteen go through
+`generate_system_shared()` in `system_codegen.rs`. Two — Rust and
+Erlang — branch into dedicated pipelines (`rust_system.rs` and
+`erlang_system.rs`) at the first line of `generate_system()`. The split
+exists because both targets diverge from the class-based-with-runtime-
+type-erasure assumption that the shared pipeline encodes. The reasons
+are structural, not stylistic:
+
+**Erlang — actor model, not a class.** OTP's `gen_statem` behaviour
+isn't a class with methods and fields; it's a state callback module
+plus a process record. Externally, callers send messages via
+`gen_statem:call/2` (the process mailbox serializes them by
+construction); internally, the `frame_dispatch__/3` helper does
+direct function calls without messaging. The "class" abstraction the
+shared pipeline emits has no analogue in Erlang, so `erlang_system.rs`
+emits raw Erlang source text rather than `CodegenNode` trees.
+
+**Rust — three independent reasons.** Rust's pipeline diverges because
+the language's compile-time guarantees don't allow the shared
+pipeline's GC-friendly assumptions:
+
+1. **Compartment ownership.** Without GC, shared mutable state requires
+   explicit `Rc<RefCell<T>>` (single-threaded) or `Arc<Mutex<T>>`
+   (multi-threaded). The shared pipeline emits the compartment as a
+   plain instance field; Rust must wrap it in a refcounted cell. This
+   threads through every field, every constructor, every method that
+   reads or mutates state.
+2. **Typed per-state `Context`.** The shared pipeline uses a single
+   type-erased compartment shape — dicts in Python, `Map<String,
+   Object>` in Java, `BTreeMap<String, Self>` in Lua. Rust insists on
+   type safety, so framec emits *one `Context` struct per state*, each
+   typed against that state's actual params + lifecycle params. See
+   [RFC-0025.1](rfcs/rfc-0025-1.md) for the full design. There isn't
+   "a compartment" in Rust; there are N of them per system.
+3. **`Rc<FrameEvent>` for `FrameContext.event`.** Storing
+   `FrameEvent` by value would make passing a `&FrameEvent` borrowed
+   from inside `self` to a `&mut self` method fail the borrow checker.
+   The Rust pipeline emits the event as `Rc<FrameEvent>` and threads
+   `Rc::clone` through the dispatch chain. See
+   [RFC-0020 § Exceptions: Rust](rfcs/rfc-0020.md#rust---rcframeevent-for-framecontextevent).
+
+The practical consequence for anyone implementing a cross-cutting
+codegen change (e.g. RFC-0043's layered async architecture, future
+trace-hook RFCs, the eventual `@@[serialize_events]` opt-in) is that
+the change has to be applied *twice*: once in the shared pipeline
+(covers 14 of the 15 async-capable backends including Java's
+sync-internals-async-boundary pattern) and once in `rust_system.rs`
+for Rust. Erlang typically receives a no-op for these changes because
+its actor model already provides the guarantee in a different form.
 
 ## Module map
 

--- a/framec/src/frame_c/compiler/codegen/erlang_system.rs
+++ b/framec/src/frame_c/compiler/codegen/erlang_system.rs
@@ -4,6 +4,25 @@
 //! It bypasses the standard class-based CodegenNode pipeline entirely, producing
 //! raw Erlang source text with proper gen_statem callbacks, -record(data, {}),
 //! and Frame infrastructure (frame_transition__, frame_dispatch__, etc.).
+//!
+//! # Why Erlang has its own pipeline
+//!
+//! The class-based primitive set the shared pipeline encodes has no
+//! analogue in Erlang. OTP's `gen_statem` is an actor with a state
+//! callback module and a process record, not an object with methods
+//! and fields. Externally, callers send messages via `gen_statem:call/2`
+//! which the process mailbox serializes by construction. Internally,
+//! the `frame_dispatch__/3` helper calls dispatch directly without
+//! messaging — this is the natural "internal vs external" split that
+//! the class-based pipeline has to reconstruct explicitly via the
+//! system/machine layering of RFC-0043.
+//!
+//! Cross-cutting codegen changes that target the class-based pipeline
+//! (RFC-0043 layered async, future trace hooks, future
+//! `@@[serialize_events]`) typically receive a no-op here because OTP
+//! already provides the equivalent guarantee in actor form. The
+//! validator may still emit warnings target-agnostically; this module
+//! ignores codegen attributes that have no Erlang manifestation.
 
 mod actions_ops;
 mod blocks;

--- a/framec/src/frame_c/compiler/codegen/rust_system.rs
+++ b/framec/src/frame_c/compiler/codegen/rust_system.rs
@@ -7,6 +7,32 @@
 //!
 //! `backends/rust.rs` handles the lower-level `CodegenNode → String`
 //! rendering and is not modified by this module.
+//!
+//! # Why Rust has its own pipeline
+//!
+//! Fifteen of seventeen targets go through
+//! `system_codegen::generate_system_shared`. Rust does not, for
+//! three independent reasons:
+//!
+//! 1. **`Rc<RefCell<Compartment>>` ownership.** Without GC, shared
+//!    mutable state requires explicit refcounted cells; the shared
+//!    pipeline emits the compartment as a plain instance field.
+//! 2. **Typed per-state `Context`.** The shared pipeline uses one
+//!    type-erased compartment shape per system. Rust emits N typed
+//!    `Context` structs, one per state, each carrying that state's
+//!    actual params + lifecycle params in their declared Rust types.
+//!    See RFC-0025.1 (`docs/rfcs/rfc-0025-1.md`) and
+//!    `rust_ctx_param_fields` below.
+//! 3. **`Rc<FrameEvent>` for `FrameContext.event`.** The borrow
+//!    checker rejects passing a `&FrameEvent` borrowed from inside
+//!    `self` to a `&mut self` method; the Rust runtime stores the
+//!    event by `Rc` and threads `Rc::clone` through dispatch.
+//!    See RFC-0020 § "Exceptions: Rust" (`docs/rfcs/rfc-0020.md`).
+//!
+//! Cross-cutting codegen changes (e.g. RFC-0043's layered async
+//! architecture) must be applied here in addition to the shared
+//! pipeline. The work is comparable in size to the shared-pipeline
+//! change, not a smaller patch.
 
 mod persistence;
 

--- a/framec/src/frame_c/compiler/codegen/system_codegen.rs
+++ b/framec/src/frame_c/compiler/codegen/system_codegen.rs
@@ -69,11 +69,32 @@ pub fn generate_system(
     lang: TargetLanguage,
     source: &[u8],
 ) -> CodegenNode {
-    // Erlang: gen_statem native — completely different codegen path
+    // Erlang and Rust have dedicated pipelines because their structural
+    // model diverges from the class-based-with-runtime-type-erasure
+    // assumption the shared pipeline encodes. See
+    // `docs/codegen_pipeline.md` § "Why two backends have dedicated
+    // pipelines" for the full rationale.
+    //
+    // Practical consequence for cross-cutting codegen changes
+    // (RFC-0043 layered async, future trace hooks, etc.): the change
+    // is applied in `generate_system_shared` for 15 backends and in
+    // `rust_system::generate_rust_system` for Rust separately. Erlang
+    // typically receives a no-op because gen_statem already provides
+    // the guarantee in actor form.
+
+    // Erlang: gen_statem actor model — emits raw Erlang source, not a
+    // CodegenNode tree. The class-based primitive set has no analogue
+    // here (callers use `gen_statem:call/2` through the process
+    // mailbox; internal dispatch is direct `frame_dispatch__/3`).
     if lang == TargetLanguage::Erlang {
         return super::erlang_system::generate_erlang_system(system, arcanum, source);
     }
-    // Rust: dedicated codegen with Rc<RefCell<Compartment>> ownership
+    // Rust: diverges for three independent reasons —
+    //   1. `Rc<RefCell<Compartment>>` ownership (no GC).
+    //   2. Typed per-state `Context` structs (RFC-0025.1) instead of
+    //      a single type-erased compartment.
+    //   3. `Rc<FrameEvent>` to satisfy the borrow checker on event
+    //      passthrough (RFC-0020 § Exceptions: Rust).
     if lang == TargetLanguage::Rust {
         return super::rust_system::generate_rust_system(system, arcanum, source);
     }


### PR DESCRIPTION
## Summary

The shared codegen pipeline (`system_codegen::generate_system_shared`) handles 15 of 17 targets. Rust and Erlang branch into dedicated pipelines (`rust_system.rs` and `erlang_system.rs`) at the first line of `generate_system()`. Until now the rationale for the split was implicit — a one-line comment per dispatch arm. This commit makes the structural reasons legible in four places that anyone implementing a cross-cutting codegen change will encounter:

- **`docs/codegen_pipeline.md`** grows a *Why two backends have dedicated pipelines* subsection. Names the three Rust reasons (`Rc<RefCell<>>` ownership; RFC-0025.1 typed per-state `Context`; RFC-0020 `Rc<FrameEvent>` for the borrow checker) and the Erlang reason (gen_statem actor model, no class analogue).
- **`system_codegen.rs::generate_system()`** — expanded comment at the dispatch site spells out the consequence for cross-cutting changes: apply once in the shared pipeline, once in `rust_system.rs` for Rust; Erlang typically receives a no-op because the actor model already provides the equivalent guarantee.
- **`rust_system.rs`** `//!` header — adds a *Why Rust has its own pipeline* block citing all three reasons with cross-references to the relevant RFCs.
- **`erlang_system.rs`** `//!` header — adds the analogous block explaining the actor model's role and the no-op-for-class-based-attributes convention.

No functional change; comment-only. The motivation for this commit emerged while planning RFC-0043 (which needs the layered async architecture applied in both pipelines), but the documentation is independent of RFC-0043 and useful regardless.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `scripts/validate_doc_samples.py` — 118/118 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)