### PR TITLE
docs(rfc-0043): async system architecture — single-driver gate (Draft)

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -277,6 +277,25 @@ fields, [compartment](#compartment), and [state stack](#state-stack) (and any
 nested `@@system` domain fields). Named with `@@[save(<name>)]`. See
 [language reference § Persistence](frame_language.md#persistence).
 
+### single-driver contract
+
+The rule that a [system](#system) instance has at most one external
+[interface](#interface) call in flight at any time. The caller — the host
+code holding the instance — is responsible for serializing its events. Frame
+provides no concurrency primitives, no locking, no event queue. Internal flow
+(`@@:self`, [forward](#forward), lifecycle cascades, async [await](#dispatch)
+suspension) is not subject to this rule. Enforced at runtime by the
+[single-driver gate](#single-driver-gate). See [RFC-0043](rfcs/rfc-0043.md).
+
+### single-driver gate
+
+The runtime mechanism that detects violations of the
+[single-driver contract](#single-driver-contract). Implemented as a per-instance
+busy flag set on entry to a public [interface](#interface) method and cleared
+on return; internal call paths bypass the flag, so re-entry from inside Frame's
+own machinery is unaffected. A violation raises `E703`. See
+[RFC-0043](rfcs/rfc-0043.md).
+
 ### start state
 
 The first [state](#state) declared in a [system](#system)'s `machine:` block —

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -32,10 +32,19 @@ read domain variables and the system / self / return accessors but cannot fire
 
 ### async system
 
-A [system](#system) whose [interface](#interface) methods are generated as the
-host language's asynchronous form (`async`/`await`, `CompletableFuture`,
-`Future`, …) while its internal [dispatch](#dispatch) stays synchronous. Enabled
-by an `async` modifier on interface methods. See
+A [system](#system) declared with the `@@[async]` system-header attribute.
+framec emits an async system as a layered pair: a public system object
+exposing the declared [interface](#interface) and [operations](#operation),
+holding a private inner [machine](#machine) that owns the
+[dispatch](#dispatch) path. The system layer is the natural home for the
+[single-driver gate](#single-driver-gate) (`E703`) and for future
+cross-cutting concerns (instrumentation, optional serialization). Interface
+methods are generated in the host language's asynchronous form
+(`async`/`await`, `CompletableFuture`, `Future`, …). On Erlang the
+`gen_statem` actor model already provides single-driver semantics; the
+layered shape is not emitted there. Async members in a system without
+`@@[async]` are an `E710` validator error (with a one-release `W710`
+grace period). See [RFC-0043](rfcs/rfc-0043.md) and
 [language reference § Async](frame_language.md#async).
 
 ### backbone
@@ -187,6 +196,13 @@ A [system](#system)'s state machine, declared in the `machine:` block: its
 [transitions](#transition) between them. See
 [language reference § Machine Section](frame_language.md#machine-section).
 
+In an [async system](#async-system) the term also refers to the *generated*
+inner artifact that owns the [dispatch](#dispatch) path —
+[kernel](#dispatch), [compartment](#compartment), [context stack](#frame-context),
+transition loop, lifecycle cascades — held privately by the outer system
+object and unreachable from outside it. See
+[RFC-0043](rfcs/rfc-0043.md).
+
 ### no-initialization
 
 Allocating a [system](#system) instance *without* running any
@@ -279,22 +295,27 @@ nested `@@system` domain fields). Named with `@@[save(<name>)]`. See
 
 ### single-driver contract
 
-The rule that a [system](#system) instance has at most one external
-[interface](#interface) call in flight at any time. The caller — the host
-code holding the instance — is responsible for serializing its events. Frame
-provides no concurrency primitives, no locking, no event queue. Internal flow
-(`@@:self`, [forward](#forward), lifecycle cascades, async [await](#dispatch)
-suspension) is not subject to this rule. Enforced at runtime by the
-[single-driver gate](#single-driver-gate). See [RFC-0043](rfcs/rfc-0043.md).
+The rule that an [async system](#async-system) instance has at most one
+external [interface](#interface) call in flight at any time. The caller —
+the host code holding the instance — is responsible for serializing its
+events. Frame provides no concurrency primitives, no locking, no event
+queue. Internal flow (`@@:self`, [forward](#forward), lifecycle cascades,
+async [await](#dispatch) suspension) is not subject to this rule because
+it never crosses out of the inner [machine](#machine). Sync systems are
+subject to the same single-driver discipline they have always been —
+the host's own call-return order — and the gate is not emitted for them.
+Enforced at runtime by the [single-driver gate](#single-driver-gate). See
+[RFC-0043](rfcs/rfc-0043.md).
 
 ### single-driver gate
 
 The runtime mechanism that detects violations of the
-[single-driver contract](#single-driver-contract). Implemented as a per-instance
-busy flag set on entry to a public [interface](#interface) method and cleared
-on return; internal call paths bypass the flag, so re-entry from inside Frame's
-own machinery is unaffected. A violation raises `E703`. See
-[RFC-0043](rfcs/rfc-0043.md).
+[single-driver contract](#single-driver-contract). Emitted on the system
+layer of every [async system](#async-system) as a per-instance busy flag,
+set on entry to a public [interface](#interface) method and cleared on
+return in a `try`/`finally` equivalent. Internal dispatch lives in the
+inner [machine](#machine) and never touches the flag. A violation raises
+`E703`. See [RFC-0043](rfcs/rfc-0043.md).
 
 ### start state
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -44,9 +44,11 @@ methods are generated in the host language's asynchronous form
 (`async`/`await`, `CompletableFuture`, `Future`, …). On Erlang the
 `gen_statem` actor model already provides single-driver semantics; the
 layered shape is not emitted there. Async members in a system without
-`@@[async]` are an `E710` validator error (with a one-release `W710`
-grace period). See [RFC-0043](rfcs/rfc-0043.md) and
-[language reference § Async](frame_language.md#async).
+`@@[async]` are an `E720` validator error from the implementing
+release — hard cut, no grace period; the codemod
+`framec project --add-async-attr` (CLI) and `migrate_async_attr` (WASM)
+mechanically insert the attribute. See [RFC-0043](rfcs/rfc-0043.md)
+and [language reference § Async](frame_language.md#async).
 
 ### backbone
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -33,10 +33,11 @@ read domain variables and the system / self / return accessors but cannot fire
 ### async system
 
 A [system](#system) declared with the `@@[async]` system-header attribute.
-framec emits an async system as a layered pair: a public system object
+framec emits an async system as a layered pair — a public [casing](#casing)
 exposing the declared [interface](#interface) and [operations](#operation),
 holding a private inner [machine](#machine) that owns the
-[dispatch](#dispatch) path. The system layer is the natural home for the
+[dispatch](#dispatch) path (the watchmaker's metaphor: a case houses the
+movement). The casing is the natural home for the
 [single-driver gate](#single-driver-gate) (`E703`) and for future
 cross-cutting concerns (instrumentation, optional serialization). Interface
 methods are generated in the host language's asynchronous form
@@ -56,6 +57,21 @@ to [oracles](#oracle). Named for being the structural spine the specialists
 attach to. framec's own parser is organized this way — one `SystemBackbone`
 system whose flat self-looping states cover the entire token-level outer grammar.
 See [RFC-0039](rfcs/rfc-0039.md#terminology).
+
+### casing
+
+The public outer artifact framec emits for an [async system](#async-system).
+Bears the user-declared name (e.g. `Counter`); is what users instantiate,
+what [domain](#domain) fields hold, and what other systems' handlers call.
+Exposes the declared [interface](#interface) and [operations](#operation) as
+the externally visible API; holds a private inner [machine](#machine) and
+delegates to it through the [single-driver gate](#single-driver-gate).
+Named for the watchmaker's metaphor: a watch case houses the movement,
+presents the readable face, and routes inputs (crown turns, button
+presses) to the movement. The casing is also where future cross-cutting
+concerns (trace hooks, instrumentation, optional serialization) will be
+mounted. Only emitted for systems carrying `@@[async]`; sync systems are
+single artifacts. See [RFC-0043](rfcs/rfc-0043.md).
 
 ### compartment
 
@@ -199,8 +215,8 @@ A [system](#system)'s state machine, declared in the `machine:` block: its
 In an [async system](#async-system) the term also refers to the *generated*
 inner artifact that owns the [dispatch](#dispatch) path —
 [kernel](#dispatch), [compartment](#compartment), [context stack](#frame-context),
-transition loop, lifecycle cascades — held privately by the outer system
-object and unreachable from outside it. See
+transition loop, lifecycle cascades — held privately by the
+[casing](#casing) and unreachable from outside it. See
 [RFC-0043](rfcs/rfc-0043.md).
 
 ### no-initialization
@@ -310,12 +326,12 @@ Enforced at runtime by the [single-driver gate](#single-driver-gate). See
 ### single-driver gate
 
 The runtime mechanism that detects violations of the
-[single-driver contract](#single-driver-contract). Emitted on the system
-layer of every [async system](#async-system) as a per-instance busy flag,
-set on entry to a public [interface](#interface) method and cleared on
-return in a `try`/`finally` equivalent. Internal dispatch lives in the
-inner [machine](#machine) and never touches the flag. A violation raises
-`E703`. See [RFC-0043](rfcs/rfc-0043.md).
+[single-driver contract](#single-driver-contract). Emitted on the
+[casing](#casing) of every [async system](#async-system) as a
+per-instance busy flag, set on entry to a public [interface](#interface)
+method and cleared on return in a `try`/`finally` equivalent. Internal
+dispatch lives in the inner [machine](#machine) and never touches the
+flag. A violation raises `E703`. See [RFC-0043](rfcs/rfc-0043.md).
 
 ### start state
 

--- a/docs/rfcs/rfc-0043.md
+++ b/docs/rfcs/rfc-0043.md
@@ -1,9 +1,9 @@
 ---
-title: "RFC-0043 — Single-driver gate: detecting concurrent external dispatch"
+title: "RFC-0043 — Async systems: layered codegen with single-driver gate"
 nav_exclude: true
 ---
 
-# RFC-0043 — Single-driver gate: detecting concurrent external dispatch
+# RFC-0043 — Async systems: layered codegen with single-driver gate
 
 - **Status:** Draft
 - **Author:** Mark Truluck <mark@frame-lang.org>
@@ -15,17 +15,20 @@ this document are to be interpreted as described in RFC 2119.
 
 ## Summary
 
-Frame's runtime has always assumed that an instance of a [system](../glossary.md#system)
-is driven by one logical caller at a time — internal flow (transitions,
-lifecycle cascades, forwarded events, `@@:self` re-entry) is Frame's
-responsibility, but the **outside** of the instance is the user's. That
-assumption has never been written down and has never been enforced. This RFC
-makes it normative — the *single-driver contract* — and adds a one-bit runtime
-check that detects violations at the moment they occur and raises `E703` rather
-than letting them corrupt state silently. The mechanism is a busy flag set on
-entry to each public [interface](../glossary.md#interface) method and cleared
-on return; internal call paths bypass the flag entirely, so re-entry from
-inside Frame's own machinery is unaffected.
+This RFC defines the codegen architecture for **async systems** and makes its
+trigger explicit: the new `@@[async]` system-header attribute. An async system
+is emitted as two layers — a public **system** object holding a private inner
+**machine**. The system layer owns the externally visible interface and
+operations and is the natural home for cross-cutting concerns: the
+single-driver gate introduced here (raises `E703` on concurrent external
+dispatch), and the instrumentation, serialization, and observability hooks
+that later RFCs will attach. The machine is the existing
+[dispatch](../glossary.md#dispatch) core — kernel, [compartment](../glossary.md#compartment),
+[context stack](../glossary.md#frame-context), [transition](../glossary.md#transition)
+loop, lifecycle cascades — held privately by the system and unreachable from
+outside it. **Sync systems are unaffected** by this RFC; the layered
+architecture and the gate are emitted only for systems that carry
+`@@[async]`.
 
 ## Motivation
 
@@ -33,114 +36,193 @@ A Frame instance's correctness depends on its [event handlers](../glossary.md#ev
 running to completion in an ordered sequence. The runtime tracks an in-flight
 event on a per-instance context stack, processes any queued transition after
 the handler returns, runs the exit/enter cascades, and only then becomes
-quiescent again. Self-call (`@@:self.method()`), [forward](../glossary.md#forward)
-(`=> $^`), and async [await](../glossary.md#dispatch) suspension all happen
-*inside* that sequence and are handled correctly.
+quiescent again. Self-call (`@@:self.method()`),
+[forward](../glossary.md#forward) (`=> $^`), and async `await` suspension all
+happen *inside* that sequence and are handled correctly.
 
-What is **not** handled is a second external caller starting a new event on the
-same instance while the first event is still in flight. The most common way
-this happens is async: an interface handler suspends on
+What is **not** handled is a second external caller starting a new event on
+the same instance while the first event is still in flight. The most common
+way this happens is async: an interface handler suspends on
 `await some_io.call()`, control returns to the host runtime's scheduler, and
 another task on the same instance calls a different interface method. The
-runtime cheerfully pushes a second context onto the stack and runs the second
-handler — against the same compartment, the same domain fields, the same
-state-args — that the first handler is still using. Nothing detects this. The
-second event may transition the machine out from under the first; the first
-may overwrite the second's writes when it resumes; the persist quiescent check
-may snapshot an instance with two open contexts. The failure mode is silent
-data corruption discovered hours later.
+runtime cheerfully pushes a second context onto the stack and runs the
+second handler — against the same compartment, the same domain fields, the
+same state-args — that the first handler is still using. Nothing detects
+this. The second event may transition the machine out from under the first;
+the first may overwrite the second's writes when it resumes; the persist
+quiescent check may snapshot an instance with two open contexts. The
+failure mode is silent data corruption discovered hours later.
 
 This is *not* a defect in the runtime, because the runtime never promised to
 support it. The single-driver assumption is the same one a hash map makes
-about concurrent mutation, the same one a Rust `&mut T` makes about aliasing.
-Frame just hasn't said so out loud. The fix is twofold: (1) state the
-contract, and (2) give the runtime the minimum mechanism needed to catch
+about concurrent mutation, the same one a Rust `&mut T` makes about
+aliasing. Frame just hasn't said so out loud. The fix is twofold: (1) state
+the contract, and (2) give the runtime the minimum mechanism needed to catch
 violations *loudly*, in the same spirit as `E700` catches `save_state()`
 called during an in-flight event.
 
-The mechanism must distinguish **external** entry — a caller from outside the
-instance starting a new event — from **internal** entry — Frame's own
-machinery re-routing within an event in flight. Self-call, forward, lifecycle
-dispatch, and the kernel's transition loop are all internal; they must not
-trip the gate. A new external event arriving while the previous is in flight
-is exactly what the gate exists to catch.
+The hazard is specific to async. A purely synchronous system in a
+single-threaded program cannot suffer it — there is no scheduler, no
+suspension point, no window for re-entry. A synchronous system in a
+multithreaded host *can* race, but that is a host-threading problem with
+host-language remedies (`Lock`, `synchronized`, `ReentrantLock`); Frame has
+never promised thread safety for sync systems and this RFC does not change
+that. The architecture proposed here therefore applies only where the hazard
+is real — to async systems, opted in explicitly with the `@@[async]`
+attribute.
+
+Beyond catching the hazard, separating the public surface from the dispatch
+core has a second payoff: it gives Frame a *place to put* the
+instrumentation, observability, and policy hooks that today have nowhere
+clean to live. The system layer becomes the natural home for trace hooks,
+metrics, optional serialization, and rate limiting. The machine remains
+purely about state-machine semantics.
 
 ## The contract
 
+### The `@@[async]` system attribute
+
+A system **MUST** carry the `@@[async]` attribute on its header if and only
+if it declares one or more `async` [interface](../glossary.md#interface),
+[action](../glossary.md#action), or [operation](../glossary.md#operation)
+members. The attribute is the user's explicit statement that this system is
+intended for async dispatch and the layered architecture is to be emitted.
+
+- Async members present without `@@[async]` is **E710** (validator):
+  *async members require `@@[async]` on the system header*.
+- `@@[async]` present without any async members is permitted: the layered
+  architecture and the gate are still emitted (a sync-dispatch system that
+  wants the concurrent-entry guarantee). The dispatch path returns
+  synchronously.
+
+```frame
+@@[async]
+@@system Fetcher {
+    interface:
+        async fetch(key: str): str
+    ...
+}
+```
+
+For one release after this RFC ships, framec **SHOULD** also accept the
+legacy pattern (async members, no `@@[async]`) with warning **W710** —
+*inferred async system; add `@@[async]` to the header* — so existing
+sources have a quiet upgrade path. The accompanying codemod (`framec
+project --add-async-attr`) inserts the attribute mechanically.
+
 ### Single-driver contract
 
-A Frame [system](../glossary.md#system) instance **MUST** have at most one
-external [interface](../glossary.md#interface) call in flight at any time. The
-caller — the host code holding the instance — is responsible for serializing
-its events into the instance. Frame provides no concurrency primitives, no
-locking, no event queue.
+A Frame [system](../glossary.md#system) instance carrying `@@[async]`
+**MUST** have at most one external [interface](../glossary.md#interface) call
+in flight at any time. The caller — the host code holding the instance — is
+responsible for serializing its events into the instance. Frame provides no
+concurrency primitives, no locking, no event queue.
 
 An "external call" is any invocation of a method declared in the system's
 `interface:` section made from outside the instance: from host code, from
-another system instance via a cross-system call, from a test driver, from an
-HTTP request handler. It is the public API of the instance.
+another system instance via a cross-system call, from a test driver, from
+an HTTP request handler. It is the public API of the instance.
 
 An "internal call" is any invocation of an interface method's body that
 Frame's own codegen has emitted as part of dispatching an event already in
 flight on this instance — `@@:self.method()`, default-forward to a parent
-state, the kernel's routing within `__kernel`, and the transition loop's
-invocation of `<$` exit and `$>` enter handlers. Internal calls are not
-subject to the single-driver contract.
+state, the kernel's routing, and the transition loop's invocation of `<$`
+exit and `$>` enter handlers. Internal calls do not cross the system/machine
+boundary; they happen inside the machine and are not subject to this
+contract.
+
+Sync systems (no `@@[async]`) are subject to the same single-driver
+discipline today as they have always been — the host's own call-return
+order — and this RFC adds nothing to or removes nothing from that.
+
+### Layered architecture
+
+framec **MUST** emit an async system as two artifacts:
+
+- A **system** artifact bearing the user-declared name (e.g. `Counter`). This
+  is what users instantiate, what domain fields hold, what other systems'
+  handlers call. It exposes the declared `interface:` and `operations:` as
+  the externally visible API. Each interface method on the system layer:
+  1. Checks the gate (see *Single-driver gate*).
+  2. Sets the gate to busy.
+  3. Delegates to the corresponding method on the machine.
+  4. Clears the gate to free in a host-language construct equivalent to
+     `try`/`finally`.
+  Each operation method on the system layer delegates to the machine
+  without touching the gate (see *Scope of the gate*).
+
+- A **machine** artifact, host-language-private to the system. This is the
+  existing async [dispatch](../glossary.md#dispatch) core — the kernel,
+  [compartment](../glossary.md#compartment), [context stack](../glossary.md#frame-context),
+  state methods, transition loop, lifecycle cascades — emitted exactly as
+  today's `@@system` would emit it. The machine has no gate; it assumes
+  the system layer has already serialized external entry.
+
+The system layer holds the machine as a private member (composition, not
+inheritance). The machine **MUST NOT** be reachable through the system's
+public surface. `@@:self.method()`, default forward, and the kernel's
+routing are emitted inside the machine and call the machine's own methods
+directly; they do not cross back out to the system layer.
+
+Because handler bodies live inside the machine, the codegen does **not**
+need to rewrite `@@:self.method()` to a different symbol — the existing
+lowering to `self.method(...)` resolves to the machine's own method,
+because inside a machine method `self` is the machine. The routing is
+structural; no call-site rewriting is required.
+
+Operations on the system layer may delegate to the machine either as a
+call to a non-dispatching operation method on the machine
+(`return self._machine.<op>()`) or as a direct read of the machine's
+state where the operation reduces to one (`return self._machine._compartment.state`).
+Both satisfy "delegates without touching the gate"; framec emits
+operation-method delegation as the canonical form.
+
+Cross-system calls — `@@OtherSystem(...).method()` and dispatched calls
+through a domain field that holds another system instance — **MUST**
+target the *system* layer of the other system, not its machine. From one
+instance's perspective, a call into a different instance is external, and
+the other instance's gate is the correct guard.
 
 ### Single-driver gate
 
-framec **MUST** generate, on every system, a per-instance busy flag and the
-discipline to maintain it:
+The per-instance busy flag introduced by the system layer **MUST**:
 
-- The flag is initialized to *free* in the [factory](../glossary.md#factory).
-- On entry to a public interface method, the generated code **MUST**:
-  1. Check the flag. If *busy*, raise `E703` (see *Error code*) and return
-     without dispatching.
-  2. Set the flag to *busy*.
-- On return from a public interface method — whether normal, exceptional, or
-  (for [async systems](../glossary.md#async-system)) on completion of the
-  returned future — the generated code **MUST** clear the flag to *free*.
-  This **MUST** happen in a host-language construct equivalent to
-  `try`/`finally` so that a panicking, exception-throwing, or
-  rejected-future handler still releases the flag.
+- Be initialized to *free* in the system's [factory](../glossary.md#factory).
+- Transition to *busy* on entry to any interface method on the system layer,
+  immediately after the check below succeeds.
+- Be checked before transition to busy: if already *busy*, raise `E703`
+  (see *Error code*) and return without dispatching to the machine.
+- Be cleared to *free* on return from the interface method — whether
+  normal, exceptional, or, for [async systems](../glossary.md#async-system),
+  on completion of the returned future. The clear **MUST** happen in a
+  host-language construct that runs on every exit path from the method,
+  including unwinding from a panic, an exception, or a rejected future.
+  Across the eleven async-capable backends:
+    - `try`/`finally` — Python, TypeScript, JavaScript, Java, C#,
+      Kotlin, Dart, GDScript.
+    - **RAII** — Rust (a `Drop`-implementing guard), C++ (a
+      destructor-owning sentinel).
+    - `defer` — Swift (`defer { ... }`).
+
+  The in-flight method name, if tracked per the *Error code* section,
+  is cleared in the same construct.
 
 The check-and-set sequence is atomic with respect to the [single-driver
 contract](#single-driver-contract): under that contract there is at most one
-logical caller, so no other writer to the flag exists. No memory barrier, no
-compare-and-swap, no lock primitive is required. A plain instance attribute
-suffices.
-
-### Split entry points
-
-framec **MUST** emit two symbols for each interface method on async-capable
-backends (Python, TypeScript, JavaScript, Rust, C++, Kotlin, Swift, C#, Java,
-Dart, GDScript) and on sync backends where re-routing is mechanically
-identical (all others except Erlang, which uses gen_statem and is out of
-scope; see *Out of scope*):
-
-- A **public** symbol with the method's declared name. This is the symbol the
-  user sees and the cross-system caller resolves against. Its body performs
-  the gate check, sets the flag, calls the internal symbol, and clears the
-  flag on completion.
-- An **internal** symbol with a host-language-natural visibility modifier and
-  an obviously-internal name (`__<method>` is the recommended convention;
-  see *Naming*). Its body is the dispatch the public symbol used to perform
-  directly. It does not touch the flag.
-
-`@@:self.method()`, default forward, and the kernel's routing **MUST** call
-the internal symbol. The transition loop's invocation of lifecycle handlers
-(`$>`, `<$`) was never on the public surface and is unchanged. Cross-system
-calls (`@@OtherSystem(...).method()`) **MUST** continue to call the public
-symbol of the target system: from one instance's perspective, a call into a
-*different* instance is external.
+logical caller, so no other writer to the flag exists. No memory barrier,
+no compare-and-swap, no lock primitive is required. A plain instance
+attribute on the system layer suffices.
 
 ### Error code
 
-`E703 — system busy: concurrent external dispatch on a single-driver
-instance.` Raised at the public entry point when the flag is already *busy*.
-The error message **SHOULD** name the method that was called and the method
-already in flight (the in-flight method name **MAY** be tracked alongside the
-flag for diagnostic quality).
+`E703 — system busy: concurrent external dispatch on an async instance.`
+Raised at the system layer's interface entry when the flag is already
+*busy*. The error message **SHOULD** name the method that was called and
+the method already in flight. framec **SHOULD** track the in-flight
+method name alongside the flag (e.g. as an `Option<&'static str>` /
+`Optional[str]` field cleared in the same `try`/`finally`) — diagnostic
+quality during debugging is materially worse without it, and a two-state
+flag (`Option<method_name>`) costs the same as a `bool`.
 
 `E703` is a runtime error in the same family as `E700` (persist quiescent)
 and `E701` (corrupted snapshot). It is not a compile-time validation error;
@@ -149,122 +231,159 @@ analysis.
 
 ### Scope of the gate
 
-The gate applies **only** to methods declared in a system's `interface:`
-section. It does **not** apply to:
+The gate applies **only** to interface methods on the system layer. It does
+**not** apply to:
 
-- **Operations.** Operations are declared on the system's public class but
-  bypass dispatch entirely; they exist precisely for inspection without
-  side effects (see [Cookbook Recipe 32](../frame_cookbook.md)). A caller
-  who wants to inspect an instance during an in-flight handler — from a
-  monitoring sidecar, a debugger, a test assertion — does so through an
-  operation, by design. This is an acknowledged backdoor, not a defect.
-- **`save_state()` and `restore_state()`.** These have their own contract
-  (`E700`, see [RFC-0012](rfc-0012.md)) that is strictly stronger than
-  the gate: they require *quiescence*, which means no event in flight at
-  all, regardless of which caller initiated it. The gate and the
-  quiescent check are orthogonal — both are emitted, neither replaces the
-  other.
+- **Operations.** Operations are declared on the system's public surface
+  but delegate to the machine without touching the gate. They exist
+  precisely for inspection without side effects (see
+  [Cookbook Recipe 32](../frame_cookbook.md)). A caller who wants to
+  inspect an instance during an in-flight handler — from a monitoring
+  sidecar, a debugger, a test assertion — does so through an operation, by
+  design. This is an acknowledged backdoor, not a defect.
+- **`save_state()` and `restore_state()`.** These live on the system
+  layer and have their own contract (`E700`, see [RFC-0012](rfc-0012.md))
+  that is strictly stronger than the gate: they require *quiescence*,
+  which means no event in flight at all in the machine, regardless of
+  which caller initiated it. The gate and the quiescent check are
+  orthogonal — both are emitted, neither replaces the other.
 - **Factory methods** (`@@[create(<name>)]`). Construction does not
   dispatch through the kernel and predates any event in flight. The
-  factory initializes the flag to *free*.
-- **Direct host-language access to internal symbols, the compartment, or
-  internal state.** A user who reaches into `instance.__method(...)`,
-  pokes `instance._compartment`, or otherwise circumvents the public
-  surface has explicitly opted out of the contract. The gate does not
-  defend against this; nothing reasonable could.
+  factory initializes the system layer, the machine, and the gate flag.
+- **Direct host-language access to the machine.** A user who reaches into
+  `instance._machine.method(...)` bypasses the system layer entirely.
+  framec does not defend against this; see *Scope of guarantee* below.
 
 ### Scope of guarantee
 
 The single-driver gate's guarantee is bounded. It is worth saying explicitly
 what it covers and what it does not:
 
-1. **Deliberate misuse of the internal symbol is undetected.** A host-code
-   caller who chooses to invoke `instance.__method(...)` directly bypasses
-   the gate. framec does not detect this. It cannot — the internal symbol
-   is reachable in every host language that has reachable methods. This
-   is the same model that `__` -prefixed APIs use in Python, that
-   `internal` uses in Kotlin and C#, that `pub(crate)` does not quite use
-   in Rust: a convention with visibility-modifier reinforcement, no
-   runtime guard.
+1. **Deliberate misuse of the inner machine is undetected.** A host-code
+   caller who chooses to reach `instance._machine.method(...)` or
+   equivalent bypasses the system layer and the gate. framec does not
+   detect this. It cannot — the machine is reachable in every host
+   language that has reachable members. This is the same model that
+   `_`-prefixed APIs use in Python, that `internal` uses in Kotlin and
+   C#, that `private` does in Java: a convention with visibility-modifier
+   reinforcement, no runtime guard.
 
 2. **Frame's own composition logic is correct by construction.** The
-   codegen knows at emission time which call sites are internal and routes
-   them to the internal symbol. The transition loop's lifecycle dispatch,
-   the kernel's routing, `@@:self`, default forward, and explicit
-   `=> $^` all hit the internal path. Nothing Frame emits trips the gate
-   by accident. Composition of Frame systems is therefore unaffected by
-   this RFC.
+   codegen knows at emission time which call sites are internal and emits
+   them inside the machine. The transition loop's lifecycle dispatch, the
+   kernel's routing, `@@:self`, default forward, and explicit `=> $^` all
+   stay inside the machine. Nothing Frame emits crosses back out to the
+   system layer by accident. Composition of Frame systems is therefore
+   unaffected by this RFC.
 
 3. **Cross-system composition is correct by construction.** When system
    `A` holds an instance of system `B` as a [composed system](../glossary.md#composed-system),
-   calls from `A`'s handlers to `B`'s interface route through `B`'s
-   public symbol — which is correct, because `A` is logically outside
-   `B`. Each instance's gate guards its own dispatch independently. No
-   coordination between gates is required.
+   `B`'s domain-field value is the *system* layer of `B`. Calls from
+   `A`'s handlers to `B`'s interface go through `B`'s system layer —
+   which is correct, because `A` is logically outside `B`. Each
+   instance's gate guards its own dispatch independently. No coordination
+   between gates is required.
 
 4. **The gate is orthogonal to the persist quiescent contract and the
    self-call guard.** `E700`'s quiescent check (no event in flight when
-   `save_state()` is called) and the existing self-call guard
-   (a self-call that transitioned aborts post-call statements) sit on
-   different signals — the context stack and the per-context
-   `_transitioned` flag respectively. The gate sits on the busy flag.
-   All three are emitted; none replaces another. Future work **MUST
-   NOT** collapse them without explicit RFC.
+   `save_state()` is called) is on the machine's context stack. The
+   self-call guard (a self-call that transitioned aborts post-call
+   statements) is on the machine's per-context `_transitioned` flag. The
+   gate is on the system layer's busy flag. Three independent guards on
+   three different signals; all are emitted; none replaces another. Future
+   work **MUST NOT** collapse them without explicit RFC.
 
-5. **Future internal-observation tooling uses the internal symbol by
-   design.** A trace hook, debug probe, or external instrument that
-   needs to observe events without re-tripping the gate **SHOULD** be
-   wired to the internal symbol — this is a legitimate use, the same
-   category as Frame's own composition. The internal symbol is the
-   documented contract for "I am part of this instance's in-flight
-   work, not an outside caller."
+5. **Future internal-observation tooling rides on the system layer by
+   design.** A trace hook, debug probe, or external instrument that needs
+   to observe events without re-tripping the gate **SHOULD** be wired to
+   the system layer's existing delegation points, alongside the gate
+   check. This is what the layering is for; the system layer is the
+   documented contract for "I am the cross-cutting concern over this
+   instance's dispatch."
 
-### Naming
+### Composition rule
 
-The recommended name for the internal symbol is `__<method>` (double
-underscore prefix). On backends where double-underscore name-mangles in a
-way that breaks reachability (Python: only on subclasses; CPython attribute
-lookup is unaffected when called via `self`), a single-underscore prefix is
-acceptable. On backends with a real visibility modifier (Kotlin `internal`,
-Swift `internal`, Java/C# package-private, C++ `protected`), framec
-**SHOULD** apply the modifier *in addition to* the naming convention so the
-internal symbol is both unmistakably-named and unreachable from typical
-external code paths.
+`@@[async]` systems may compose other `@@[async]` or sync systems as
+domain fields. A sync system **MUST NOT** compose an `@@[async]` system as
+a domain field: the sync handler would have no way to `await` the async
+child's interface, and framec **MUST** reject the combination at validation
+time (**E711** — *sync system cannot compose async system*). This rule
+falls out of the host language's typing; the validator surfaces it as a
+deliberate Frame-level error.
 
-The name and the modifier serve complementary purposes: the name
-documents intent at the call site; the modifier reduces accidental
-reach. Neither defends against the deliberate misuse described in
-point 1 of *Scope of guarantee*.
+### Naming and visibility
+
+The system layer **MUST** be emitted with the user-declared name (e.g.
+`Counter`). The machine **MUST** be emitted with a name that is both
+discoverable and clearly an internal artifact (`_<Name>Machine` is the
+recommended convention; backends with their own private-member
+conventions may follow them).
+
+The machine **MUST** be hidden behind whatever visibility modifier the
+target language offers:
+
+- Python: leading-underscore convention on the machine class and the
+  `_machine` field; `__machine` on the field if the system has subclasses.
+- TypeScript: `private _machine: _CounterMachine`.
+- JavaScript: `#machine` (private class field).
+- Rust: machine struct is module-private; field is non-public. Interface
+  methods take `&mut self`, so Rust's borrow checker provides the primary
+  enforcement of the single-driver contract for safe code — two
+  concurrent callers cannot share an instance without an explicit
+  serializing primitive (`Mutex`, `RefCell`), and every such primitive
+  itself serializes. The busy-flag gate remains as defense-in-depth
+  against `unsafe` aliasing and as a uniform shape across backends.
+- Kotlin / Swift: `internal` class, `private val machine`.
+- Java / C#: package-private (default) class; `private` field.
+- C++: machine is a private nested class; field is `private`.
+- Dart: leading-underscore class and field (library-private).
+- GDScript: leading-underscore convention.
+
+Neither the naming convention nor the visibility modifier defends against
+the deliberate misuse described in point 1 of *Scope of guarantee*.
 
 ### Out of scope
 
-- **Erlang.** The Erlang backend uses `gen_statem` actor semantics; the
-  actor process model already serializes events into the state machine
-  by construction. The gate adds nothing. Erlang systems do not emit a
-  busy flag and do not emit split entry points.
-- **C, Go, PHP, Ruby, Lua** when the system is **not** async. These
-  targets have no async surface and the single-driver contract is
-  satisfied by the host's own call-return discipline on a single
-  thread. The gate is emitted anyway — it costs one boolean and one
-  branch, and the host may still thread events from multiple sources
-  into the same instance.
+- **Sync systems.** Systems without `@@[async]` are emitted exactly as
+  before this RFC. No layered architecture, no gate, no `_machine`. Their
+  codegen is byte-identical to the prior release.
+- **Erlang.** The Erlang backend already emits the layered architecture
+  in OTP-idiomatic form: external callers go through `gen_statem:call/2`,
+  whose process mailbox serializes events by construction; internal
+  self-call uses a direct helper (`frame_dispatch__/3`) that does not
+  send a message. The mailbox is structurally a stronger guarantee than
+  the busy-flag gate — it *queues* the second message rather than
+  rejecting it — and predates this RFC. `@@[async]` on Erlang is
+  accepted (so the same Frame source compiles across all targets) but
+  emits no additional structure; the existing codegen is the reference.
 - **Multi-driver / shared-instance support.** Adding a real lock and
   permitting multiple concurrent callers per instance is a separate
-  feature that requires choosing a serialization primitive per backend,
-  defining ordering semantics, and addressing the persist
-  interaction. It is explicitly not in this RFC. If demand
-  materializes, the natural shape is an opt-in
-  `@@[serialize_events]` system attribute that wraps the gate's busy
-  flag with a host-runtime-appropriate async lock — a strictly larger
-  design done later.
-- **Catching deliberate misuse of the internal symbol.** Discussed
-  in *Scope of guarantee*. Not provided; not promised.
+  feature. It is explicitly not in this RFC. The natural shape, if it
+  ships, is an opt-in `@@[serialize_events]` system attribute that swaps
+  the gate's busy flag for a host-runtime-appropriate async lock — a
+  strictly larger design done later, and a strictly smaller change once
+  the system layer exists. The Erlang backend's mailbox model is the
+  reference implementation of the opt-in pattern for Python/Rust/the
+  rest: "behave like Erlang already does."
+- **Multithreaded safety for sync systems.** A sync system shared across
+  multiple host threads can race; that is a host-threading problem with
+  host-language remedies and is not covered by this RFC. A future
+  `@@[thread_safe]` attribute could address it without disturbing the
+  async architecture defined here.
+- **Catching deliberate misuse of the inner machine.** Discussed in
+  *Scope of guarantee*. Not provided; not promised.
 
 ## Examples
 
-### A normal flow, with self-call
+The Frame source for these examples is unchanged from any prior version of
+Frame. What the RFC affects is the *generated code*: an async system is
+emitted as a system layer plus a private machine; a sync system is emitted
+as today.
+
+### A normal flow with self-call
 
 ```
+@@[async]
 @@system Counter {
     interface:
         bump()
@@ -274,7 +393,7 @@ point 1 of *Scope of guarantee*.
         $Active {
             bump() {
                 $.n = $.n + 1
-                @@:self.snapshot()   // internal — does NOT trip the gate
+                @@:self.snapshot()   // internal — stays inside the machine
             }
             snapshot(): int {
                 @@:($.n)
@@ -285,16 +404,17 @@ point 1 of *Scope of guarantee*.
 }
 ```
 
-`bump()` is called externally. The public `bump` symbol checks the gate
-(free), sets it busy, dispatches, and in the handler calls
-`@@:self.snapshot()`. The self-call is routed to the internal
-`__snapshot` symbol, which does not touch the gate. `bump` returns, the
-gate is cleared in `finally`, and the instance is free for the next
-external call.
+`bump()` is called externally. It hits the public `Counter.bump` on the
+system layer, which checks the gate (free), sets it busy, delegates to the
+machine's `bump`, and clears the gate in `finally` on completion. Inside
+the machine, `@@:self.snapshot()` resolves to the machine's own
+`snapshot` — it never reaches back to the system layer, so the gate is
+not consulted.
 
 ### Async handler that suspends
 
 ```
+@@[async]
 @@system Fetcher {
     interface:
         async fetch(key: str): str
@@ -308,149 +428,192 @@ external call.
 }
 ```
 
-A caller does `await fetcher.fetch("x")`. The public `fetch` symbol
-checks the gate (free), sets it busy, dispatches the kernel which awaits
-`self.cache.get("x")`, and yields control to the scheduler. The gate
-remains *busy* across the suspension — that is the correct semantics.
-If a second task on the same instance calls `fetcher.fetch("y")` while
-the first is suspended, the public `fetch` symbol sees the gate is
-busy and raises `E703`. The first call eventually resumes, returns,
-and the gate clears in `finally`.
+A caller does `await fetcher.fetch("x")`. The system layer's `fetch`
+checks the gate (free), sets it busy, delegates to the machine's `fetch`,
+which awaits `self.cache.get("x")` and yields. The gate remains *busy*
+across the suspension — that is the correct semantics. If a second task
+on the same instance calls `fetcher.fetch("y")` while the first is
+suspended, the system layer's `fetch` sees the gate is busy and raises
+`E703`. The first call eventually resumes, the machine returns, and the
+system layer clears the gate in `finally`.
 
 ### Cross-system composition
 
 ```
+@@[async]
 @@system Parent {
     interface:
-        notify()
+        async notify()
 
     machine:
         $Up {
-            notify() {
-                self.child.bump()    // external from Parent's POV; public symbol on Child
+            async notify() {
+                await self.child.bump()
             }
         }
 
     domain:
-        child = @@Counter()
+        child = @@Counter()    // @@Counter is an async system; field holds its system layer
 }
 ```
 
-`Parent.notify` checks Parent's gate, sets Parent's busy, calls
-`self.child.bump()`. The call into `Counter` is *external from
-`Counter`'s perspective* — it hits `Counter`'s public `bump` symbol,
-which checks Counter's gate and sets Counter's busy. Two independent
-gates; two independent in-flight events; correct by construction. On
-return, `Counter`'s gate clears first, then `Parent`'s.
+`Parent.notify` checks Parent's gate, sets Parent's busy, delegates to
+the machine. Inside Parent's machine, `await self.child.bump()` goes to
+the *system layer* of `Counter` — which is correct, because Parent is
+outside Counter. Counter's gate sees free, sets busy, delegates to
+Counter's machine. Two independent gates; two independent in-flight
+events; correct by construction. On return, Counter's gate clears, then
+Parent's.
 
 ### Operations are a backdoor
 
 ```
+@@[async]
 @@system Pump {
     interface:
-        run()
+        async run()
     operations:
         state(): str { @@:(@@:system.state) }
 
     machine:
-        $Idle { run() { -> $Running } }
-        $Running { run() { ... } }
+        $Idle { async run() { -> $Running } }
+        $Running { async run() { ... } }
 }
 ```
 
 A test driver calls `pump.state()` while `pump.run()` is in flight on
-another task. The operation does not pass through the gate (operations
-are not dispatched); it reads `@@:system.state` from the compartment
-and returns. This is intentional — `state()` is the canonical
+another task. The operation on the system layer delegates to the machine
+*without* checking the gate; it reads `@@:system.state` from the
+compartment and returns. This is intentional — `state()` is the canonical
 inspection point (see [Cookbook Recipe 32](../frame_cookbook.md)) and
-must remain reachable even while an event is in flight, by design.
+must remain reachable even while an event is in flight.
 
 ## Alternatives
+
+### Split entry points on a single class
+
+An earlier draft of this RFC proposed emitting two symbols per interface
+method on a single class — a public `bump` that gates and dispatches, and
+an internal `__bump` that does the work — with `@@:self`, forwards, and
+the kernel's routing rewired at codegen time to the internal symbol.
+
+Rejected. The single-class form requires every backend to police a
+naming convention plus a visibility modifier on the same class, and the
+codegen has to rewrite every internal call site to a parallel name. The
+layered architecture replaces all of that with one structural rule: the
+machine is inside, the system is outside, and the only thing that
+crosses the boundary is interface and operation delegation. Internal
+calls stay inside the machine and need no rewriting. The two-symbol form
+also gave the layered architecture's other affordances — trace hooks,
+serialization, operations as a documented backdoor — nowhere clean to
+live.
 
 ### Reentrant lock with caller-identity discriminator
 
 A single entry point per interface method, guarded by a reentrant lock
 keyed on caller identity — `asyncio.current_task()` on Python async,
 `Thread.currentThread()` on threaded sync, an equivalent per backend.
-Same observable behaviour as the split-entry-point design (re-entry
-from the same logical caller is allowed; from a different one,
-rejected).
+Same observable behaviour as the layered design (re-entry from the same
+logical caller is allowed; from a different one, rejected).
 
 Rejected. The mechanism is per-backend by construction — every target
 needs the right identity primitive, and the choice between async-aware
-and thread-aware varies even within a single backend (Rust with
-`tokio` vs. Rust threaded; Java with `CompletableFuture` vs. Java
-threaded). The split-entry-point design replaces that runtime
-discriminator with a *codegen* discriminator that is uniform across
-every target: at emission time, framec knows whether a call site is
-internal or external, and routes accordingly. One mechanism, one
-shape, one error code; no per-backend identity primitive to keep in
-agreement.
+and thread-aware varies even within a single backend (Rust with `tokio`
+vs. Rust threaded; Java with `CompletableFuture` vs. Java threaded).
+The layered design replaces that runtime discriminator with a
+*structural* one: a call from outside the system reaches the system
+layer, a call from inside it reaches the machine, and the layering
+itself answers the question. One mechanism, one shape, one error code;
+no per-backend identity primitive to keep in agreement.
 
 ### Serializing lock — block-and-wait instead of fail-fast
 
-The same lock as above, but on contention the second caller *waits*
-for the first to complete rather than raising. Events arrive in
-the order the host schedules them and execute in series, silently.
+A lock that, on contention, makes the second caller *wait* for the
+first to complete rather than raising. Events arrive in the order the
+host schedules them and execute in series, silently.
 
 Rejected for the default behaviour. Silent serialization makes the
-contract violation invisible — users who fan multiple sources into
-one instance get correct results by accident and never learn that
-their architecture has drifted off the single-driver contract.
-Frame's existing runtime guards (`E700`, `E701`, the self-call
-abort) are all *loud*. The default for this gate should match.
+contract violation invisible — users who fan multiple sources into one
+instance get correct results by accident and never learn that their
+architecture has drifted off the single-driver contract. Frame's
+existing runtime guards (`E700`, `E701`, the self-call abort) are all
+*loud*. The default for this gate should match.
 
 This design is not foreclosed; the natural shape is the opt-in
-`@@[serialize_events]` attribute described under *Out of scope*. It
-is a strictly later, strictly larger piece of work.
+`@@[serialize_events]` attribute described under *Out of scope*. It is
+a strictly later, strictly larger piece of work — and a strictly
+smaller change once the system layer exists, since the layer is
+already the place where a lock would naturally live.
 
 ### Documentation only — state the contract, emit no gate
 
 Write the single-driver contract into [`frame_runtime.md`](../frame_runtime.md)
 and the per-language guides; rely on user discipline.
 
-Rejected as the *whole* answer, accepted as part of it. The
-contract must be documented either way — this RFC asks for both
-the doc text *and* a runtime check, because silent corruption
-on contract violation is too cheap a bug to leave undefended when
-the defense is one boolean per instance.
+Rejected as the *whole* answer, accepted as part of it. The contract
+must be documented either way — this RFC asks for both the doc text
+*and* a runtime check, because silent corruption on contract violation
+is too cheap a bug to leave undefended when the defense is one boolean
+per instance.
+
+### Always-on layered architecture, including for sync systems
+
+Emit the system/machine split on every `@@system`, regardless of
+`@@[async]`. Uniform codegen shape; no axis to remember; gate is
+universally available.
+
+Rejected on the *simple as possible but no simpler* principle. The
+hazard the gate exists to catch cannot occur in a single-threaded sync
+program. The instrumentation hooks the system layer affords are
+weakly motivated for sync systems (the failure modes are visible,
+debugging is straightforward). Forcing every sync system to grow a
+private machine, a delegation layer, and a gate field on every
+interface method — across all 17 backends — pays a cost where there
+is no corresponding benefit. Async opt-in keeps the codegen options
+clean and lets later RFCs add other system attributes
+(`@@[traced]`, `@@[thread_safe]`, `@@[rate_limited]`) along the same
+axis without coupling them to a layout users may not want.
 
 ### Always-on serialization with no opt-out
 
-Make every system always behave as if it had `@@[serialize_events]` —
-the runtime serializes external events into a per-instance queue,
-no error is ever raised, the single-driver contract becomes
-"effectively, single-driver from the runtime's perspective; the
-caller may fan in freely."
+Make every async system always behave as if it had
+`@@[serialize_events]` — the runtime serializes external events into a
+per-instance queue, no error is ever raised, the single-driver
+contract becomes "effectively, single-driver from the runtime's
+perspective; the caller may fan in freely."
 
 Rejected. This pulls Frame into making concurrency promises it has
 explicitly avoided since the [Oceans Model](../glossary.md#oceans-model)
-was formalized. Frame is meant to live inside the host runtime, not
-to introduce its own scheduler or its own queue. Users who want
-fan-in compose it on the outside, today with `asyncio.Queue` or
-`Channel` or `BlockingQueue`. Forcing a Frame-internal queue on
-every instance — async or not, parameterized or not, persisted or
-not — would be a non-trivial behaviour change applied to all 17
-backends, when the cost-to-value ratio of "you may now fan multiple
-sources into one instance" against "framec gets larger and Frame's
-runtime model gets bigger" doesn't justify it.
+was formalized. Frame is meant to live inside the host runtime, not to
+introduce its own scheduler or its own queue. Users who want fan-in
+compose it on the outside, today with `asyncio.Queue` or `Channel` or
+`BlockingQueue`; a future `@@[serialize_events]` will let them opt in
+to a generated equivalent. Default-on serialization deprives both
+groups of choice and ships a queue per instance whether anyone wants
+one or not.
 
 ## Migration
 
-Source-additive; no breaking change to Frame source. Existing systems
-continue to compile and generate the same dispatch path, with the
-addition of the busy flag and the split entry points. A correctly
-single-driver host application will see no behaviour change. A
-formerly-misbehaving host application that violated the contract will
-now see `E703` at the moment of violation rather than silent
-corruption — that is the intended user-visible effect.
+**Sync systems: no change.** Codegen output is byte-identical to the
+prior release. No source change. No regenerate.
 
-Generated-code output changes: each interface method now lowers to a
-public-symbol/internal-symbol pair, and the system class grows one
-boolean field. Codegen output is therefore *not* byte-identical to
-the prior release for systems with an `interface:` section; the
-CHANGELOG entry for the release that ships this RFC **MUST** call
-that out.
+**Existing async systems: one-line attribute addition.** The system
+header gains `@@[async]`. The codemod
+`framec project --add-async-attr` performs this mechanically across a
+tree. For a grace period of one minor release, framec accepts the
+legacy inferred form with warning **W710** so unmodified sources
+continue to build; the warning suggests the codemod.
+
+**Generated code for async systems changes shape.** Each async system
+now lowers to a public system class plus a private machine class. The
+user-facing name remains the same — `Counter` is still `Counter` from
+the caller's perspective. Internal symbols (the `_machine` field, the
+`_<Name>Machine` class) are private by convention and by language
+modifier where one exists. Codegen output for async systems is
+therefore *not* byte-identical to the prior release; the CHANGELOG
+entry for the release that ships this RFC **MUST** call that out, and
+the [Versioning & Stability](../frame_language.md#versioning--stability)
+note in the language reference covers the general expectation.
 
 ## References
 

--- a/docs/rfcs/rfc-0043.md
+++ b/docs/rfcs/rfc-0043.md
@@ -17,8 +17,8 @@ this document are to be interpreted as described in RFC 2119.
 
 This RFC defines the codegen architecture for **async systems** and makes its
 trigger explicit: the new `@@[async]` system-header attribute. An async system
-is emitted as two layers — a public **system** object holding a private inner
-**machine**. The system layer owns the externally visible interface and
+is emitted as two layers — a public **casing** holding a private inner
+**machine** (the watchmaker's metaphor: a case houses the movement). The casing owns the externally visible interface and
 operations and is the natural home for cross-cutting concerns: the
 single-driver gate introduced here (raises `E703` on concurrent external
 dispatch), and the instrumentation, serialization, and observability hooks
@@ -74,7 +74,7 @@ attribute.
 Beyond catching the hazard, separating the public surface from the dispatch
 core has a second payoff: it gives Frame a *place to put* the
 instrumentation, observability, and policy hooks that today have nowhere
-clean to live. The system layer becomes the natural home for trace hooks,
+clean to live. The casing becomes the natural home for trace hooks,
 metrics, optional serialization, and rate limiting. The machine remains
 purely about state-machine semantics.
 
@@ -139,30 +139,30 @@ order — and this RFC adds nothing to or removes nothing from that.
 
 framec **MUST** emit an async system as two artifacts:
 
-- A **system** artifact bearing the user-declared name (e.g. `Counter`). This
-  is what users instantiate, what domain fields hold, what other systems'
-  handlers call. It exposes the declared `interface:` and `operations:` as
-  the externally visible API. Each interface method on the system layer:
+- A **casing** bearing the user-declared name (e.g. `Counter`). This is
+  what users instantiate, what domain fields hold, what other systems'
+  handlers call. It exposes the declared `interface:` and `operations:`
+  as the externally visible API. Each interface method on the casing:
   1. Checks the gate (see *Single-driver gate*).
   2. Sets the gate to busy.
   3. Delegates to the corresponding method on the machine.
   4. Clears the gate to free in a host-language construct equivalent to
      `try`/`finally`.
-  Each operation method on the system layer delegates to the machine
+  Each operation method on the casing delegates to the machine
   without touching the gate (see *Scope of the gate*).
 
-- A **machine** artifact, host-language-private to the system. This is the
+- A **machine**, host-language-private to the casing. This is the
   existing async [dispatch](../glossary.md#dispatch) core — the kernel,
   [compartment](../glossary.md#compartment), [context stack](../glossary.md#frame-context),
-  state methods, transition loop, lifecycle cascades — emitted exactly as
-  today's `@@system` would emit it. The machine has no gate; it assumes
-  the system layer has already serialized external entry.
+  state methods, transition loop, lifecycle cascades — emitted exactly
+  as today's `@@system` would emit it. The machine has no gate; it
+  assumes the casing has already serialized external entry.
 
-The system layer holds the machine as a private member (composition, not
-inheritance). The machine **MUST NOT** be reachable through the system's
+The casing holds the machine as a private member (composition, not
+inheritance). The machine **MUST NOT** be reachable through the casing's
 public surface. `@@:self.method()`, default forward, and the kernel's
 routing are emitted inside the machine and call the machine's own methods
-directly; they do not cross back out to the system layer.
+directly; they do not cross back out to the casing.
 
 Because handler bodies live inside the machine, the codegen does **not**
 need to rewrite `@@:self.method()` to a different symbol — the existing
@@ -170,7 +170,7 @@ lowering to `self.method(...)` resolves to the machine's own method,
 because inside a machine method `self` is the machine. The routing is
 structural; no call-site rewriting is required.
 
-Operations on the system layer may delegate to the machine either as a
+Operations on the casing may delegate to the machine either as a
 call to a non-dispatching operation method on the machine
 (`return self._machine.<op>()`) or as a direct read of the machine's
 state where the operation reduces to one (`return self._machine._compartment.state`).
@@ -179,16 +179,16 @@ operation-method delegation as the canonical form.
 
 Cross-system calls — `@@OtherSystem(...).method()` and dispatched calls
 through a domain field that holds another system instance — **MUST**
-target the *system* layer of the other system, not its machine. From one
-instance's perspective, a call into a different instance is external, and
-the other instance's gate is the correct guard.
+target the *casing* of the other system, not its machine. From one
+instance's perspective, a call into a different instance is external,
+and the other instance's gate is the correct guard.
 
 ### Single-driver gate
 
-The per-instance busy flag introduced by the system layer **MUST**:
+The per-instance busy flag introduced by the casing **MUST**:
 
-- Be initialized to *free* in the system's [factory](../glossary.md#factory).
-- Transition to *busy* on entry to any interface method on the system layer,
+- Be initialized to *free* in the casing's [factory](../glossary.md#factory).
+- Transition to *busy* on entry to any interface method on the casing,
   immediately after the check below succeeds.
 - Be checked before transition to busy: if already *busy*, raise `E703`
   (see *Error code*) and return without dispatching to the machine.
@@ -211,12 +211,12 @@ The check-and-set sequence is atomic with respect to the [single-driver
 contract](#single-driver-contract): under that contract there is at most one
 logical caller, so no other writer to the flag exists. No memory barrier,
 no compare-and-swap, no lock primitive is required. A plain instance
-attribute on the system layer suffices.
+attribute on the casing suffices.
 
 ### Error code
 
 `E703 — system busy: concurrent external dispatch on an async instance.`
-Raised at the system layer's interface entry when the flag is already
+Raised at the casing's interface entry when the flag is already
 *busy*. The error message **SHOULD** name the method that was called and
 the method already in flight. framec **SHOULD** track the in-flight
 method name alongside the flag (e.g. as an `Option<&'static str>` /
@@ -231,27 +231,27 @@ analysis.
 
 ### Scope of the gate
 
-The gate applies **only** to interface methods on the system layer. It does
+The gate applies **only** to interface methods on the casing. It does
 **not** apply to:
 
-- **Operations.** Operations are declared on the system's public surface
-  but delegate to the machine without touching the gate. They exist
+- **Operations.** Operations sit on the casing alongside the interface
+  methods but delegate to the machine without touching the gate. They exist
   precisely for inspection without side effects (see
   [Cookbook Recipe 32](../frame_cookbook.md)). A caller who wants to
   inspect an instance during an in-flight handler — from a monitoring
   sidecar, a debugger, a test assertion — does so through an operation, by
   design. This is an acknowledged backdoor, not a defect.
-- **`save_state()` and `restore_state()`.** These live on the system
-  layer and have their own contract (`E700`, see [RFC-0012](rfc-0012.md))
+- **`save_state()` and `restore_state()`.** These live on the casing
+  and have their own contract (`E700`, see [RFC-0012](rfc-0012.md))
   that is strictly stronger than the gate: they require *quiescence*,
   which means no event in flight at all in the machine, regardless of
   which caller initiated it. The gate and the quiescent check are
   orthogonal — both are emitted, neither replaces the other.
 - **Factory methods** (`@@[create(<name>)]`). Construction does not
   dispatch through the kernel and predates any event in flight. The
-  factory initializes the system layer, the machine, and the gate flag.
+  factory initializes the casing, the machine, and the gate flag.
 - **Direct host-language access to the machine.** A user who reaches into
-  `instance._machine.method(...)` bypasses the system layer entirely.
+  `instance._machine.method(...)` bypasses the casing entirely.
   framec does not defend against this; see *Scope of guarantee* below.
 
 ### Scope of guarantee
@@ -261,7 +261,7 @@ what it covers and what it does not:
 
 1. **Deliberate misuse of the inner machine is undetected.** A host-code
    caller who chooses to reach `instance._machine.method(...)` or
-   equivalent bypasses the system layer and the gate. framec does not
+   equivalent bypasses the casing and the gate. framec does not
    detect this. It cannot — the machine is reachable in every host
    language that has reachable members. This is the same model that
    `_`-prefixed APIs use in Python, that `internal` uses in Kotlin and
@@ -273,13 +273,13 @@ what it covers and what it does not:
    them inside the machine. The transition loop's lifecycle dispatch, the
    kernel's routing, `@@:self`, default forward, and explicit `=> $^` all
    stay inside the machine. Nothing Frame emits crosses back out to the
-   system layer by accident. Composition of Frame systems is therefore
+   casing by accident. Composition of Frame systems is therefore
    unaffected by this RFC.
 
 3. **Cross-system composition is correct by construction.** When system
    `A` holds an instance of system `B` as a [composed system](../glossary.md#composed-system),
    `B`'s domain-field value is the *system* layer of `B`. Calls from
-   `A`'s handlers to `B`'s interface go through `B`'s system layer —
+   `A`'s handlers to `B`'s interface go through `B`'s casing —
    which is correct, because `A` is logically outside `B`. Each
    instance's gate guards its own dispatch independently. No coordination
    between gates is required.
@@ -289,15 +289,15 @@ what it covers and what it does not:
    `save_state()` is called) is on the machine's context stack. The
    self-call guard (a self-call that transitioned aborts post-call
    statements) is on the machine's per-context `_transitioned` flag. The
-   gate is on the system layer's busy flag. Three independent guards on
+   gate is on the casing's busy flag. Three independent guards on
    three different signals; all are emitted; none replaces another. Future
    work **MUST NOT** collapse them without explicit RFC.
 
-5. **Future internal-observation tooling rides on the system layer by
+5. **Future internal-observation tooling rides on the casing by
    design.** A trace hook, debug probe, or external instrument that needs
    to observe events without re-tripping the gate **SHOULD** be wired to
-   the system layer's existing delegation points, alongside the gate
-   check. This is what the layering is for; the system layer is the
+   the casing's existing delegation points, alongside the gate
+   check. This is what the layering is for; the casing is the
    documented contract for "I am the cross-cutting concern over this
    instance's dispatch."
 
@@ -313,7 +313,7 @@ deliberate Frame-level error.
 
 ### Naming and visibility
 
-The system layer **MUST** be emitted with the user-declared name (e.g.
+The casing **MUST** be emitted with the user-declared name (e.g.
 `Counter`). The machine **MUST** be emitted with a name that is both
 discoverable and clearly an internal artifact (`_<Name>Machine` is the
 recommended convention; backends with their own private-member
@@ -362,7 +362,7 @@ the deliberate misuse described in point 1 of *Scope of guarantee*.
   ships, is an opt-in `@@[serialize_events]` system attribute that swaps
   the gate's busy flag for a host-runtime-appropriate async lock — a
   strictly larger design done later, and a strictly smaller change once
-  the system layer exists. The Erlang backend's mailbox model is the
+  the casing exists. The Erlang backend's mailbox model is the
   reference implementation of the opt-in pattern for Python/Rust/the
   rest: "behave like Erlang already does."
 - **Multithreaded safety for sync systems.** A sync system shared across
@@ -377,7 +377,7 @@ the deliberate misuse described in point 1 of *Scope of guarantee*.
 
 The Frame source for these examples is unchanged from any prior version of
 Frame. What the RFC affects is the *generated code*: an async system is
-emitted as a system layer plus a private machine; a sync system is emitted
+emitted as a casing plus a private machine; a sync system is emitted
 as today.
 
 ### A normal flow with self-call
@@ -405,10 +405,10 @@ as today.
 ```
 
 `bump()` is called externally. It hits the public `Counter.bump` on the
-system layer, which checks the gate (free), sets it busy, delegates to the
+casing, which checks the gate (free), sets it busy, delegates to the
 machine's `bump`, and clears the gate in `finally` on completion. Inside
 the machine, `@@:self.snapshot()` resolves to the machine's own
-`snapshot` — it never reaches back to the system layer, so the gate is
+`snapshot` — it never reaches back to the casing, so the gate is
 not consulted.
 
 ### Async handler that suspends
@@ -428,14 +428,14 @@ not consulted.
 }
 ```
 
-A caller does `await fetcher.fetch("x")`. The system layer's `fetch`
+A caller does `await fetcher.fetch("x")`. The casing's `fetch`
 checks the gate (free), sets it busy, delegates to the machine's `fetch`,
 which awaits `self.cache.get("x")` and yields. The gate remains *busy*
 across the suspension — that is the correct semantics. If a second task
 on the same instance calls `fetcher.fetch("y")` while the first is
-suspended, the system layer's `fetch` sees the gate is busy and raises
+suspended, the casing's `fetch` sees the gate is busy and raises
 `E703`. The first call eventually resumes, the machine returns, and the
-system layer clears the gate in `finally`.
+casing clears the gate in `finally`.
 
 ### Cross-system composition
 
@@ -453,13 +453,13 @@ system layer clears the gate in `finally`.
         }
 
     domain:
-        child = @@Counter()    // @@Counter is an async system; field holds its system layer
+        child = @@Counter()    // @@Counter is an async system; field holds its casing
 }
 ```
 
 `Parent.notify` checks Parent's gate, sets Parent's busy, delegates to
 the machine. Inside Parent's machine, `await self.child.bump()` goes to
-the *system layer* of `Counter` — which is correct, because Parent is
+the *casing* of `Counter` — which is correct, because Parent is
 outside Counter. Counter's gate sees free, sets busy, delegates to
 Counter's machine. Two independent gates; two independent in-flight
 events; correct by construction. On return, Counter's gate clears, then
@@ -482,7 +482,7 @@ Parent's.
 ```
 
 A test driver calls `pump.state()` while `pump.run()` is in flight on
-another task. The operation on the system layer delegates to the machine
+another task. The operation on the casing delegates to the machine
 *without* checking the gate; it reads `@@:system.state` from the
 compartment and returns. This is intentional — `state()` is the canonical
 inspection point (see [Cookbook Recipe 32](../frame_cookbook.md)) and
@@ -521,10 +521,10 @@ needs the right identity primitive, and the choice between async-aware
 and thread-aware varies even within a single backend (Rust with `tokio`
 vs. Rust threaded; Java with `CompletableFuture` vs. Java threaded).
 The layered design replaces that runtime discriminator with a
-*structural* one: a call from outside the system reaches the system
-layer, a call from inside it reaches the machine, and the layering
-itself answers the question. One mechanism, one shape, one error code;
-no per-backend identity primitive to keep in agreement.
+*structural* one: a call from outside the system reaches the casing,
+a call from inside it reaches the machine, and the layering itself
+answers the question. One mechanism, one shape, one error code; no
+per-backend identity primitive to keep in agreement.
 
 ### Serializing lock — block-and-wait instead of fail-fast
 
@@ -542,7 +542,7 @@ existing runtime guards (`E700`, `E701`, the self-call abort) are all
 This design is not foreclosed; the natural shape is the opt-in
 `@@[serialize_events]` attribute described under *Out of scope*. It is
 a strictly later, strictly larger piece of work — and a strictly
-smaller change once the system layer exists, since the layer is
+smaller change once the casing exists, since the layer is
 already the place where a lock would naturally live.
 
 ### Documentation only — state the contract, emit no gate
@@ -564,7 +564,7 @@ universally available.
 
 Rejected on the *simple as possible but no simpler* principle. The
 hazard the gate exists to catch cannot occur in a single-threaded sync
-program. The instrumentation hooks the system layer affords are
+program. The instrumentation hooks the casing affords are
 weakly motivated for sync systems (the failure modes are visible,
 debugging is straightforward). Forcing every sync system to grow a
 private machine, a delegation layer, and a gate field on every
@@ -605,11 +605,11 @@ legacy inferred form with warning **W710** so unmodified sources
 continue to build; the warning suggests the codemod.
 
 **Generated code for async systems changes shape.** Each async system
-now lowers to a public system class plus a private machine class. The
-user-facing name remains the same — `Counter` is still `Counter` from
-the caller's perspective. Internal symbols (the `_machine` field, the
-`_<Name>Machine` class) are private by convention and by language
-modifier where one exists. Codegen output for async systems is
+now lowers to a public casing plus a private machine. The user-facing
+name remains the same — `Counter` is still `Counter` from the caller's
+perspective; the casing IS the `Counter` class users instantiate.
+Internal symbols (the `_machine` field, the `_<Name>Machine` class)
+are private by convention and by language modifier where one exists. Codegen output for async systems is
 therefore *not* byte-identical to the prior release; the CHANGELOG
 entry for the release that ships this RFC **MUST** call that out, and
 the [Versioning & Stability](../frame_language.md#versioning--stability)

--- a/docs/rfcs/rfc-0043.md
+++ b/docs/rfcs/rfc-0043.md
@@ -1,0 +1,463 @@
+---
+title: "RFC-0043 — Single-driver gate: detecting concurrent external dispatch"
+nav_exclude: true
+---
+
+# RFC-0043 — Single-driver gate: detecting concurrent external dispatch
+
+- **Status:** Draft
+- **Author:** Mark Truluck <mark@frame-lang.org>
+- **Created:** 2026-05-31
+- **Builds on:** RFC-0012 (the persist quiescent contract)
+
+The key words **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY** in
+this document are to be interpreted as described in RFC 2119.
+
+## Summary
+
+Frame's runtime has always assumed that an instance of a [system](../glossary.md#system)
+is driven by one logical caller at a time — internal flow (transitions,
+lifecycle cascades, forwarded events, `@@:self` re-entry) is Frame's
+responsibility, but the **outside** of the instance is the user's. That
+assumption has never been written down and has never been enforced. This RFC
+makes it normative — the *single-driver contract* — and adds a one-bit runtime
+check that detects violations at the moment they occur and raises `E703` rather
+than letting them corrupt state silently. The mechanism is a busy flag set on
+entry to each public [interface](../glossary.md#interface) method and cleared
+on return; internal call paths bypass the flag entirely, so re-entry from
+inside Frame's own machinery is unaffected.
+
+## Motivation
+
+A Frame instance's correctness depends on its [event handlers](../glossary.md#event-handler)
+running to completion in an ordered sequence. The runtime tracks an in-flight
+event on a per-instance context stack, processes any queued transition after
+the handler returns, runs the exit/enter cascades, and only then becomes
+quiescent again. Self-call (`@@:self.method()`), [forward](../glossary.md#forward)
+(`=> $^`), and async [await](../glossary.md#dispatch) suspension all happen
+*inside* that sequence and are handled correctly.
+
+What is **not** handled is a second external caller starting a new event on the
+same instance while the first event is still in flight. The most common way
+this happens is async: an interface handler suspends on
+`await some_io.call()`, control returns to the host runtime's scheduler, and
+another task on the same instance calls a different interface method. The
+runtime cheerfully pushes a second context onto the stack and runs the second
+handler — against the same compartment, the same domain fields, the same
+state-args — that the first handler is still using. Nothing detects this. The
+second event may transition the machine out from under the first; the first
+may overwrite the second's writes when it resumes; the persist quiescent check
+may snapshot an instance with two open contexts. The failure mode is silent
+data corruption discovered hours later.
+
+This is *not* a defect in the runtime, because the runtime never promised to
+support it. The single-driver assumption is the same one a hash map makes
+about concurrent mutation, the same one a Rust `&mut T` makes about aliasing.
+Frame just hasn't said so out loud. The fix is twofold: (1) state the
+contract, and (2) give the runtime the minimum mechanism needed to catch
+violations *loudly*, in the same spirit as `E700` catches `save_state()`
+called during an in-flight event.
+
+The mechanism must distinguish **external** entry — a caller from outside the
+instance starting a new event — from **internal** entry — Frame's own
+machinery re-routing within an event in flight. Self-call, forward, lifecycle
+dispatch, and the kernel's transition loop are all internal; they must not
+trip the gate. A new external event arriving while the previous is in flight
+is exactly what the gate exists to catch.
+
+## The contract
+
+### Single-driver contract
+
+A Frame [system](../glossary.md#system) instance **MUST** have at most one
+external [interface](../glossary.md#interface) call in flight at any time. The
+caller — the host code holding the instance — is responsible for serializing
+its events into the instance. Frame provides no concurrency primitives, no
+locking, no event queue.
+
+An "external call" is any invocation of a method declared in the system's
+`interface:` section made from outside the instance: from host code, from
+another system instance via a cross-system call, from a test driver, from an
+HTTP request handler. It is the public API of the instance.
+
+An "internal call" is any invocation of an interface method's body that
+Frame's own codegen has emitted as part of dispatching an event already in
+flight on this instance — `@@:self.method()`, default-forward to a parent
+state, the kernel's routing within `__kernel`, and the transition loop's
+invocation of `<$` exit and `$>` enter handlers. Internal calls are not
+subject to the single-driver contract.
+
+### Single-driver gate
+
+framec **MUST** generate, on every system, a per-instance busy flag and the
+discipline to maintain it:
+
+- The flag is initialized to *free* in the [factory](../glossary.md#factory).
+- On entry to a public interface method, the generated code **MUST**:
+  1. Check the flag. If *busy*, raise `E703` (see *Error code*) and return
+     without dispatching.
+  2. Set the flag to *busy*.
+- On return from a public interface method — whether normal, exceptional, or
+  (for [async systems](../glossary.md#async-system)) on completion of the
+  returned future — the generated code **MUST** clear the flag to *free*.
+  This **MUST** happen in a host-language construct equivalent to
+  `try`/`finally` so that a panicking, exception-throwing, or
+  rejected-future handler still releases the flag.
+
+The check-and-set sequence is atomic with respect to the [single-driver
+contract](#single-driver-contract): under that contract there is at most one
+logical caller, so no other writer to the flag exists. No memory barrier, no
+compare-and-swap, no lock primitive is required. A plain instance attribute
+suffices.
+
+### Split entry points
+
+framec **MUST** emit two symbols for each interface method on async-capable
+backends (Python, TypeScript, JavaScript, Rust, C++, Kotlin, Swift, C#, Java,
+Dart, GDScript) and on sync backends where re-routing is mechanically
+identical (all others except Erlang, which uses gen_statem and is out of
+scope; see *Out of scope*):
+
+- A **public** symbol with the method's declared name. This is the symbol the
+  user sees and the cross-system caller resolves against. Its body performs
+  the gate check, sets the flag, calls the internal symbol, and clears the
+  flag on completion.
+- An **internal** symbol with a host-language-natural visibility modifier and
+  an obviously-internal name (`__<method>` is the recommended convention;
+  see *Naming*). Its body is the dispatch the public symbol used to perform
+  directly. It does not touch the flag.
+
+`@@:self.method()`, default forward, and the kernel's routing **MUST** call
+the internal symbol. The transition loop's invocation of lifecycle handlers
+(`$>`, `<$`) was never on the public surface and is unchanged. Cross-system
+calls (`@@OtherSystem(...).method()`) **MUST** continue to call the public
+symbol of the target system: from one instance's perspective, a call into a
+*different* instance is external.
+
+### Error code
+
+`E703 — system busy: concurrent external dispatch on a single-driver
+instance.` Raised at the public entry point when the flag is already *busy*.
+The error message **SHOULD** name the method that was called and the method
+already in flight (the in-flight method name **MAY** be tracked alongside the
+flag for diagnostic quality).
+
+`E703` is a runtime error in the same family as `E700` (persist quiescent)
+and `E701` (corrupted snapshot). It is not a compile-time validation error;
+the violation is dynamic and cannot in general be detected by static
+analysis.
+
+### Scope of the gate
+
+The gate applies **only** to methods declared in a system's `interface:`
+section. It does **not** apply to:
+
+- **Operations.** Operations are declared on the system's public class but
+  bypass dispatch entirely; they exist precisely for inspection without
+  side effects (see [Cookbook Recipe 32](../frame_cookbook.md)). A caller
+  who wants to inspect an instance during an in-flight handler — from a
+  monitoring sidecar, a debugger, a test assertion — does so through an
+  operation, by design. This is an acknowledged backdoor, not a defect.
+- **`save_state()` and `restore_state()`.** These have their own contract
+  (`E700`, see [RFC-0012](rfc-0012.md)) that is strictly stronger than
+  the gate: they require *quiescence*, which means no event in flight at
+  all, regardless of which caller initiated it. The gate and the
+  quiescent check are orthogonal — both are emitted, neither replaces the
+  other.
+- **Factory methods** (`@@[create(<name>)]`). Construction does not
+  dispatch through the kernel and predates any event in flight. The
+  factory initializes the flag to *free*.
+- **Direct host-language access to internal symbols, the compartment, or
+  internal state.** A user who reaches into `instance.__method(...)`,
+  pokes `instance._compartment`, or otherwise circumvents the public
+  surface has explicitly opted out of the contract. The gate does not
+  defend against this; nothing reasonable could.
+
+### Scope of guarantee
+
+The single-driver gate's guarantee is bounded. It is worth saying explicitly
+what it covers and what it does not:
+
+1. **Deliberate misuse of the internal symbol is undetected.** A host-code
+   caller who chooses to invoke `instance.__method(...)` directly bypasses
+   the gate. framec does not detect this. It cannot — the internal symbol
+   is reachable in every host language that has reachable methods. This
+   is the same model that `__` -prefixed APIs use in Python, that
+   `internal` uses in Kotlin and C#, that `pub(crate)` does not quite use
+   in Rust: a convention with visibility-modifier reinforcement, no
+   runtime guard.
+
+2. **Frame's own composition logic is correct by construction.** The
+   codegen knows at emission time which call sites are internal and routes
+   them to the internal symbol. The transition loop's lifecycle dispatch,
+   the kernel's routing, `@@:self`, default forward, and explicit
+   `=> $^` all hit the internal path. Nothing Frame emits trips the gate
+   by accident. Composition of Frame systems is therefore unaffected by
+   this RFC.
+
+3. **Cross-system composition is correct by construction.** When system
+   `A` holds an instance of system `B` as a [composed system](../glossary.md#composed-system),
+   calls from `A`'s handlers to `B`'s interface route through `B`'s
+   public symbol — which is correct, because `A` is logically outside
+   `B`. Each instance's gate guards its own dispatch independently. No
+   coordination between gates is required.
+
+4. **The gate is orthogonal to the persist quiescent contract and the
+   self-call guard.** `E700`'s quiescent check (no event in flight when
+   `save_state()` is called) and the existing self-call guard
+   (a self-call that transitioned aborts post-call statements) sit on
+   different signals — the context stack and the per-context
+   `_transitioned` flag respectively. The gate sits on the busy flag.
+   All three are emitted; none replaces another. Future work **MUST
+   NOT** collapse them without explicit RFC.
+
+5. **Future internal-observation tooling uses the internal symbol by
+   design.** A trace hook, debug probe, or external instrument that
+   needs to observe events without re-tripping the gate **SHOULD** be
+   wired to the internal symbol — this is a legitimate use, the same
+   category as Frame's own composition. The internal symbol is the
+   documented contract for "I am part of this instance's in-flight
+   work, not an outside caller."
+
+### Naming
+
+The recommended name for the internal symbol is `__<method>` (double
+underscore prefix). On backends where double-underscore name-mangles in a
+way that breaks reachability (Python: only on subclasses; CPython attribute
+lookup is unaffected when called via `self`), a single-underscore prefix is
+acceptable. On backends with a real visibility modifier (Kotlin `internal`,
+Swift `internal`, Java/C# package-private, C++ `protected`), framec
+**SHOULD** apply the modifier *in addition to* the naming convention so the
+internal symbol is both unmistakably-named and unreachable from typical
+external code paths.
+
+The name and the modifier serve complementary purposes: the name
+documents intent at the call site; the modifier reduces accidental
+reach. Neither defends against the deliberate misuse described in
+point 1 of *Scope of guarantee*.
+
+### Out of scope
+
+- **Erlang.** The Erlang backend uses `gen_statem` actor semantics; the
+  actor process model already serializes events into the state machine
+  by construction. The gate adds nothing. Erlang systems do not emit a
+  busy flag and do not emit split entry points.
+- **C, Go, PHP, Ruby, Lua** when the system is **not** async. These
+  targets have no async surface and the single-driver contract is
+  satisfied by the host's own call-return discipline on a single
+  thread. The gate is emitted anyway — it costs one boolean and one
+  branch, and the host may still thread events from multiple sources
+  into the same instance.
+- **Multi-driver / shared-instance support.** Adding a real lock and
+  permitting multiple concurrent callers per instance is a separate
+  feature that requires choosing a serialization primitive per backend,
+  defining ordering semantics, and addressing the persist
+  interaction. It is explicitly not in this RFC. If demand
+  materializes, the natural shape is an opt-in
+  `@@[serialize_events]` system attribute that wraps the gate's busy
+  flag with a host-runtime-appropriate async lock — a strictly larger
+  design done later.
+- **Catching deliberate misuse of the internal symbol.** Discussed
+  in *Scope of guarantee*. Not provided; not promised.
+
+## Examples
+
+### A normal flow, with self-call
+
+```
+@@system Counter {
+    interface:
+        bump()
+        snapshot(): int
+
+    machine:
+        $Active {
+            bump() {
+                $.n = $.n + 1
+                @@:self.snapshot()   // internal — does NOT trip the gate
+            }
+            snapshot(): int {
+                @@:($.n)
+            }
+
+            $.n: int = 0
+        }
+}
+```
+
+`bump()` is called externally. The public `bump` symbol checks the gate
+(free), sets it busy, dispatches, and in the handler calls
+`@@:self.snapshot()`. The self-call is routed to the internal
+`__snapshot` symbol, which does not touch the gate. `bump` returns, the
+gate is cleared in `finally`, and the instance is free for the next
+external call.
+
+### Async handler that suspends
+
+```
+@@system Fetcher {
+    interface:
+        async fetch(key: str): str
+
+    machine:
+        $Ready {
+            async fetch(key: str): str {
+                @@:return = await self.cache.get(key)
+            }
+        }
+}
+```
+
+A caller does `await fetcher.fetch("x")`. The public `fetch` symbol
+checks the gate (free), sets it busy, dispatches the kernel which awaits
+`self.cache.get("x")`, and yields control to the scheduler. The gate
+remains *busy* across the suspension — that is the correct semantics.
+If a second task on the same instance calls `fetcher.fetch("y")` while
+the first is suspended, the public `fetch` symbol sees the gate is
+busy and raises `E703`. The first call eventually resumes, returns,
+and the gate clears in `finally`.
+
+### Cross-system composition
+
+```
+@@system Parent {
+    interface:
+        notify()
+
+    machine:
+        $Up {
+            notify() {
+                self.child.bump()    // external from Parent's POV; public symbol on Child
+            }
+        }
+
+    domain:
+        child = @@Counter()
+}
+```
+
+`Parent.notify` checks Parent's gate, sets Parent's busy, calls
+`self.child.bump()`. The call into `Counter` is *external from
+`Counter`'s perspective* — it hits `Counter`'s public `bump` symbol,
+which checks Counter's gate and sets Counter's busy. Two independent
+gates; two independent in-flight events; correct by construction. On
+return, `Counter`'s gate clears first, then `Parent`'s.
+
+### Operations are a backdoor
+
+```
+@@system Pump {
+    interface:
+        run()
+    operations:
+        state(): str { @@:(@@:system.state) }
+
+    machine:
+        $Idle { run() { -> $Running } }
+        $Running { run() { ... } }
+}
+```
+
+A test driver calls `pump.state()` while `pump.run()` is in flight on
+another task. The operation does not pass through the gate (operations
+are not dispatched); it reads `@@:system.state` from the compartment
+and returns. This is intentional — `state()` is the canonical
+inspection point (see [Cookbook Recipe 32](../frame_cookbook.md)) and
+must remain reachable even while an event is in flight, by design.
+
+## Alternatives
+
+### Reentrant lock with caller-identity discriminator
+
+A single entry point per interface method, guarded by a reentrant lock
+keyed on caller identity — `asyncio.current_task()` on Python async,
+`Thread.currentThread()` on threaded sync, an equivalent per backend.
+Same observable behaviour as the split-entry-point design (re-entry
+from the same logical caller is allowed; from a different one,
+rejected).
+
+Rejected. The mechanism is per-backend by construction — every target
+needs the right identity primitive, and the choice between async-aware
+and thread-aware varies even within a single backend (Rust with
+`tokio` vs. Rust threaded; Java with `CompletableFuture` vs. Java
+threaded). The split-entry-point design replaces that runtime
+discriminator with a *codegen* discriminator that is uniform across
+every target: at emission time, framec knows whether a call site is
+internal or external, and routes accordingly. One mechanism, one
+shape, one error code; no per-backend identity primitive to keep in
+agreement.
+
+### Serializing lock — block-and-wait instead of fail-fast
+
+The same lock as above, but on contention the second caller *waits*
+for the first to complete rather than raising. Events arrive in
+the order the host schedules them and execute in series, silently.
+
+Rejected for the default behaviour. Silent serialization makes the
+contract violation invisible — users who fan multiple sources into
+one instance get correct results by accident and never learn that
+their architecture has drifted off the single-driver contract.
+Frame's existing runtime guards (`E700`, `E701`, the self-call
+abort) are all *loud*. The default for this gate should match.
+
+This design is not foreclosed; the natural shape is the opt-in
+`@@[serialize_events]` attribute described under *Out of scope*. It
+is a strictly later, strictly larger piece of work.
+
+### Documentation only — state the contract, emit no gate
+
+Write the single-driver contract into [`frame_runtime.md`](../frame_runtime.md)
+and the per-language guides; rely on user discipline.
+
+Rejected as the *whole* answer, accepted as part of it. The
+contract must be documented either way — this RFC asks for both
+the doc text *and* a runtime check, because silent corruption
+on contract violation is too cheap a bug to leave undefended when
+the defense is one boolean per instance.
+
+### Always-on serialization with no opt-out
+
+Make every system always behave as if it had `@@[serialize_events]` —
+the runtime serializes external events into a per-instance queue,
+no error is ever raised, the single-driver contract becomes
+"effectively, single-driver from the runtime's perspective; the
+caller may fan in freely."
+
+Rejected. This pulls Frame into making concurrency promises it has
+explicitly avoided since the [Oceans Model](../glossary.md#oceans-model)
+was formalized. Frame is meant to live inside the host runtime, not
+to introduce its own scheduler or its own queue. Users who want
+fan-in compose it on the outside, today with `asyncio.Queue` or
+`Channel` or `BlockingQueue`. Forcing a Frame-internal queue on
+every instance — async or not, parameterized or not, persisted or
+not — would be a non-trivial behaviour change applied to all 17
+backends, when the cost-to-value ratio of "you may now fan multiple
+sources into one instance" against "framec gets larger and Frame's
+runtime model gets bigger" doesn't justify it.
+
+## Migration
+
+Source-additive; no breaking change to Frame source. Existing systems
+continue to compile and generate the same dispatch path, with the
+addition of the busy flag and the split entry points. A correctly
+single-driver host application will see no behaviour change. A
+formerly-misbehaving host application that violated the contract will
+now see `E703` at the moment of violation rather than silent
+corruption — that is the intended user-visible effect.
+
+Generated-code output changes: each interface method now lowers to a
+public-symbol/internal-symbol pair, and the system class grows one
+boolean field. Codegen output is therefore *not* byte-identical to
+the prior release for systems with an `interface:` section; the
+CHANGELOG entry for the release that ships this RFC **MUST** call
+that out.
+
+## References
+
+- [RFC-0012](rfc-0012.md) — the persist quiescent contract (`E700`)
+  and its relationship to the single-driver gate.
+- [Frame language reference § Async](../frame_language.md#async)
+- [Frame runtime reference](../frame_runtime.md)
+- [Frame cookbook recipe 32 — Test Harness](../frame_cookbook.md)
+- [Glossary](../glossary.md)
+- `CHANGELOG.md`

--- a/docs/rfcs/rfc-0043.md
+++ b/docs/rfcs/rfc-0043.md
@@ -88,7 +88,7 @@ if it declares one or more `async` [interface](../glossary.md#interface),
 members. The attribute is the user's explicit statement that this system is
 intended for async dispatch and the layered architecture is to be emitted.
 
-- Async members present without `@@[async]` is **E710** (validator):
+- Async members present without `@@[async]` is **E720** (validator):
   *async members require `@@[async]` on the system header*.
 - `@@[async]` present without any async members is permitted: the layered
   architecture and the gate are still emitted (a sync-dispatch system that
@@ -104,11 +104,21 @@ intended for async dispatch and the layered architecture is to be emitted.
 }
 ```
 
-For one release after this RFC ships, framec **SHOULD** also accept the
-legacy pattern (async members, no `@@[async]`) with warning **W710** —
-*inferred async system; add `@@[async]` to the header* — so existing
-sources have a quiet upgrade path. The accompanying codemod (`framec
-project --add-async-attr`) inserts the attribute mechanically.
+The release that ships this RFC's implementation makes E720 a **hard
+cut** — no warning grace period. This matches the migration model
+RFC-0015 and RFC-0042 established: source-compatibility breaks are
+loud and immediate; a codemod (`framec project --add-async-attr`)
+mechanically inserts `@@[async]` across a tree to migrate existing
+sources. Authors who pin framec versions in CI control the timing of
+their upgrade and run the codemod once at that boundary.
+
+Users compiling Frame source through the WASM build
+(`@frame-lang/framec-wasm`) need an equivalent in-environment
+migration path because the CLI `framec project` subcommand is not
+reachable from WASM. framec-wasm **MUST** expose a
+`migrate_async_attr(source: &str) -> String` function alongside `run`
+so playground, web, and npm-embedded users have a programmatic
+upgrade path that produces the same result as the CLI codemod.
 
 ### Single-driver contract
 
@@ -304,12 +314,23 @@ what it covers and what it does not:
 ### Composition rule
 
 `@@[async]` systems may compose other `@@[async]` or sync systems as
-domain fields. A sync system **MUST NOT** compose an `@@[async]` system as
-a domain field: the sync handler would have no way to `await` the async
-child's interface, and framec **MUST** reject the combination at validation
-time (**E711** — *sync system cannot compose async system*). This rule
-falls out of the host language's typing; the validator surfaces it as a
-deliberate Frame-level error.
+domain fields. A sync system **MUST NOT** compose an `@@[async]` system
+as a domain field: the sync handler would have no way to `await` the
+async child's interface, and framec **MUST** reject the combination at
+validation time (**E721** — *sync system cannot compose async system*).
+This rule falls out of the host language's typing; the validator
+surfaces it as a deliberate Frame-level error.
+
+**Scope of E721:** the validator resolves the composed system's type
+within the same source file. Cross-file resolution (where the composed
+system is brought in via [RFC-0040 `@@import`](rfc-0040.md)) is
+deferred — RFC-0040 itself currently defers cross-file arg/type
+validation. Until cross-file resolution matures, a sync system
+composing an `@@[async]` system imported from another file passes
+framec validation silently; the host language's type-check then
+rejects the un-`await`ed coroutine call at compile time. This is a
+Frame-side gap, not a correctness hole; the program does not run with
+a bad composition.
 
 ### Naming and visibility
 
@@ -597,12 +618,17 @@ one or not.
 **Sync systems: no change.** Codegen output is byte-identical to the
 prior release. No source change. No regenerate.
 
-**Existing async systems: one-line attribute addition.** The system
-header gains `@@[async]`. The codemod
-`framec project --add-async-attr` performs this mechanically across a
-tree. For a grace period of one minor release, framec accepts the
-legacy inferred form with warning **W710** so unmodified sources
-continue to build; the warning suggests the codemod.
+**Existing async systems: one-line attribute addition, applied at the
+upgrade boundary.** The system header gains `@@[async]`. The CLI
+codemod `framec project --add-async-attr <path>` performs this
+mechanically across a tree; the WASM build exposes
+`migrate_async_attr(source) -> source` for the same purpose in
+browser / Node embeddings. Run once when upgrading framec; the
+implementing release rejects the legacy inferred form with **E720**
+immediately on first compile. There is no grace period — consistent
+with RFC-0015's factory rename and RFC-0042's `@@fsm` hard-cut
+precedents. Authors who pin framec versions in CI control when this
+boundary is crossed.
 
 **Generated code for async systems changes shape.** Each async system
 now lowers to a public casing plus a private machine. The user-facing


### PR DESCRIPTION
## Summary

RFC-0043 proposes the codegen architecture for async systems and makes its trigger explicit: the new `@@[async]` system-header attribute. An async system is emitted as two layers — a public **casing** holding a private inner **machine** (the watchmaker's metaphor: a case houses the movement). The casing owns the single-driver gate that raises `E703` on concurrent external dispatch and is the natural home for the cross-cutting hooks that later RFCs will attach (trace, optional serialization). The machine is the existing dispatch core, held privately by the casing and unreachable from outside it.

**Sync systems are unaffected** by this RFC; the layered architecture and the gate are emitted only for systems that carry `@@[async]`.

## What's in this PR

Four commits, preserved as the design evolution:

1. **`docs(rfc-0043): single-driver gate — draft`** — initial split-symbols design (one class, two method-name twins per interface method). Preserved as the rejected alternative in commit 2.
2. **`docs(rfc-0043): redesign around layered architecture; validate across Python, Rust, Erlang`** — the redesign that replaces split-symbols with the casing/machine layered architecture. Includes the proof-of-concept validation across three backends:
   - Python: hand-built layered codegen; 6 of 6 RFC scenarios pass end-to-end.
   - Rust: hand-built using tokio; 6 of 6 pass. Finding: the borrow checker subsumes the gate for safe code, gate remains as defense-in-depth.
   - Erlang: analysis of existing gen_statem codegen shows the layered architecture is already there in OTP-idiomatic form (mailbox = serialization; `gen_statem:call` vs `frame_dispatch__` = external vs internal split). Erlang's mailbox is the reference implementation of the future `@@[serialize_events]` opt-in.
3. **`docs(rfc-0043): rename "system layer" -> "casing"`** — adopts the architectural term. Resolves the prior *"system layer of the system"* self-reference.
4. **`docs(rfc-0043): hard cut, E720/E721 renumber, WASM codemod, cross-file E721 deferral`** — four corrections after adversarial review of the implementation plan:
   - Hard cut from day 1; no grace period (matches RFC-0015 / RFC-0042 precedent).
   - E710/E711 renumbered to E720/E721 (E710/E711 shipped with RFC-0042 on 2026-05-31).
   - `framec-wasm` must expose `migrate_async_attr` because the CLI codemod is unreachable on the WASM path.
   - Cross-file E721 deferral scoped explicitly (waits for RFC-0040 cross-file resolution to mature).

## Error codes reserved

- **E703** — runtime: concurrent external dispatch on async instance (the gate firing).
- **E720** — validator: async members present without `@@[async]` on the system header. Hard cut from implementing release.
- **E721** — validator: sync system composes async system as domain field. Same-file resolution only; cross-file deferred.

## Status

**Draft.** This PR lands the design document; the implementation is a follow-on arc (drafted in `_scratch/rfc0043_impl_proposal.md`, ~9–11 weeks of focused work across the validator, the codemod, the shared codegen pipeline, the Rust pipeline, and the per-backend snapshot rollout). User decisions on the implementation are locked: hard cut from day 1, `_<Name>Machine` for the internal symbol, single feature branch with per-phase commits.

## Test plan

- [x] `scripts/validate_doc_samples.py` — all 118 samples pass (RFC code blocks are illustrative; correctly skipped by the validator)
- [x] `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check` — clean (doc-only change)
- [ ] Render the docs site locally and verify the RFC + glossary updates

## Related

- Builds on RFC-0012 (the persist quiescent contract / E700).
- Touches the codegen pipeline split formalized in #32 (which can land independently).
- See `_scratch/rfc0043_impl_proposal.md` (uncommitted; local notes) for the implementation phasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)