### PR TITLE
fix(graphviz): emit forward edge for push$ -> $State

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [4.4.0] - 2026-06-06
+
 Ships RFC-0043: the `@@[async]` system-header attribute and a layered
 casing/machine codegen architecture for every async-capable backend. Async
 systems are now emitted as a public **casing** (user-declared name) that gates
@@ -197,6 +199,16 @@ works.
 If your GDScript code relies on E703 firing in release builds, no change
 needed — D3 replaces the assert-based gate with `push_error` + typed-zero,
 which survives `--remap`.
+
+- **Graphviz: `push$ -> $X` now draws a forward edge.** The Graphviz backend
+  emitted no edge into a state reached by `push$ -> $Target`, so the pushed-to
+  state appeared unreachable in the diagram even though the FSM ran correctly.
+  The diagram IR builder's `StackPush` arm dropped the transition target; it now
+  emits a forward edge to the pushed-to state. For an HSM-inherited `push$` on a
+  parent state the edge is cluster-anchored (`ltail="cluster_<Parent>"`), and a
+  single-state push emits a plain forward edge. The push edge is distinguished
+  by a `(push$)` label tag on a solid edge (dashed/dotted remain `->>`/`=>`).
+  Graphviz-only; all other targets are byte-identical to 4.3.0.
 
 ## [4.3.0] - 2026-05-27
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "framec"
-version = "4.3.0"
+version = "4.4.0"
 dependencies = [
  "chrono",
  "clap",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "framec-wasm"
-version = "4.3.0"
+version = "4.4.0"
 dependencies = [
  "framec",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["framec", "framec-wasm"]
 
 [workspace.package]
-version = "4.3.0"
+version = "4.4.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/frame-lang/framec"

--- a/framec/src/frame_c/compiler/graphviz/builder.rs
+++ b/framec/src/frame_c/compiler/graphviz/builder.rs
@@ -175,8 +175,25 @@ fn extract_transitions_from_statements(
                     guard: guard.map(|s| s.to_string()),
                 });
             }
-            Statement::StackPush(_) => {
+            Statement::StackPush(push) => {
                 *has_state_stack = true;
+                // `push$ -> $Target` carries a forward transition; emit the
+                // edge so the pushed-to state isn't left unreachable in the
+                // diagram (Issue #46). A bare `push$` has no target → no edge.
+                // Distinguished from a normal transition by a "(push$)" label
+                // tag only; the edge stays solid (dashed/dotted are taken by
+                // ->>/=>). Cluster anchoring (ltail) is applied by emit_edge
+                // when the source is a parent state.
+                if let Some(target) = &push.transition_target {
+                    transitions.push(TransitionEdge {
+                        source: source_state.to_string(),
+                        target: TransitionTarget::State(target.clone()),
+                        event: event.to_string(),
+                        label: Some(format!("{} (push$)", event)),
+                        kind: TransitionKind::Transition,
+                        guard: guard.map(|s| s.to_string()),
+                    });
+                }
             }
             Statement::StackPop(_) => {
                 *has_state_stack = true;
@@ -321,7 +338,7 @@ fn format_expression(expr: &Expression) -> String {
 mod tests {
     use super::*;
     use crate::frame_c::compiler::frame_ast::{
-        HandlerAst, HandlerBody, IfAst, MachineAst, Span, StateAst, TransitionAst,
+        HandlerAst, HandlerBody, IfAst, MachineAst, Span, StackPushAst, StateAst, TransitionAst,
     };
 
     fn span() -> Span {
@@ -568,5 +585,120 @@ mod tests {
             .find(|t| matches!(&t.target, TransitionTarget::State(n) if n == "Bad"))
             .unwrap();
         assert_eq!(to_bad.guard, Some("else".to_string()));
+    }
+
+    /// Build a `StateAst` carrying a single handler whose body is `stmts`.
+    fn state_with_handler(
+        name: &str,
+        parent: Option<&str>,
+        event: &str,
+        stmts: Vec<Statement>,
+    ) -> StateAst {
+        StateAst {
+            name: name.to_string(),
+            params: vec![],
+            parent: parent.map(|p| p.to_string()),
+            state_vars: vec![],
+            handlers: vec![HandlerAst {
+                event: event.to_string(),
+                params: vec![],
+                return_type: None,
+                return_init: None,
+                leading_comments: Vec::new(),
+                attributes: Vec::new(),
+                body: HandlerBody {
+                    statements: stmts,
+                    span: span(),
+                },
+                span: span(),
+            }],
+            enter: None,
+            exit: None,
+            default_forward: false,
+            leading_comments: Vec::new(),
+            span: span(),
+            body_span: span(),
+        }
+    }
+
+    /// Build a handler-less `StateAst`.
+    fn bare_state(name: &str, parent: Option<&str>) -> StateAst {
+        StateAst {
+            name: name.to_string(),
+            params: vec![],
+            parent: parent.map(|p| p.to_string()),
+            state_vars: vec![],
+            handlers: vec![],
+            enter: None,
+            exit: None,
+            default_forward: false,
+            leading_comments: Vec::new(),
+            span: span(),
+            body_span: span(),
+        }
+    }
+
+    #[test]
+    fn test_push_transition_emits_forward_edge() {
+        // Issue #46: an inherited `push$ -> $Paused` on a parent state must
+        // emit a forward edge into Paused. The source is a parent (InGame has
+        // child Playing), so emit_edge cluster-anchors it via ltail.
+        let mut system = SystemAst::new("Repro".to_string(), span());
+        system.machine = Some(MachineAst {
+            states: vec![
+                state_with_handler(
+                    "InGame",
+                    None,
+                    "pause",
+                    vec![Statement::StackPush(StackPushAst {
+                        span: span(),
+                        indent: 0,
+                        transition_target: Some("Paused".to_string()),
+                    })],
+                ),
+                bare_state("Playing", Some("InGame")),
+                bare_state("Paused", None),
+            ],
+            span: span(),
+        });
+
+        let arcanum = Arcanum::default();
+        let graph = build_system_graph(&system, &arcanum);
+
+        assert!(graph.has_state_stack);
+        let edge = graph
+            .transitions
+            .iter()
+            .find(|t| matches!(&t.target, TransitionTarget::State(n) if n == "Paused"))
+            .expect("push$ -> $Paused should emit a forward edge into Paused");
+        assert_eq!(edge.source, "InGame");
+        assert_eq!(edge.label, Some("pause (push$)".to_string()));
+        assert_eq!(edge.kind, TransitionKind::Transition);
+    }
+
+    #[test]
+    fn test_bare_push_emits_no_edge() {
+        // A bare `push$` (no target) pushes the current state — no forward
+        // edge, but it still flags the state stack so the Stack node renders.
+        let mut system = SystemAst::new("Bare".to_string(), span());
+        system.machine = Some(MachineAst {
+            states: vec![state_with_handler(
+                "Active",
+                None,
+                "hold",
+                vec![Statement::StackPush(StackPushAst {
+                    span: span(),
+                    indent: 0,
+                    transition_target: None,
+                })],
+            )],
+            span: span(),
+        });
+
+        let arcanum = Arcanum::default();
+        let graph = build_system_graph(&system, &arcanum);
+
+        assert!(graph.has_state_stack);
+        assert!(graph.transitions.is_empty());
     }
 }


### PR DESCRIPTION
## What
The Graphviz backend drew no edge into a state reached by `push$ -> $Target`, so the pushed-to state looked unreachable in the diagram even though the FSM ran correctly. The IR builder's `StackPush` arm discarded the AST payload, ignoring `StackPushAst.transition_target`.

The arm now emits a forward `TransitionEdge` when the push carries a target:
- HSM-inherited pushes are cluster-anchored via the existing `ltail` logic.
- Single-state pushes emit a plain forward edge.
- Distinguished by a `(push$)` label tag on a solid edge (`dashed`/`dotted` stay reserved for `->>`/`=>`).

## Tests
- 2 new builder unit tests; `cargo test --lib` green (513).
- Graphviz isn't a matrix target (diagram-only), so this is unit-verified.

## Release
Part of **4.4.0** (was tagged 4.3.1 before the release collapse). Bumps `Cargo.toml` 4.3.0 → 4.4.0 + CHANGELOG entry under `[4.4.0]`.

> Note: the `[4.4.0]` CHANGELOG section / version line overlaps the RFC-0045 PR — expect a trivial CHANGELOG merge depending on order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)