### PR TITLE
feat(lang)!: RFC-0045 reserve @@:system.state + RFC-0044/D-PY-1 fix — cut 4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,22 @@ which survives `--remap`.
   by a `(push$)` label tag on a solid edge (dashed/dotted remain `->>`/`=>`).
   Graphviz-only; all other targets are byte-identical to 4.3.0.
 
+### RFC-0045 — reserve `@@:system.state`, relocate name to `@@:system.state.name`
+
+- **BREAKING — the current-state name accessor moves to `@@:system.state.name`
+  (RFC-0045).** `@@:system.state` previously evaluated to the current state's
+  name as a string; that spelling is now **reserved** for a future meaning (a
+  direct reference to the current compartment), and the name accessor is
+  `@@:system.state.name`. Bare `@@:system.state` is a hard error (**E608**) with
+  a fix-it message. Generated output for `@@:system.state.name` is byte-identical
+  on all 17 backends to what `@@:system.state` produced before. Migration is
+  mechanical: `@@:system.state` → `@@:system.state.name`. (Pre-public-beta: no
+  published program is affected.)
+- **E608 — `@@:system.state` is reserved (RFC-0045).** Fires in handler and
+  operation bodies for the bare form, pointing at `@@:system.state.name`. The
+  E604 hint (bare `@@:system`) now suggests `@@:system.state.name`, and E421
+  (no state access in static operations) is retargeted to the new spelling.
+
 ## [4.3.0] - 2026-05-27
 
 Re-introduces the `@@import` directive (removed in 4.2.0 by RFC-0024) in a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,18 @@ which survives `--remap`.
   E604 hint (bare `@@:system`) now suggests `@@:system.state.name`, and E421
   (no state access in static operations) is retargeted to the new spelling.
 
+### RFC-0044 — context stack cleans up on a handler exception (D-PY-1)
+
+- **The interface dispatch wrapper now pops the context stack even when a
+  handler throws.** Previously the `push / __kernel / pop` sequence had no
+  exception safety, so a handler that raised mid-dispatch leaked a stale
+  context-stack entry per failed call — the leak RFC-0043's casing surfaced.
+  Fixed across 12 backends with each language's idiom (try/finally, try/catch +
+  rethrow, begin/ensure, `defer`, `pcall` + re-raise). Holds under RFC-0043's
+  casing (the machine layer carries the guard; the casing delegates to it).
+  C, GDScript, Swift, and Erlang are exempt — no catchable exception can
+  propagate through their dispatch.
+
 ## [4.3.0] - 2026-05-27
 
 Re-introduces the `@@import` directive (removed in 4.2.0 by RFC-0024) in a

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![CI](https://github.com/frame-lang/framec/actions/workflows/ci.yml/badge.svg)
 ![License](https://img.shields.io/badge/license-Apache--2.0-blue)
-![Version](https://img.shields.io/badge/version-4.3.0-green)
+![Version](https://img.shields.io/badge/version-4.4.0-green)
 
 framec (aka the **framepiler**) — is the transpiler for the Frame language. Currently framec supports output to 17 target languges + Graphviz. Frame is a domain-specific language for specifying state machines that transpiles to production code in multiple target languages. You write `@@system` blocks inside your native source files, and the framepiler expands them into full state machine implementations. All native code passes through unchanged — your native compiler handles everything outside the `@@system` blocks and other `@@` tagged pragmas and statements.
 

--- a/docs/frame_cookbook.md
+++ b/docs/frame_cookbook.md
@@ -1420,11 +1420,11 @@ if __name__ == '__main__':
                 @@:(self.trace)
             }
 
-            status(): str { @@:(@@:system.state) }
+            status(): str { @@:(@@:system.state.name) }
         }
 
         $Shutdown {
-            status(): str { @@:(@@:system.state) }
+            status(): str { @@:(@@:system.state.name) }
         }
 
     domain:
@@ -1442,7 +1442,7 @@ if __name__ == '__main__':
     s2 = @@Sensor()
     s2.attempt_post_shutdown()
     print(s2.trace)          # "before" — "after" was suppressed
-    print(s2.status())       # "Shutdown" (via @@:system.state)
+    print(s2.status())       # "Shutdown" (via @@:system.state.name)
 ```
 
 **How it works:** `@@:self.reading()` dispatches through the full kernel pipeline. The return value is available as a native expression.
@@ -1459,9 +1459,9 @@ def _s_Active_hdl_user_attempt_post_shutdown(self, __e, compartment):
 
 The kernel sets `_transitioned = True` on every stacked context after processing a transition. The guard returns early when the flag is set, so `self.trace = "after"` never runs and the trace ends at `"before"`.
 
-This is a runtime safety property, not a manual pattern — every `@@:self.method(...)` call across all 17 backends gets the guard automatically. Authors don't need to write defensive `@@:system.state == "..."` checks; framec inserts the guard wherever it belongs.
+This is a runtime safety property, not a manual pattern — every `@@:self.method(...)` call across all 17 backends gets the guard automatically. Authors don't need to write defensive `@@:system.state.name == "..."` checks; framec inserts the guard wherever it belongs.
 
-**Features used:** `@@:self.method()`, reentrant dispatch, return value from self-call, automatic transition guard (runtime feature), `@@:system.state` (read of current state name)
+**Features used:** `@@:self.method()`, reentrant dispatch, return value from self-call, automatic transition guard (runtime feature), `@@:system.state.name` (read of current state name)
 
 -----
 
@@ -2285,7 +2285,7 @@ if __name__ == '__main__':
 
 ![32 state diagram](images/cookbook/32.svg)
 
-**Problem:** A system with operations for test inspection. `@@:system.state` is a read-only accessor — allowed in operations because it doesn't mutate the state machine.
+**Problem:** A system with operations for test inspection. `@@:system.state.name` is a read-only accessor — allowed in operations because it doesn't mutate the state machine.
 
 ```frame
 @@[target("python_3")]
@@ -2293,10 +2293,10 @@ if __name__ == '__main__':
 @@system TrafficLight {
     operations:
         current_state(): str {
-            return @@:system.state
+            return @@:system.state.name
         }
         is_in_state(name: str): bool {
-            return @@:system.state == name
+            return @@:system.state.name == name
         }
         get_config(): dict {
             return {"green": self.green_dur, "yellow": self.yellow_dur, "red": self.red_dur}
@@ -2365,7 +2365,7 @@ if __name__ == '__main__':
     print("All tests passed!")
 ```
 
-**Features stressed:** `@@:system.state` in operations, white-box testing pattern, events ignored in wrong state, state variable reset (`$.ticks`)
+**Features stressed:** `@@:system.state.name` in operations, white-box testing pattern, events ignored in wrong state, state variable reset (`$.ticks`)
 
 -----
 
@@ -3624,9 +3624,9 @@ Recipes 46-49 model real-world protocols and safety-critical systems at full fid
         get_leaves_qty(): float { return self.leaves_qty }
         get_avg_px(): float { return self.avg_px }
         get_cl_ord_id(): str { return self.cl_ord_id }
-        get_status(): str { return @@:system.state }
+        get_status(): str { return @@:system.state.name }
         is_terminal(): bool {
-            return @@:system.state in ["Filled", "Canceled", "Rejected"]
+            return @@:system.state.name in ["Filled", "Canceled", "Rejected"]
         }
 
     interface:
@@ -3984,7 +3984,7 @@ if __name__ == '__main__':
 
 **Operations for inspection.** `get_cum_qty()`, `get_leaves_qty()`, `get_avg_px()`, `is_terminal()` bypass the state machine for clean test access.
 
-**Features stressed:** 13-state machine, HSM, system params (3 domain overrides), operations with `@@:system.state`, domain arithmetic (VWAP), conditional transitions based on quantity, fills during pending states, terminal states ignoring all events, actions modifying domain vars
+**Features stressed:** 13-state machine, HSM, system params (3 domain overrides), operations with `@@:system.state.name`, domain arithmetic (VWAP), conditional transitions based on quantity, fills during pending states, terminal states ignoring all events, actions modifying domain vars
 
 ---
 
@@ -4654,7 +4654,7 @@ if __name__ == '__main__':
             return self.current_velocity
         }
         get_state(): str {
-            return @@:system.state
+            return @@:system.state.name
         }
 
     interface:
@@ -4981,7 +4981,7 @@ $SafetyCheck
 
 **Auto program execution.** `$AutoExecuting` reads the program step list, dispatches each command, and uses `@@:self.program_step_done()` to re-enter itself for the next step. This is the enter-handler chain pattern applied to program execution.
 
-**Features stressed:** 14 states, 3-level HSM (deepest in the cookbook), operations with `@@:system.state`, mode-based event rejection, `@@:self.method()` for program stepping, transient states, enter/exit handlers for velocity management, domain variables for 3D position
+**Features stressed:** 14 states, 3-level HSM (deepest in the cookbook), operations with `@@:system.state.name`, mode-based event rejection, `@@:self.method()` for program stepping, transient states, enter/exit handlers for velocity management, domain variables for 3D position
 
 ---
 
@@ -13973,7 +13973,7 @@ if __name__ == '__main__':
 @@system DroneFlightMode {
     operations:
         altitude(): float { return self.current_altitude }
-        flight_mode(): str { return @@:system.state }
+        flight_mode(): str { return @@:system.state.name }
 
     interface:
         arm()
@@ -14163,9 +14163,9 @@ if __name__ == '__main__':
 
 **Compare with Recipe 48.** The launch sequence has altitude-dependent abort modes (<30km pad escape, 30–100km downrange, >100km abort-to-orbit) — same *event* (`abort()`), different handler logic based on state. This drone recipe uses the inverse: different *events* (battery vs GPS vs RC), different target states, handler logic stays simple. Both are valid HSM patterns; the choice depends on whether the triggering conditions are distinguishable at the event layer or need to be discriminated inside a handler.
 
-**`flight_mode()` operation.** Returns the current state name directly. A ground station subscribing to drone status needs exactly this — no handler logic, no transitions, just "what state are you in right now." Same pattern as Recipe 22 (`@@:system.state`).
+**`flight_mode()` operation.** Returns the current state name directly. A ground station subscribing to drone status needs exactly this — no handler logic, no transitions, just "what state are you in right now." Same pattern as Recipe 22 (`@@:system.state.name`).
 
-**Features stressed:** HSM failsafe overlay with multiple distinct failsafes, state-scoped failsafe handling (ground states opt out), `@@:system.state` via operation, parallel to launch-sequence abort pattern
+**Features stressed:** HSM failsafe overlay with multiple distinct failsafes, state-scoped failsafe handling (ground states opt out), `@@:system.state.name` via operation, parallel to launch-sequence abort pattern
 
 -----
 
@@ -14182,7 +14182,7 @@ if __name__ == '__main__':
 
 @@system FleetRobot(robot_id: str) {
     operations:
-        robot_state(): str { return @@:system.state }
+        robot_state(): str { return @@:system.state.name }
         get_id(): str { return self.rid }
 
     interface:
@@ -14588,7 +14588,7 @@ if __name__ == '__main__':
 |`@@:(expr)` return           |yes         |yes all         |yes all              |yes all              |yes all              |yes all                 |
 |`@@:return(expr)` exit sugar |yes #22     |yes #28         |no                   |no                   |no                   |no                      |
 |`@@:self.method()`           |yes #22     |yes #33         |no                   |yes #49              |no                   |no                      |
-|`@@:system.state`            |yes #22     |yes #32         |no                   |yes #46, #49         |no                   |no                      |
+|`@@:system.state.name`            |yes #22     |yes #32         |no                   |yes #46, #49         |no                   |no                      |
 |Operations                   |no          |yes #23, #25, #32|yes #41, #45        |yes #46 (7), #49 (3) |yes #50, #51         |yes #69                 |
 |`static` operations          |no          |yes #25         |no                   |yes #46              |no                   |no                      |
 |System params (domain)       |yes #21     |yes #23         |no                   |yes #46 (3)          |no                   |no                      |

--- a/docs/frame_getting_started.md
+++ b/docs/frame_getting_started.md
@@ -1684,9 +1684,9 @@ When an interface method is called, Frame creates a *context* that handlers can 
 | `@@:event` | The name of the interface method that was called |
 | `@@:data.key` | Call-scoped data that persists across transitions |
 | `@@:self.method()` | Reentrant call to own interface method |
-| `@@:system.state` | Current state name (read-only string) |
+| `@@:system.state.name` | Current state name (read-only string) |
 
-`@@:self` and `@@:system` are **syntactic prefixes**, not values — bare use is an error (E603 / E604). Always chain a member: `@@:self.method()`, `@@:system.state`.
+`@@:self` and `@@:system` are **syntactic prefixes**, not values — bare use is an error (E603 / E604). Always chain a member: `@@:self.method()`, `@@:system.state.name`.
 
 #### Accessing Parameters
 

--- a/docs/frame_language.md
+++ b/docs/frame_language.md
@@ -455,7 +455,7 @@ actions:
     }
 ```
 
-**Can access:** domain variables, `@@:return`, `@@:params.x`, `@@:event`, `@@:data.key`, `@@:self.method()`, `@@:system.state`
+**Can access:** domain variables, `@@:return`, `@@:params.x`, `@@:event`, `@@:data.key`, `@@:self.method()`, `@@:system.state.name`
 
 **Cannot access (E401):** `-> $State`, `=> $^`, `push$`, `pop$`, `$.varName`
 
@@ -618,7 +618,7 @@ See [System Context](#system-context) for full semantics.
 
 ```frame
 @@:self.method(args) // call own interface method (reentrant)
-@@:system.state      // current state name (read-only)
+@@:system.state.name      // current state name (read-only)
 ```
 
 `@@:self` and `@@:system` are syntactic prefixes — neither is a first-class value. Bare `@@:self` (E603) and bare `@@:system` (E604) are errors.
@@ -840,21 +840,26 @@ The generated interface method handles FrameEvent construction, context push/pop
 
 | Syntax | Meaning |
 |--------|---------|
-| `@@:system.state` | Current state name (read-only string) |
+| `@@:system.state.name` | Current state name (read-only string) |
 
-### Current State — `@@:system.state`
+### Current State — `@@:system.state.name`
 
 Returns the current state name as a string, without the `$` prefix. Read-only — assignment is a parse error.
 
 ```frame
 $Processing {
     status(): str {
-        @@:(@@:system.state)    // returns "Processing"
+        @@:(@@:system.state.name)    // returns "Processing"
     }
 }
 ```
 
-`@@:system.state` reads from the compartment's `state` field. It reflects the current state at the time of access — if a transition has been deferred but not yet processed, `@@:system.state` still returns the pre-transition state.
+`@@:system.state.name` reads from the compartment's `state` field. It reflects the current state at the time of access — if a transition has been deferred but not yet processed, `@@:system.state.name` still returns the pre-transition state.
+
+> **Bare `@@:system.state` is reserved** ([RFC-0045](rfcs/rfc-0045.md)). The
+> name accessor is `@@:system.state.name`; writing bare `@@:system.state` is a
+> compile error (**E608**). The `@@:system.state` path is held for a future
+> direct reference to the current *compartment*, of which the name is one field.
 
 **Available in:** event handlers, enter/exit handlers, actions, non-static operations.
 
@@ -1132,7 +1137,7 @@ Both `@@:self` and `@@:system` are syntactic prefixes. Bare forms are errors (E6
 | Token | Meaning |
 |-------|---------|
 | `@@:self.method()` | Self interface call (reentrant) |
-| `@@:system.state` | Current state name (read-only) |
+| `@@:system.state.name` | Current state name (read-only) |
 
 ---
 
@@ -1178,7 +1183,8 @@ Both `@@:self` and `@@:system` are syntactic prefixes. Bare forms are errors (E6
 | E601 | `unknown-iface-method` | `@@:self.method()` targets method not in `interface:` |
 | E602 | `self-call-arity` | Argument count does not match interface declaration |
 | E603 | `bare-self-reference` | Bare `@@:self` — must be `@@:self.method(args)` |
-| E604 | `bare-system-reference` | Bare `@@:system` — must be `@@:system.state` (or other member) |
+| E604 | `bare-system-reference` | Bare `@@:system` — must be `@@:system.state.name` (or other member) |
+| E608 | `reserved-system-state` | `@@:system.state` is reserved (RFC-0045) — use `@@:system.state.name` for the state name |
 
 ### Domain & Pop Errors (E6xx)
 
@@ -1327,7 +1333,7 @@ Frame reference (`$.x` → `self.x`) spliced in.
 
 4. **Expressions** — yield a value. Frame has exactly two kinds:
    - *Property references* (**getters**): `$.x`, `@@:return`, `@@:data.key`,
-     `@@:event`, `@@:params.x`, `@@:system.state`, `@@:self`.
+     `@@:event`, `@@:params.x`, `@@:system.state.name`, `@@:self`.
    - *Call expressions*: `@@:self.method(args)` (re-entrant self-dispatch) and
      `@@Sys(args)` / `@@!Sys()` (system instantiation). Both are usable in value
      position (assignment RHS) and, standalone, as expression-statements.
@@ -1355,7 +1361,7 @@ Frame-managed place value. A property exposes up to two **accessors**:
 | `@@:return` | yes | yes (`= e`, `@@:(e)`; `@@:return(e)` also exits) |
 | `@@:event` | yes | — (read-only) |
 | `@@:params.x` | yes | — (read-only) |
-| `@@:system.state` | yes | — (read-only) |
+| `@@:system.state.name` | yes | — (read-only) |
 | `@@:self` | yes | — (read-only) |
 
 "Two kinds of accessor" = getter and setter. A read-only property has only a

--- a/docs/frame_quickstart.md
+++ b/docs/frame_quickstart.md
@@ -134,7 +134,7 @@ All use colon-then-namespace, dot for fields:
 | `@@:event` | current interface method name |
 | `@@:data.key` | call-scoped data (per-dispatch) |
 | `@@:self.method(args)` | reentrant self-call (method must be in `interface:` — E601) |
-| `@@:system.state` | current state name (read-only string, no `$`) |
+| `@@:system.state.name` | current state name (read-only string, no `$`) |
 
 **`return expr` is native — does NOT set the return value** (W415). Use `@@:(expr)` / `@@:return = expr` / `@@:return(expr)`.
 
@@ -358,7 +358,7 @@ Assignment to a `const` field in a handler body is E615. Per-target rendering: `
 | **E601** | `@@:self.X()` method not in interface | `X` is in `actions:` or `operations:` |
 | **E602** | `@@:self.X()` arg count mismatch | interface has 2 params, call passes 3 |
 | **E603** | bare `@@:self` | must be `@@:self.method(args)` |
-| **E604** | bare `@@:system` | must be `@@:system.state` (or other member) |
+| **E604** | bare `@@:system` | must be `@@:system.state.name` (or other member) |
 | **E605** | static target, no type on domain field | add `: T` in Rust/C/C++/Go |
 | **E613** | domain field shadows system param | pick different names |
 | **E615** | assigning to `const` field | remove `const` or drop the assignment |

--- a/docs/frame_runtime.md
+++ b/docs/frame_runtime.md
@@ -1970,7 +1970,7 @@ to wire up.
 
 ---
 
-## Step 17 — `const` domain fields and `@@:system.state`
+## Step 17 — `const` domain fields and `@@:system.state.name`
 
 ```frame
 @@system Lamp(name: str = "Lamp", max_brightness: int = 100) {
@@ -1983,7 +1983,7 @@ to wire up.
         }
         // new in this step
         get_state(): str {
-            return @@:system.state
+            return @@:system.state.name
         }
 
     interface:
@@ -2032,7 +2032,7 @@ Two additions:
   system parameter at construction and can never be reassigned.
   Handlers that try will be rejected at compile time (E615).
 - A new operation, `get_state()`, returns the current state name
-  via `@@:system.state`.
+  via `@@:system.state.name`.
 
 The constructor emits the const field with a marker for its
 immutability:
@@ -2067,7 +2067,7 @@ The framepiler enforces single-assignment at compile time
 regardless of target — even in Python, assigning to a `const`
 field in a handler body is E615.
 
-`@@:system.state` compiles to a direct read off the current
+`@@:system.state.name` compiles to a direct read off the current
 compartment:
 
 ```python
@@ -2086,7 +2086,7 @@ without dispatching an event to find out.
 
 Two prefixes worth knowing about:
 
-- `@@:system.state` — the only `@@:system` reference currently
+- `@@:system.state.name` — the only `@@:system` reference currently
   defined. Reads the current state name.
 - `@@:self.method(args)` — calls the system's own interface
   method. Goes through the full dispatch pipeline. We'll see this
@@ -2683,7 +2683,7 @@ Self-calls have compile-time checks:
 | E601 | Method doesn't exist in `interface:` |
 | E602 | Argument count doesn't match |
 | E603 | Bare `@@:self` (must be `@@:self.method(args)`) |
-| E604 | Bare `@@:system` (must be `@@:system.state`) |
+| E604 | Bare `@@:system` (must be `@@:system.state.name`) |
 
 The validation runs at the same stage as other interface
 references. By the time the framepiler emits code, all self-calls
@@ -3247,10 +3247,10 @@ of mistake the rebuild-on-every-transition rule makes visible.
 ### Self-calls and HSM
 
 The transition guard pattern from Step 19 (checking
-`@@:system.state` after a self-call that might transition) still
-works with HSM. `@@:system.state` reads the leaf state's name —
+`@@:system.state.name` after a self-call that might transition) still
+works with HSM. `@@:system.state.name` reads the leaf state's name —
 which is what you want. After a self-call that transitions from
-`$Heating` to `$Cooling`, `@@:system.state` returns `"Cooling"`.
+`$Heating` to `$Cooling`, `@@:system.state.name` returns `"Cooling"`.
 The guard pattern is unaffected by HSM depth.
 
 ---

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -58,6 +58,7 @@ numbers are not re-used.
 | [0041](rfc-0041.md) | Web persistence — storage-bound save/load for browser targets (`@@[web_persist]`) | Draft | builds on [0012](rfc-0012.md), [0015](rfc-0015.md), [0016](rfc-0016.md) |
 | [0043](rfc-0043.md) | `@@[async]` — single-driver gate via layered casing/machine | Accepted; shipped in 4.4.0 | builds on [0015](rfc-0015.md), [0017](rfc-0017.md), [0020](rfc-0020.md) |
 | [0044](rfc-0044.md) | Kernel context-stack must clean up on exception | Draft | builds on [0020](rfc-0020.md), surfaced by [0043](rfc-0043.md) |
+| [0045](rfc-0045.md) | Reserve `@@:system`; relocate state name to `@@:system.state.name` | Accepted; implemented | builds on [0006](rfc-0006.md), [0013](rfc-0013.md); breaking (pre-public-beta) |
 
 ## Other documents in this directory
 

--- a/docs/rfcs/frc-future.md
+++ b/docs/rfcs/frc-future.md
@@ -14,7 +14,7 @@ Frame's grammar is anchored by one token: **`@@`**, the **system context token**
 | Scope | What `@@` reaches | Examples |
 |-------|-------------------|----------|
 | **Module scope** | Frame directives, system declarations, system instantiation | `@@[target("python_3")]`, `@@[persist]`, `@@system Name { ... }`, `@@SystemName(args)` |
-| **Inside a handler, action, or operation** | The **dispatch context** of the current interface call | `@@:return`, `@@:params.x`, `@@:event`, `@@:data.k`, `@@:self.method()`, `@@:system.state` |
+| **Inside a handler, action, or operation** | The **dispatch context** of the current interface call | `@@:return`, `@@:params.x`, `@@:event`, `@@:data.k`, `@@:self.method()`, `@@:system.state.name` |
 
 At module scope, `@@` is followed by a Frame keyword (`target`, `codegen`, `persist`, `system`) or a system name being instantiated. Inside a handler, the most-used target is the dispatch context — so common that Frame gives it dedicated syntax: a colon after `@@`.
 
@@ -27,7 +27,7 @@ The accessor grammar is uniform:
 - **`:`** descends through Frame's namespace hierarchy
 - **`.`** accesses a field on the resolved object
 
-So `@@:params.x` reads as "into the context, navigate to `params`, then access field `x`." `@@:system.state` reads as "into the context, navigate to `system`, then access field `state`." And `@@:return` reads as "into the context, the return slot" — because `return` resolves to a value, not a container, no `.` follows.
+So `@@:params.x` reads as "into the context, navigate to `params`, then access field `x`." `@@:system.state.name` reads as "into the context, navigate to `system`, then `state`, then access field `name`." And `@@:return` reads as "into the context, the return slot" — because `return` resolves to a value, not a container, no `.` follows.
 
 ### `@@:` Defaults to `@@:return`
 
@@ -52,8 +52,8 @@ That single rule explains all three return-value forms:
 Both must be followed by a member access:
 
 - `@@:self.method(args)` — call your own interface (validated against `interface:`; E601 if the method doesn't exist, E602 on arity mismatch)
-- `@@:system.state` — read the current state name
+- `@@:system.state.name` — read the current state name
 
-Bare `@@:self` is **E603**; bare `@@:system` is **E604**. This is deliberate. Letting these escape into native code as free-floating values would force Frame to commit to a target-specific type for "the system's self-reference," which would break source-portability across the 17 backends — a single Rust target alone has at least four plausible self-types (`&Self`, `&mut Self`, `Rc<RefCell<Self>>`, `Arc<Mutex<Self>>`).
+Bare `@@:self` is **E603**; bare `@@:system` is **E604**; bare `@@:system.state` (without `.name`) is **E608**, reserved per [RFC-0045](rfc-0045.md) for a future direct reference to the current *compartment* (`@@:system.state.name` is the current name accessor). This is deliberate. Letting these escape into native code as free-floating values would force Frame to commit to a target-specific type for "the system's self-reference," which would break source-portability across the 17 backends — a single Rust target alone has at least four plausible self-types (`&Self`, `&mut Self`, `Rc<RefCell<Self>>`, `Arc<Mutex<Self>>`).
 
 For patterns that need a system to hold a reference to another system, pass the reference in at construction time from native call-site code (e.g., `child = ChildSystem(self)` written natively, *not* through `@@`). For patterns that need to hand a self-reference to native code from inside a handler, write a small action that returns `self` in your target language — this localizes the target-specific code to one place rather than scattering it through handler bodies.

--- a/docs/rfcs/rfc-0045.md
+++ b/docs/rfcs/rfc-0045.md
@@ -5,7 +5,7 @@ nav_exclude: true
 
 # RFC-0045 — Reserve `@@:system`; relocate the state-name accessor to `@@:system.state.name`
 
-- **Status:** Accepted — implemented in framec 4.3.x (pre-public-beta breaking change)
+- **Status:** Accepted — implemented in framec 4.4.0 (pre-public-beta breaking change)
 - **Author:** Mark Truluck <mark.truluck@cogiton.com>
 - **Created:** 2026-06-04
 - **Builds on:** RFC-0006 (self interface call `@@:self.iface()`), RFC-0013 (`@@`/`@@:` syntax)

--- a/docs/rfcs/rfc-0045.md
+++ b/docs/rfcs/rfc-0045.md
@@ -1,0 +1,128 @@
+---
+title: "RFC-0045: Reserve @@:system, relocate state name to @@:system.state.name"
+nav_exclude: true
+---
+
+# RFC-0045 — Reserve `@@:system`; relocate the state-name accessor to `@@:system.state.name`
+
+- **Status:** Accepted — implemented in framec 4.3.x (pre-public-beta breaking change)
+- **Author:** Mark Truluck <mark.truluck@cogiton.com>
+- **Created:** 2026-06-04
+- **Builds on:** RFC-0006 (self interface call `@@:self.iface()`), RFC-0013 (`@@`/`@@:` syntax)
+
+The key words **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY** are
+to be interpreted as described in RFC 2119.
+
+## Summary
+
+The `@@:system.state` accessor — which reads the current state's **name** as a
+string — is renamed to **`@@:system.state.name`**. The bare path
+**`@@:system.state` is reserved**: framec rejects it with a new diagnostic,
+**E608**, pointing the author at `@@:system.state.name`.
+
+The reservation keeps `@@:system.state` open for a future, richer meaning — a
+direct reference to the current **compartment** (the runtime object that carries
+the state's identity, its state arguments, and its state variables), of which the
+name is one field. Under that future model `@@:system.state` would denote the
+compartment and `@@:system.state.name` would denote its name field — so today's
+spelling is chosen to be forward-compatible with it.
+
+This is a **breaking change**, made deliberately before Frame has public users.
+No published Frame program breaks; framec's own demos, fixtures, and docs migrate
+mechanically (`@@:system.state` → `@@:system.state.name`).
+
+## Motivation
+
+`@@:` is a **descent into the dispatch context**: `@@:params.x`, `@@:data.k`,
+`@@:self.method()`, `@@:return`. Read that way, `@@:system` is a *path prefix*
+("into the context, navigate to `system`…"), and `@@:system.state` reads as
+"navigate to `system`, then to `state`." Today `state` resolves directly to a
+string. That is a dead end: it pins the only thing `@@:system.state` can ever
+mean to "the name," with no room to later expose the compartment's other facets
+(state arguments, state variables, identity) through the same natural path.
+
+Frame intends to make **compartments first-class, directly referenceable** in a
+later RFC. When it does, `@@:system.state` is the obvious spelling for "the
+current compartment," with `.name`, `.args`, `.vars`, etc. hanging off it. To
+keep that door open without a second breaking change later, the name accessor
+must move to its proper place — `@@:system.state.name` — **now**, while the cost
+is only our own repos.
+
+## Design
+
+### Grammar
+
+The context-construct parser FSM
+(`native_region_scanner/context_parser.frs`, state `$ParseSystem`) changes as
+follows:
+
+- `@@:system.state.name` (a word-bounded `.name` following `.state`) → the
+  current-state name accessor (segment kind `ContextSystemState`, unchanged
+  downstream).
+- `@@:system.state` **not** followed by `.name` → a new segment kind,
+  `ContextSystemStateReserved` → **E608**.
+- `@@:system` followed by any other member, or nothing → `ContextSystemBare` →
+  **E604** (unchanged; its hint now reads `@@:system.state.name`).
+
+The FSM is dogfooded Frame; the generated `context_parser.gen.rs` is regenerated
+from the `.frs` and **MUST NOT** be hand-edited.
+
+### Validation
+
+- **E608** — *bare `@@:system.state` is reserved.* Emitted for the new segment
+  kind in **handler bodies** (segment-kind check, `frame_validator/system_checks.rs`),
+  and by a text scan over **operation bodies** (which are raw native code and are
+  not scanned into Frame segments) in `frame_validator.rs`. The text scan treats
+  `@@:system.state` as reserved unless it is a complete token continued by a
+  word-bounded `.name`.
+- **E421** — *no state access in static operations.* Retargeted from
+  `@@:system.state` to `@@:system.state.name` (the new valid spelling). A static
+  operation that writes bare `@@:system.state` gets E608, not E421.
+
+### Code generation — unchanged behavior
+
+`@@:system.state.name` lowers to exactly what `@@:system.state` lowered to
+before: the per-backend compartment state-name accessor produced by
+`expand_system_state(lang)` (`codegen/frame_expansion/scanner_dispatch.rs`) — e.g.
+`self.__compartment.state` (Python), `self->__compartment->state` (C),
+`frame_state_name__(Data#data.frame_current_state)` (Erlang). The generated
+output for the relocated accessor is **byte-identical** to the pre-RFC output for
+the old spelling, on all 17 backends. No `match lang` arm changes; only the
+operation-body string-replace target moves from `@@:system.state` to
+`@@:system.state.name`.
+
+### Why E608
+
+E601–E607 are already assigned (E603 bare `@@:self`, E604 bare `@@:system`,
+E605 typed domain fields, E606 typed parameters, E607 transitions). E608 is the
+next free code and sits in the `@@:`/context-accessor neighborhood.
+
+## Migration
+
+Mechanical and total: replace `@@:system.state` with `@@:system.state.name`
+everywhere. There is no transition window — bare `@@:system.state` is an
+immediate hard error (that is the point of the reservation). Affected framec-owned
+surfaces:
+
+- **Docs/spec:** `docs/frame_language.md`, `docs/frame_cookbook.md`,
+  `docs/frame_quickstart.md`, `docs/frame_getting_started.md`,
+  `docs/frame_runtime.md`, and the `frc-future.md` "System Context" essay.
+- **Test environment** (`framec-test-env`): the `gen_const_sys.py` fuzz generator
+  and the `context_parser` positive fixtures across all 17 backends.
+- **Showcase** (`frame-games`): `.fjs` chapters — handled as a follow-up.
+
+## Future work (non-normative)
+
+Make compartments first-class so `@@:system.state` denotes the current
+compartment value, with `@@:system.state.name`, `@@:system.state.args.*`, and
+`@@:system.state.vars.*` reading its facets. That work is a separate RFC; this
+one only **reserves the spelling** and relocates the name accessor so the later
+change is additive, not breaking.
+
+## Reference — diagnostics
+
+| Code | Meaning |
+|---|---|
+| **E608** (new) | `@@:system.state` is reserved for future use; use `@@:system.state.name` to read the current state name. |
+| E604 (amended hint) | bare `@@:system` requires a member access (e.g. `@@:system.state.name`). |
+| E421 (retargeted) | `@@:system.state.name` is not allowed in a static operation (no compartment access). |

--- a/framec/src/frame_c/compiler/codegen/frame_expansion.rs
+++ b/framec/src/frame_c/compiler/codegen/frame_expansion.rs
@@ -125,6 +125,12 @@ pub(crate) fn generate_frame_expansion(
             context_data::expand_context_system_bare(body_bytes, span, indent, lang, ctx, metadata)
         }
         FrameSegmentKind::ContextSystemState => expand_system_state(lang),
+        // Reserved (RFC-0045) — validation rejects bare `@@:system.state` with
+        // E608 before codegen; this fallback only fires if validation is
+        // bypassed, in which case it passes the text through like a bare member.
+        FrameSegmentKind::ContextSystemStateReserved => {
+            context_data::expand_context_system_bare(body_bytes, span, indent, lang, ctx, metadata)
+        }
         FrameSegmentKind::ContextSelf => {
             context_self::expand_context_self(body_bytes, span, indent, lang, ctx, metadata)
         }

--- a/framec/src/frame_c/compiler/codegen/frame_expansion/scanner_dispatch.rs
+++ b/framec/src/frame_c/compiler/codegen/frame_expansion/scanner_dispatch.rs
@@ -98,9 +98,11 @@ pub(crate) fn expand_system_state(lang: TargetLanguage) -> String {
 pub(crate) fn expand_system_state_in_code(code: &str, lang: TargetLanguage) -> String {
     let mut result = code.to_string();
 
-    // Expand @@:system.state → compartment accessor
-    if result.contains("@@:system.state") {
-        result = result.replace("@@:system.state", &expand_system_state(lang));
+    // Expand @@:system.state.name → compartment accessor (the state-name
+    // string). Bare `@@:system.state` is reserved (RFC-0045) and rejected by
+    // E608 during validation, so only the `.name` form reaches codegen.
+    if result.contains("@@:system.state.name") {
+        result = result.replace("@@:system.state.name", &expand_system_state(lang));
     }
 
     // Expand @@:(expr) → return expr

--- a/framec/src/frame_c/compiler/codegen/interface_gen.rs
+++ b/framec/src/frame_c/compiler/codegen/interface_gen.rs
@@ -166,24 +166,36 @@ pub(crate) fn generate_interface_wrappers(
                     || method.return_init.is_some();
                 if has_return {
                     CodegenNode::NativeBlock {
+                        // D-PY-1: the pop MUST run even if __kernel raises,
+                        // or a failed dispatch leaks a stale context-stack
+                        // entry. try/finally guarantees it (async injects
+                        // `await` before self.__kernel — line-based, so the
+                        // try/finally lines are untouched).
                         code: format!(
                             r#"__e = {}("{}", {})
 __ctx = {}(__e, None){}
 self._context_stack.append(__ctx)
-self.__kernel(__e)
-return self._context_stack.pop()._return"#,
+try:
+    self.__kernel(__e)
+finally:
+    __frame_ctx = self._context_stack.pop()
+return __frame_ctx._return"#,
                             event_class, method.name, params_code, context_class, default_init
                         ),
                         span: None,
                     }
                 } else {
                     CodegenNode::NativeBlock {
+                        // D-PY-1: pop in finally so a raising handler can't
+                        // leak a context-stack entry.
                         code: format!(
                             r#"__e = {}("{}", {})
 __ctx = {}(__e, None){}
 self._context_stack.append(__ctx)
-self.__kernel(__e)
-self._context_stack.pop()"#,
+try:
+    self.__kernel(__e)
+finally:
+    self._context_stack.pop()"#,
                             event_class, method.name, params_code, context_class, default_init
                         ),
                         span: None,
@@ -223,8 +235,10 @@ self._context_stack.pop()"#,
                     || method.return_init.is_some()
                 {
                     CodegenNode::NativeBlock {
+                        // D-PY-1: pop on both success and exception paths so a
+                        // throwing handler can't leak a context-stack entry.
                         code: format!(
-                            "const __e = new {}(\"{}\", {});\nconst __ctx = new {}(__e, null);{}\nthis._context_stack.push(__ctx);\nthis.__kernel(__e);\nreturn this._context_stack.pop(){}._return;",
+                            "const __e = new {}(\"{}\", {});\nconst __ctx = new {}(__e, null);{}\nthis._context_stack.push(__ctx);\ntry {{\n    this.__kernel(__e);\n    return this._context_stack.pop(){}._return;\n}} catch (__frame_err) {{\n    this._context_stack.pop();\n    throw __frame_err;\n}}",
                             event_class, method.name, params_code, context_class, default_init, pop_suffix
                         ),
                         span: None,
@@ -232,7 +246,7 @@ self._context_stack.pop()"#,
                 } else {
                     CodegenNode::NativeBlock {
                         code: format!(
-                            "const __e = new {}(\"{}\", {});\nconst __ctx = new {}(__e, null);{}\nthis._context_stack.push(__ctx);\nthis.__kernel(__e);\nthis._context_stack.pop();",
+                            "const __e = new {}(\"{}\", {});\nconst __ctx = new {}(__e, null);{}\nthis._context_stack.push(__ctx);\ntry {{\n    this.__kernel(__e);\n}} finally {{\n    this._context_stack.pop();\n}}",
                             event_class, method.name, params_code, context_class, default_init
                         ),
                         span: None,
@@ -263,8 +277,10 @@ self._context_stack.pop()"#,
                     || method.return_init.is_some()
                 {
                     CodegenNode::NativeBlock {
+                        // D-PY-1: pop on both paths so a throwing handler
+                        // can't leak a context-stack entry.
                         code: format!(
-                            "$__e = new {}(\"{}\", {});\n$__ctx = new {}($__e, null);{}\n$this->_context_stack[] = $__ctx;\n$this->__kernel($__e);\nreturn array_pop($this->_context_stack)->_return;",
+                            "$__e = new {}(\"{}\", {});\n$__ctx = new {}($__e, null);{}\n$this->_context_stack[] = $__ctx;\ntry {{\n    $this->__kernel($__e);\n    return array_pop($this->_context_stack)->_return;\n}} catch (\\Throwable $__frame_err) {{\n    array_pop($this->_context_stack);\n    throw $__frame_err;\n}}",
                             event_class, method.name, params_code, context_class, default_init
                         ),
                         span: None,
@@ -272,7 +288,7 @@ self._context_stack.pop()"#,
                 } else {
                     CodegenNode::NativeBlock {
                         code: format!(
-                            "$__e = new {}(\"{}\", {});\n$__ctx = new {}($__e, null);{}\n$this->_context_stack[] = $__ctx;\n$this->__kernel($__e);\narray_pop($this->_context_stack);",
+                            "$__e = new {}(\"{}\", {});\n$__ctx = new {}($__e, null);{}\n$this->_context_stack[] = $__ctx;\ntry {{\n    $this->__kernel($__e);\n}} finally {{\n    array_pop($this->_context_stack);\n}}",
                             event_class, method.name, params_code, context_class, default_init
                         ),
                         span: None,
@@ -303,8 +319,9 @@ self._context_stack.pop()"#,
                     || method.return_init.is_some()
                 {
                     CodegenNode::NativeBlock {
+                        // D-PY-1: ensure the pop runs even if a handler raises.
                         code: format!(
-                            "__e = {}.new(\"{}\", {})\n__ctx = {}.new(__e, nil){}\n@_context_stack.push(__ctx)\n__kernel(__e)\nreturn @_context_stack.pop._return",
+                            "__e = {}.new(\"{}\", {})\n__ctx = {}.new(__e, nil){}\n@_context_stack.push(__ctx)\nbegin\n    __kernel(__e)\n    return @_context_stack.last._return\nensure\n    @_context_stack.pop\nend",
                             event_class, method.name, params_code, context_class, default_init
                         ),
                         span: None,
@@ -312,7 +329,7 @@ self._context_stack.pop()"#,
                 } else {
                     CodegenNode::NativeBlock {
                         code: format!(
-                            "__e = {}.new(\"{}\", {})\n__ctx = {}.new(__e, nil){}\n@_context_stack.push(__ctx)\n__kernel(__e)\n@_context_stack.pop",
+                            "__e = {}.new(\"{}\", {})\n__ctx = {}.new(__e, nil){}\n@_context_stack.push(__ctx)\nbegin\n    __kernel(__e)\nensure\n    @_context_stack.pop\nend",
                             event_class, method.name, params_code, context_class, default_init
                         ),
                         span: None,
@@ -480,25 +497,32 @@ return __result;"#,
                 }
 
                 code.push_str("_context_stack.push_back(std::move(__ctx));\n");
-                // Async: await the kernel so nested co_awaits work; sync:
-                // plain call.
+                // D-PY-1: pop on both paths so a throwing handler can't leak.
+                // try/catch is valid inside a coroutine; `throw;` re-propagates
+                // through the promise. Async: await the kernel so nested
+                // co_awaits work; sync: plain call.
+                code.push_str("try {\n");
                 if system_is_async {
-                    code.push_str("co_await __kernel(_context_stack.back()._event);\n");
+                    code.push_str("    co_await __kernel(_context_stack.back()._event);\n");
                 } else {
-                    code.push_str("__kernel(_context_stack.back()._event);\n");
+                    code.push_str("    __kernel(_context_stack.back()._event);\n");
                 }
 
                 let ret_kw = if system_is_async { "co_return" } else { "return" };
                 if returns_value {
-                    code.push_str(&format!("auto __result = std::any_cast<{}>(std::move(_context_stack.back()._return));\n", return_type_str));
-                    code.push_str("_context_stack.pop_back();\n");
-                    code.push_str(&format!("{} __result;", ret_kw));
+                    code.push_str(&format!("    auto __result = std::any_cast<{}>(std::move(_context_stack.back()._return));\n", return_type_str));
+                    code.push_str("    _context_stack.pop_back();\n");
+                    code.push_str(&format!("    {} __result;\n", ret_kw));
                 } else if system_is_async {
-                    code.push_str("_context_stack.pop_back();\n");
-                    code.push_str("co_return;");
+                    code.push_str("    _context_stack.pop_back();\n");
+                    code.push_str("    co_return;\n");
                 } else {
-                    code.push_str("_context_stack.pop_back();");
+                    code.push_str("    _context_stack.pop_back();\n");
                 }
+                code.push_str("} catch (...) {\n");
+                code.push_str("    _context_stack.pop_back();\n");
+                code.push_str("    throw;\n");
+                code.push_str("}");
 
                 CodegenNode::NativeBlock { code, span: None }
             }
@@ -548,24 +572,32 @@ return __result;"#,
                     code.push_str(&format!("{} __ctx = new {}(__e, null);\n", context_class, context_class));
                 }
 
+                // D-PY-1: pop on both paths so a throwing handler can't leak
+                // a context-stack entry (catch+rethrow; Java dispatch is not
+                // declared `throws`, so only unchecked exceptions propagate).
                 code.push_str("_context_stack.add(__ctx);\n");
-                code.push_str("__kernel(_context_stack.get(_context_stack.size() - 1)._event);\n");
+                code.push_str("try {\n");
+                code.push_str("    __kernel(_context_stack.get(_context_stack.size() - 1)._event);\n");
 
                 if has_return && return_type_str != "void" && return_type_str != "Any" && return_type_str != "Object" {
                     let java_type = java_map_type(&return_type_str);
-                    code.push_str(&format!("{} __result = ({}) _context_stack.get(_context_stack.size() - 1)._return;\n", java_type, java_type));
-                    code.push_str("_context_stack.remove(_context_stack.size() - 1);\n");
+                    code.push_str(&format!("    {} __result = ({}) _context_stack.get(_context_stack.size() - 1)._return;\n", java_type, java_type));
+                    code.push_str("    _context_stack.remove(_context_stack.size() - 1);\n");
                     if method_is_async {
-                        code.push_str("return java.util.concurrent.CompletableFuture.completedFuture(__result);");
+                        code.push_str("    return java.util.concurrent.CompletableFuture.completedFuture(__result);\n");
                     } else {
-                        code.push_str("return __result;");
+                        code.push_str("    return __result;\n");
                     }
                 } else {
-                    code.push_str("_context_stack.remove(_context_stack.size() - 1);");
+                    code.push_str("    _context_stack.remove(_context_stack.size() - 1);\n");
                     if method_is_async {
-                        code.push_str("\nreturn java.util.concurrent.CompletableFuture.completedFuture(null);");
+                        code.push_str("    return java.util.concurrent.CompletableFuture.completedFuture(null);\n");
                     }
                 }
+                code.push_str("} catch (RuntimeException __frame_err) {\n");
+                code.push_str("    _context_stack.remove(_context_stack.size() - 1);\n");
+                code.push_str("    throw __frame_err;\n");
+                code.push_str("}");
 
                 CodegenNode::NativeBlock { code, span: None }
             }
@@ -608,17 +640,23 @@ return __result;"#,
                     code.push_str(&format!("val __ctx = {}(__e, null)\n", context_class));
                 }
 
+                // D-PY-1: pop on both paths so a throwing handler can't leak.
                 code.push_str("_context_stack.add(__ctx)\n");
-                code.push_str("__kernel(_context_stack[_context_stack.size - 1]._event)\n");
+                code.push_str("try {\n");
+                code.push_str("    __kernel(_context_stack[_context_stack.size - 1]._event)\n");
 
                 if has_return && return_type_str != "void" && return_type_str != "Any" && return_type_str != "Any?" {
                     let kotlin_type = kotlin_map_type(&return_type_str);
-                    code.push_str(&format!("val __result = _context_stack[_context_stack.size - 1]._return as {}\n", kotlin_type));
-                    code.push_str("_context_stack.removeAt(_context_stack.size - 1)\n");
-                    code.push_str("return __result");
+                    code.push_str(&format!("    val __result = _context_stack[_context_stack.size - 1]._return as {}\n", kotlin_type));
+                    code.push_str("    _context_stack.removeAt(_context_stack.size - 1)\n");
+                    code.push_str("    return __result\n");
                 } else {
-                    code.push_str("_context_stack.removeAt(_context_stack.size - 1)");
+                    code.push_str("    _context_stack.removeAt(_context_stack.size - 1)\n");
                 }
+                code.push_str("} catch (__frame_err: Throwable) {\n");
+                code.push_str("    _context_stack.removeAt(_context_stack.size - 1)\n");
+                code.push_str("    throw __frame_err\n");
+                code.push_str("}");
 
                 CodegenNode::NativeBlock { code, span: None }
             }
@@ -706,17 +744,23 @@ return __result;"#,
                     code.push_str(&format!("{} __ctx = new {}(__e, null);\n", context_class, context_class));
                 }
 
+                // D-PY-1: pop on both paths so a throwing handler can't leak.
                 code.push_str("_context_stack.Add(__ctx);\n");
-                code.push_str("__kernel(_context_stack[_context_stack.Count - 1]._event);\n");
+                code.push_str("try {\n");
+                code.push_str("    __kernel(_context_stack[_context_stack.Count - 1]._event);\n");
 
                 if has_return && return_type_str != "void" && return_type_str != "Any" && return_type_str != "object" {
                     let cs_type = csharp_map_type(&return_type_str);
-                    code.push_str(&format!("var __result = ({}) _context_stack[_context_stack.Count - 1]._return;\n", cs_type));
-                    code.push_str("_context_stack.RemoveAt(_context_stack.Count - 1);\n");
-                    code.push_str("return __result;");
+                    code.push_str(&format!("    var __result = ({}) _context_stack[_context_stack.Count - 1]._return;\n", cs_type));
+                    code.push_str("    _context_stack.RemoveAt(_context_stack.Count - 1);\n");
+                    code.push_str("    return __result;\n");
                 } else {
-                    code.push_str("_context_stack.RemoveAt(_context_stack.Count - 1);");
+                    code.push_str("    _context_stack.RemoveAt(_context_stack.Count - 1);\n");
                 }
+                code.push_str("} catch {\n");
+                code.push_str("    _context_stack.RemoveAt(_context_stack.Count - 1);\n");
+                code.push_str("    throw;\n");
+                code.push_str("}");
 
                 CodegenNode::NativeBlock { code, span: None }
             }
@@ -749,20 +793,23 @@ return __result;"#,
                 }
 
                 code.push_str("s._context_stack = append(s._context_stack, __ctx)\n");
+                // D-PY-1: defer the pop so a panicking handler can't leak a
+                // context-stack entry (defer runs on panic unwinding too).
+                code.push_str("defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()\n");
                 code.push_str("s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)\n");
 
                 if has_return && return_type_str != "void" && return_type_str != "Any" {
                     let go_type = go_map_type(&return_type_str);
-                    if go_type.is_empty() {
-                        code.push_str("s._context_stack = s._context_stack[:len(s._context_stack)-1]");
-                    } else {
+                    if !go_type.is_empty() {
+                        // Read the return value while __ctx is still on the
+                        // stack; the deferred pop runs after the return value
+                        // is evaluated.
                         code.push_str(&format!("var __result {}\nif __rv := s._context_stack[len(s._context_stack)-1]._return; __rv != nil {{ __result = __rv.({}) }}\n", go_type, go_type));
-                        code.push_str("s._context_stack = s._context_stack[:len(s._context_stack)-1]\n");
                         code.push_str("return __result");
                     }
-                } else {
-                    code.push_str("s._context_stack = s._context_stack[:len(s._context_stack)-1]");
+                    // go_type empty (unit-like return) → defer handles the pop.
                 }
+                // void → defer handles the pop.
 
                 CodegenNode::NativeBlock { code, span: None }
             }
@@ -796,9 +843,13 @@ return __result;"#,
                     // as a single expression so the return statement has
                     // the value embedded inline — no trailing token to
                     // strip.
+                    // D-PY-1: pcall the kernel so a handler `error()` can't
+                    // leak a context-stack entry — pop, then re-raise. The
+                    // final `return` stays an inline expression (block
+                    // transformer strips a token after a bare `return`).
                     CodegenNode::NativeBlock {
                         code: format!(
-                            "local __e = {}.new(\"{}\", {})\nlocal __ctx = {}.new(__e, nil){}\nself._context_stack[#self._context_stack + 1] = __ctx\nself:__kernel(__e)\nreturn table.remove(self._context_stack)._return",
+                            "local __e = {}.new(\"{}\", {})\nlocal __ctx = {}.new(__e, nil){}\nself._context_stack[#self._context_stack + 1] = __ctx\nlocal __ok, __err = pcall(self.__kernel, self, __e)\nif not __ok then\n    self._context_stack[#self._context_stack] = nil\n    error(__err)\nend\nreturn table.remove(self._context_stack)._return",
                             event_class, method.name, params_code, context_class, default_init
                         ),
                         span: None,
@@ -806,7 +857,7 @@ return __result;"#,
                 } else {
                     CodegenNode::NativeBlock {
                         code: format!(
-                            "local __e = {}.new(\"{}\", {})\nlocal __ctx = {}.new(__e, nil){}\nself._context_stack[#self._context_stack + 1] = __ctx\nself:__kernel(__e)\nself._context_stack[#self._context_stack] = nil",
+                            "local __e = {}.new(\"{}\", {})\nlocal __ctx = {}.new(__e, nil){}\nself._context_stack[#self._context_stack + 1] = __ctx\nlocal __ok, __err = pcall(self.__kernel, self, __e)\nself._context_stack[#self._context_stack] = nil\nif not __ok then error(__err) end",
                             event_class, method.name, params_code, context_class, default_init
                         ),
                         span: None,
@@ -841,8 +892,9 @@ return __result;"#,
                         _ => "null",
                     };
                     CodegenNode::NativeBlock {
+                        // D-PY-1: pop on both paths so a throwing handler can't leak.
                         code: format!(
-                            "final __e = {}(\"{}\", {});\nfinal __ctx = {}(__e, {});{}\n_context_stack.add(__ctx);\n__kernel(__e);\nreturn _context_stack.removeLast()._return;",
+                            "final __e = {}(\"{}\", {});\nfinal __ctx = {}(__e, {});{}\n_context_stack.add(__ctx);\ntry {{\n    __kernel(__e);\n    return _context_stack.removeLast()._return;\n}} catch (__frame_err) {{\n    _context_stack.removeLast();\n    rethrow;\n}}",
                             event_class, method.name, params_code, context_class, dart_default, default_init
                         ),
                         span: None,
@@ -850,7 +902,7 @@ return __result;"#,
                 } else {
                     CodegenNode::NativeBlock {
                         code: format!(
-                            "final __e = {}(\"{}\", {});\nfinal __ctx = {}(__e, null);{}\n_context_stack.add(__ctx);\n__kernel(__e);\n_context_stack.removeLast();",
+                            "final __e = {}(\"{}\", {});\nfinal __ctx = {}(__e, null);{}\n_context_stack.add(__ctx);\ntry {{\n    __kernel(__e);\n}} finally {{\n    _context_stack.removeLast();\n}}",
                             event_class, method.name, params_code, context_class, default_init
                         ),
                         span: None,

--- a/framec/src/frame_c/compiler/frame_validator.rs
+++ b/framec/src/frame_c/compiler/frame_validator.rs
@@ -358,24 +358,67 @@ impl FrameValidator {
         }
 
         // E401: Validate no Frame statements in operations
-        // E421: @@:system.state not allowed in static operations
+        // E608: bare `@@:system.state` is reserved (RFC-0045); the name
+        //       accessor is `@@:system.state.name`.
+        // E421: `@@:system.state.name` not allowed in static operations.
+        //
+        // Operation bodies are raw native code (not scanned into Frame
+        // segments), so these are detected by text scan here rather than via
+        // the segment-kind checks that cover handler bodies.
+        //
+        // `@@:system.state` is reserved unless it is a complete token
+        // continued by `.name` (a word-bounded `.name` suffix).
+        fn has_reserved_system_state(code: &str) -> bool {
+            let needle = "@@:system.state";
+            let mut from = 0;
+            while let Some(rel) = code[from..].find(needle) {
+                let after = from + rel + needle.len();
+                let rest = &code[after..];
+                let state_is_token = rest
+                    .chars()
+                    .next()
+                    .map_or(true, |c| !c.is_ascii_alphanumeric() && c != '_');
+                let is_name = rest.starts_with(".name")
+                    && rest[5..]
+                        .chars()
+                        .next()
+                        .map_or(true, |c| !c.is_ascii_alphanumeric() && c != '_');
+                if state_is_token && !is_name {
+                    return true;
+                }
+                from = after;
+            }
+            false
+        }
+
         for operation in &system.operations {
             self.validate_operation_no_frame_statements(operation);
-            if operation.is_static {
-                if let Some(ref code) = operation.body.code {
-                    if code.contains("@@:system.state") {
-                        self.errors.push(
-                            ValidationError::new(
-                                "E421",
-                                format!(
-                                    "'@@:system.state' is not allowed in static operation '{}' in system '{}'. \
-                                     Static operations have no access to the system's compartment.",
-                                    operation.name, system.name
-                                ),
-                            )
-                            .with_span(operation.span.clone()),
-                        );
-                    }
+            if let Some(ref code) = operation.body.code {
+                if has_reserved_system_state(code) {
+                    self.errors.push(
+                        ValidationError::new(
+                            "E608",
+                            format!(
+                                "'@@:system.state' is reserved for future use in operation '{}' of system '{}'; \
+                                 use '@@:system.state.name' to read the current state name.",
+                                operation.name, system.name
+                            ),
+                        )
+                        .with_span(operation.span.clone()),
+                    );
+                }
+                if operation.is_static && code.contains("@@:system.state.name") {
+                    self.errors.push(
+                        ValidationError::new(
+                            "E421",
+                            format!(
+                                "'@@:system.state.name' is not allowed in static operation '{}' in system '{}'. \
+                                 Static operations have no access to the system's compartment.",
+                                operation.name, system.name
+                            ),
+                        )
+                        .with_span(operation.span.clone()),
+                    );
                 }
             }
         }
@@ -2494,5 +2537,97 @@ mod tests {
                 errs.iter().map(|e| &e.code).collect::<Vec<_>>()
             );
         }
+    }
+
+    // ===== RFC-0045: state-name relocation to `@@:system.state.name`,
+    //                 bare `@@:system.state` reserved (E608) =====
+
+    #[test]
+    fn test_e608_bare_system_state_in_handler() {
+        let source = r#"
+@@system R {
+    interface:
+        go()
+    machine:
+        $Active {
+            go() { let s = @@:system.state }
+        }
+}"#;
+        let codes = v4_codes(source);
+        assert!(
+            codes.iter().any(|c| c == "E608"),
+            "expected E608 for bare `@@:system.state` in a handler, got {:?}",
+            codes
+        );
+    }
+
+    #[test]
+    fn test_state_name_in_handler_accepted() {
+        let source = r#"
+@@system R {
+    interface:
+        go()
+    machine:
+        $Active {
+            go() { let s = @@:system.state.name }
+        }
+}"#;
+        let codes = v4_codes(source);
+        assert!(
+            !codes.iter().any(|c| c == "E608" || c == "E604"),
+            "`@@:system.state.name` should be accepted in a handler, got {:?}",
+            codes
+        );
+    }
+
+    #[test]
+    fn test_e608_bare_system_state_in_operation() {
+        let source = r#"
+@@system R {
+    operations:
+        peek() { let s = @@:system.state }
+    machine:
+        $Active { }
+}"#;
+        let codes = v4_codes(source);
+        assert!(
+            codes.iter().any(|c| c == "E608"),
+            "expected E608 for bare `@@:system.state` in an operation, got {:?}",
+            codes
+        );
+    }
+
+    #[test]
+    fn test_e421_state_name_in_static_operation() {
+        let source = r#"
+@@system R {
+    operations:
+        static peek() { let s = @@:system.state.name }
+    machine:
+        $Active { }
+}"#;
+        let codes = v4_codes(source);
+        assert!(
+            codes.iter().any(|c| c == "E421"),
+            "expected E421 for `@@:system.state.name` in a static operation, got {:?}",
+            codes
+        );
+    }
+
+    #[test]
+    fn test_state_name_in_nonstatic_operation_accepted() {
+        let source = r#"
+@@system R {
+    operations:
+        peek() { let s = @@:system.state.name }
+    machine:
+        $Active { }
+}"#;
+        let codes = v4_codes(source);
+        assert!(
+            !codes.iter().any(|c| c == "E608" || c == "E421"),
+            "`@@:system.state.name` in a non-static operation should be accepted, got {:?}",
+            codes
+        );
     }
 }

--- a/framec/src/frame_c/compiler/frame_validator/system_checks.rs
+++ b/framec/src/frame_c/compiler/frame_validator/system_checks.rs
@@ -286,12 +286,23 @@ impl FrameValidator {
                         ));
                     }
 
-                    // E604: bare @@:system without .state
+                    // E604: bare @@:system without a recognized member
                     FrameSegmentKind::ContextSystemBare => {
                         self.errors.push(ValidationError::new(
                             "E604",
                             format!(
-                                "bare `@@:system` in {}/{} — `@@:system` requires a member access (e.g. `@@:system.state`)",
+                                "bare `@@:system` in {}/{} — `@@:system` requires a member access (e.g. `@@:system.state.name`)",
+                                scope_outer, scope_inner
+                            ),
+                        ));
+                    }
+
+                    // E608: @@:system.state without .name — reserved (RFC-0045)
+                    FrameSegmentKind::ContextSystemStateReserved => {
+                        self.errors.push(ValidationError::new(
+                            "E608",
+                            format!(
+                                "`@@:system.state` in {}/{} is reserved for future use; use `@@:system.state.name` to read the current state name",
                                 scope_outer, scope_inner
                             ),
                         ));

--- a/framec/src/frame_c/compiler/native_region_scanner/context_parser.frs
+++ b/framec/src/frame_c/compiler/native_region_scanner/context_parser.frs
@@ -13,7 +13,8 @@
 //   @@:return(expr)    → ReturnCall (kind=9)
 //   @@:self.method()   → ContextSelfCall (kind=10)
 //   @@:self            → ContextSelf (kind=11)
-//   @@:system.state    → ContextSystemState (kind=12)
+//   @@:system.state.name → ContextSystemState (kind=12), current state name
+//   @@:system.state    → ContextSystemStateReserved (kind=14), reserved (RFC-0045) → E608
 //   other              → no match (has_result=false)
 //
 // For SystemInstantiation, the FSM sets `result_no_init = true` if the source
@@ -330,7 +331,9 @@ include!("expr_scanner.gen.rs");
 
         $ParseSystem {
             $>() {
-                // @@:system — currently only .state is supported
+                // @@:system — `.state.name` is the current-state name accessor.
+                // Bare `@@:system.state` is RESERVED for future use (RFC-0045)
+                // and rejected with E608; anything else is E604.
                 let i = self.pos;
                 let end = self.end;
                 let bytes = &self.bytes;
@@ -338,12 +341,23 @@ include!("expr_scanner.gen.rs");
                 if i + 5 < end && &bytes[i..i + 6] == b".state"
                     && (i + 6 >= end || !(bytes[i + 6].is_ascii_alphanumeric() || bytes[i + 6] == b'_'))
                 {
-                    // @@:system.state — read-only state name accessor
-                    self.result_end = i + 6;
-                    self.result_kind = 12; // ContextSystemState
-                    self.has_result = true;
+                    // Matched `.state` at a word boundary — now require `.name`.
+                    let j = i + 6;
+                    if j + 4 < end && &bytes[j..j + 5] == b".name"
+                        && (j + 5 >= end || !(bytes[j + 5].is_ascii_alphanumeric() || bytes[j + 5] == b'_'))
+                    {
+                        // @@:system.state.name — read-only state name accessor
+                        self.result_end = j + 5;
+                        self.result_kind = 12; // ContextSystemState
+                        self.has_result = true;
+                    } else {
+                        // @@:system.state (no `.name`) — reserved (RFC-0045) → E608
+                        self.result_end = j;
+                        self.result_kind = 14; // ContextSystemStateReserved
+                        self.has_result = true;
+                    }
                 } else {
-                    // Bare @@:system or unknown variant — emit for validation
+                    // Bare @@:system or unknown variant — emit for validation (E604)
                     self.result_end = i;
                     self.result_kind = 13; // ContextSystemBare
                     self.has_result = true;

--- a/framec/src/frame_c/compiler/native_region_scanner/context_parser.gen.rs
+++ b/framec/src/frame_c/compiler/native_region_scanner/context_parser.gen.rs
@@ -12,7 +12,8 @@
 //   @@:return(expr)    → ReturnCall (kind=9)
 //   @@:self.method()   → ContextSelfCall (kind=10)
 //   @@:self            → ContextSelf (kind=11)
-//   @@:system.state    → ContextSystemState (kind=12)
+//   @@:system.state.name → ContextSystemState (kind=12), current state name
+//   @@:system.state    → ContextSystemStateReserved (kind=14), reserved (RFC-0045) → E608
 //   other              → no match (has_result=false)
 //
 // For SystemInstantiation, the FSM sets `result_no_init = true` if the source
@@ -712,7 +713,9 @@ mod _context_parser_fsm_framec {
         }
 
         fn _s_ParseSystem_hdl_frame_enter(&mut self, __e: &ContextParserFsmFrameEvent) {
-            // @@:system — currently only .state is supported
+            // @@:system — `.state.name` is the current-state name accessor.
+            // Bare `@@:system.state` is RESERVED for future use (RFC-0045)
+            // and rejected with E608; anything else is E604.
             let i = self.pos;
             let end = self.end;
             let bytes = &self.bytes;
@@ -720,12 +723,23 @@ mod _context_parser_fsm_framec {
             if i + 5 < end && &bytes[i..i + 6] == b".state"
                 && (i + 6 >= end || !(bytes[i + 6].is_ascii_alphanumeric() || bytes[i + 6] == b'_'))
             {
-                // @@:system.state — read-only state name accessor
-                self.result_end = i + 6;
-                self.result_kind = 12; // ContextSystemState
-                self.has_result = true;
+                // Matched `.state` at a word boundary — now require `.name`.
+                let j = i + 6;
+                if j + 4 < end && &bytes[j..j + 5] == b".name"
+                    && (j + 5 >= end || !(bytes[j + 5].is_ascii_alphanumeric() || bytes[j + 5] == b'_'))
+                {
+                    // @@:system.state.name — read-only state name accessor
+                    self.result_end = j + 5;
+                    self.result_kind = 12; // ContextSystemState
+                    self.has_result = true;
+                } else {
+                    // @@:system.state (no `.name`) — reserved (RFC-0045) → E608
+                    self.result_end = j;
+                    self.result_kind = 14; // ContextSystemStateReserved
+                    self.has_result = true;
+                }
             } else {
-                // Bare @@:system or unknown variant — emit for validation
+                // Bare @@:system or unknown variant — emit for validation (E604)
                 self.result_end = i;
                 self.result_kind = 13; // ContextSystemBare
                 self.has_result = true;

--- a/framec/src/frame_c/compiler/native_region_scanner/mod.rs
+++ b/framec/src/frame_c/compiler/native_region_scanner/mod.rs
@@ -7,19 +7,20 @@ pub enum FrameSegmentKind {
     StateVar,       // $.varName (read access)
     StateVarAssign, // $.varName = expr (assignment)
     // System context syntax (@@)
-    ContextReturn,       // @@:return - return value slot (assignment or read)
-    ContextEvent,        // @@:event - interface event name
-    ContextData,         // @@:data[key] - call-scoped data (read)
-    ContextDataAssign,   // @@:data[key] = expr - call-scoped data (assignment)
-    ContextParams,       // @@:params[key] - explicit parameter access
-    ContextReturnExpr,   // @@:(expr) - set context return value (concise form)
-    SystemInstantiation, // @@SystemName() - validated system instantiation
-    ReturnCall,          // @@:return(expr) - set return value AND exit handler
-    ContextSelfCall,     // @@:self.method(args) - reentrant interface call
-    ContextSelf,         // @@:self - bare system instance reference
-    ContextSystemState,  // @@:system.state - current state name (read-only)
-    ContextSystemBare,   // @@:system without recognized member - error E604
-    ReturnStatement,     // return <expr>? - native return keyword in handler body
+    ContextReturn,              // @@:return - return value slot (assignment or read)
+    ContextEvent,               // @@:event - interface event name
+    ContextData,                // @@:data[key] - call-scoped data (read)
+    ContextDataAssign,          // @@:data[key] = expr - call-scoped data (assignment)
+    ContextParams,              // @@:params[key] - explicit parameter access
+    ContextReturnExpr,          // @@:(expr) - set context return value (concise form)
+    SystemInstantiation,        // @@SystemName() - validated system instantiation
+    ReturnCall,                 // @@:return(expr) - set return value AND exit handler
+    ContextSelfCall,            // @@:self.method(args) - reentrant interface call
+    ContextSelf,                // @@:self - bare system instance reference
+    ContextSystemState,         // @@:system.state.name - current state name (read-only)
+    ContextSystemBare,          // @@:system without recognized member - error E604
+    ContextSystemStateReserved, // @@:system.state without .name - reserved (RFC-0045), error E608
+    ReturnStatement,            // return <expr>? - native return keyword in handler body
 }
 
 /// Structured content parsed from a Frame segment during scanning.
@@ -366,6 +367,12 @@ pub fn regions_to_statements(
                         stmts.push(Statement::ContextSystemState { span: seg_span });
                     }
                     FrameSegmentKind::ContextSystemBare => {
+                        stmts.push(Statement::NativeCode(raw()));
+                    }
+                    FrameSegmentKind::ContextSystemStateReserved => {
+                        // Reserved (RFC-0045) — validation rejects it with E608
+                        // before codegen; emit as native so nothing leaks if a
+                        // caller skips validation.
                         stmts.push(Statement::NativeCode(raw()));
                     }
                     FrameSegmentKind::ReturnStatement => {

--- a/framec/src/frame_c/compiler/native_region_scanner/unified.rs
+++ b/framec/src/frame_c/compiler/native_region_scanner/unified.rs
@@ -567,6 +567,7 @@ pub fn scan_native_regions<S: SyntaxSkipper>(
                         11 => FrameSegmentKind::ContextSelf,
                         12 => FrameSegmentKind::ContextSystemState,
                         13 => FrameSegmentKind::ContextSystemBare,
+                        14 => FrameSegmentKind::ContextSystemStateReserved,
                         _ => FrameSegmentKind::ContextReturn, // shouldn't happen
                     };
                     let mut seg_end = parser.result_end;
@@ -1704,14 +1705,29 @@ mod tests {
     }
 
     #[test]
-    fn test_system_state_recognized() {
-        let kinds = scan_for_kinds("{ let s = @@:system.state; }");
+    fn test_system_state_name_recognized() {
+        // RFC-0045: the current-state name accessor is `@@:system.state.name`.
+        let kinds = scan_for_kinds("{ let s = @@:system.state.name; }");
         assert_eq!(kinds, vec![FrameSegmentKind::ContextSystemState]);
     }
 
     #[test]
+    fn test_bare_system_state_reserved() {
+        // RFC-0045: bare `@@:system.state` (no `.name`) is reserved → E608.
+        let kinds = scan_for_kinds("{ let s = @@:system.state; }");
+        assert_eq!(kinds, vec![FrameSegmentKind::ContextSystemStateReserved]);
+    }
+
+    #[test]
+    fn test_system_state_dot_other_reserved() {
+        // `.state.<other>` is not the `.name` accessor → reserved → E608.
+        let kinds = scan_for_kinds("{ let s = @@:system.state.foo; }");
+        assert_eq!(kinds, vec![FrameSegmentKind::ContextSystemStateReserved]);
+    }
+
+    #[test]
     fn test_system_state_in_return_expr() {
-        let kinds = scan_for_kinds("{ @@:(@@:system.state) }");
+        let kinds = scan_for_kinds("{ @@:(@@:system.state.name) }");
         assert_eq!(kinds, vec![FrameSegmentKind::ContextReturnExpr]);
     }
 

--- a/framec/src/frame_c/compiler/native_region_scanner/unified/metadata.rs
+++ b/framec/src/frame_c/compiler/native_region_scanner/unified/metadata.rs
@@ -147,6 +147,7 @@ pub(super) fn extract_segment_metadata(kind: FrameSegmentKind, text: &str) -> Se
         FrameSegmentKind::ContextSelf
         | FrameSegmentKind::ContextSystemState
         | FrameSegmentKind::ContextSystemBare
+        | FrameSegmentKind::ContextSystemStateReserved
         | FrameSegmentKind::ContextEvent => {
             // These carry no variable content — the kind is sufficient
             SegmentMetadata::None

--- a/framec/tests/snapshots/cpp_snapshots__actions.snap
+++ b/framec/tests/snapshots/cpp_snapshots__actions.snap
@@ -1,6 +1,5 @@
 ---
 source: framec/tests/cpp_snapshots.rs
-assertion_line: 58
 expression: "compile_fixture(\"10_actions\", \"cpp\")"
 ---
 #include <string>
@@ -177,8 +176,13 @@ public:
         ActionsFrameEvent __e("increment", std::vector<std::any>{n});
         ActionsFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        _context_stack.pop_back();
+        try {
+            __kernel(_context_stack.back()._event);
+            _context_stack.pop_back();
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 
@@ -186,10 +190,15 @@ public:
         ActionsFrameEvent __e("get_total");
         ActionsFrameContext __ctx(std::move(__e), std::any(int()));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
-        _context_stack.pop_back();
-        return __result;
+        try {
+            __kernel(_context_stack.back()._event);
+            auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
+            _context_stack.pop_back();
+            return __result;
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 };

--- a/framec/tests/snapshots/cpp_snapshots__consts.snap
+++ b/framec/tests/snapshots/cpp_snapshots__consts.snap
@@ -1,6 +1,5 @@
 ---
 source: framec/tests/cpp_snapshots.rs
-assertion_line: 63
 expression: "compile_fixture(\"11_consts\", \"cpp\")"
 ---
 #include <string>
@@ -178,8 +177,13 @@ public:
         ConstsFrameEvent __e("tick");
         ConstsFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        _context_stack.pop_back();
+        try {
+            __kernel(_context_stack.back()._event);
+            _context_stack.pop_back();
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 
@@ -187,10 +191,15 @@ public:
         ConstsFrameEvent __e("get_count");
         ConstsFrameContext __ctx(std::move(__e), std::any(int()));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
-        _context_stack.pop_back();
-        return __result;
+        try {
+            __kernel(_context_stack.back()._event);
+            auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
+            _context_stack.pop_back();
+            return __result;
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 };

--- a/framec/tests/snapshots/cpp_snapshots__forward.snap
+++ b/framec/tests/snapshots/cpp_snapshots__forward.snap
@@ -1,6 +1,5 @@
 ---
 source: framec/tests/cpp_snapshots.rs
-assertion_line: 43
 expression: "compile_fixture(\"07_forward\", \"cpp\")"
 ---
 #include <string>
@@ -210,8 +209,13 @@ public:
         ForwardFrameEvent __e("run");
         ForwardFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        _context_stack.pop_back();
+        try {
+            __kernel(_context_stack.back()._event);
+            _context_stack.pop_back();
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 
@@ -219,8 +223,13 @@ public:
         ForwardFrameEvent __e("finish");
         ForwardFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        _context_stack.pop_back();
+        try {
+            __kernel(_context_stack.back()._event);
+            _context_stack.pop_back();
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 };

--- a/framec/tests/snapshots/cpp_snapshots__hsm.snap
+++ b/framec/tests/snapshots/cpp_snapshots__hsm.snap
@@ -1,6 +1,5 @@
 ---
 source: framec/tests/cpp_snapshots.rs
-assertion_line: 18
 expression: "compile_fixture(\"02_hsm\", \"cpp\")"
 ---
 #include <string>
@@ -245,8 +244,13 @@ public:
         MiniHsmFrameEvent __e("wake");
         MiniHsmFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        _context_stack.pop_back();
+        try {
+            __kernel(_context_stack.back()._event);
+            _context_stack.pop_back();
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 
@@ -254,8 +258,13 @@ public:
         MiniHsmFrameEvent __e("sleep");
         MiniHsmFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        _context_stack.pop_back();
+        try {
+            __kernel(_context_stack.back()._event);
+            _context_stack.pop_back();
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 
@@ -263,8 +272,13 @@ public:
         MiniHsmFrameEvent __e("signal");
         MiniHsmFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        _context_stack.pop_back();
+        try {
+            __kernel(_context_stack.back()._event);
+            _context_stack.pop_back();
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 };

--- a/framec/tests/snapshots/cpp_snapshots__lifecycle.snap
+++ b/framec/tests/snapshots/cpp_snapshots__lifecycle.snap
@@ -1,6 +1,5 @@
 ---
 source: framec/tests/cpp_snapshots.rs
-assertion_line: 48
 expression: "compile_fixture(\"08_lifecycle\", \"cpp\")"
 ---
 #include <string>
@@ -206,8 +205,13 @@ public:
         LifecycleFrameEvent __e("start", std::vector<std::any>{label});
         LifecycleFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        _context_stack.pop_back();
+        try {
+            __kernel(_context_stack.back()._event);
+            _context_stack.pop_back();
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 
@@ -215,8 +219,13 @@ public:
         LifecycleFrameEvent __e("stop");
         LifecycleFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        _context_stack.pop_back();
+        try {
+            __kernel(_context_stack.back()._event);
+            _context_stack.pop_back();
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 };

--- a/framec/tests/snapshots/cpp_snapshots__lifecycle_args.snap
+++ b/framec/tests/snapshots/cpp_snapshots__lifecycle_args.snap
@@ -1,6 +1,5 @@
 ---
 source: framec/tests/cpp_snapshots.rs
-assertion_line: 73
 expression: "compile_fixture(\"13_lifecycle_args\", \"cpp\")"
 ---
 #include <string>
@@ -206,8 +205,13 @@ public:
         LifecycleArgsFrameEvent __e("load", std::vector<std::any>{n, label});
         LifecycleArgsFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        _context_stack.pop_back();
+        try {
+            __kernel(_context_stack.back()._event);
+            _context_stack.pop_back();
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 
@@ -215,10 +219,15 @@ public:
         LifecycleArgsFrameEvent __e("total");
         LifecycleArgsFrameContext __ctx(std::move(__e), std::any(int()));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
-        _context_stack.pop_back();
-        return __result;
+        try {
+            __kernel(_context_stack.back()._event);
+            auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
+            _context_stack.pop_back();
+            return __result;
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 
@@ -226,10 +235,15 @@ public:
         LifecycleArgsFrameEvent __e("tag");
         LifecycleArgsFrameContext __ctx(std::move(__e), std::any(std::string()));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        auto __result = std::any_cast<std::string>(std::move(_context_stack.back()._return));
-        _context_stack.pop_back();
-        return __result;
+        try {
+            __kernel(_context_stack.back()._event);
+            auto __result = std::any_cast<std::string>(std::move(_context_stack.back()._return));
+            _context_stack.pop_back();
+            return __result;
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 };

--- a/framec/tests/snapshots/cpp_snapshots__linear_fsm.snap
+++ b/framec/tests/snapshots/cpp_snapshots__linear_fsm.snap
@@ -1,6 +1,5 @@
 ---
 source: framec/tests/cpp_snapshots.rs
-assertion_line: 13
 expression: "compile_fixture(\"01_linear_fsm\", \"cpp\")"
 ---
 #include <string>
@@ -200,8 +199,13 @@ public:
         LinearFsmFrameEvent __e("start");
         LinearFsmFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        _context_stack.pop_back();
+        try {
+            __kernel(_context_stack.back()._event);
+            _context_stack.pop_back();
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 
@@ -209,8 +213,13 @@ public:
         LinearFsmFrameEvent __e("progress", std::vector<std::any>{amount});
         LinearFsmFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        _context_stack.pop_back();
+        try {
+            __kernel(_context_stack.back()._event);
+            _context_stack.pop_back();
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 
@@ -218,8 +227,13 @@ public:
         LinearFsmFrameEvent __e("finish");
         LinearFsmFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        _context_stack.pop_back();
+        try {
+            __kernel(_context_stack.back()._event);
+            _context_stack.pop_back();
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 };

--- a/framec/tests/snapshots/cpp_snapshots__no_persist.snap
+++ b/framec/tests/snapshots/cpp_snapshots__no_persist.snap
@@ -1,6 +1,5 @@
 ---
 source: framec/tests/cpp_snapshots.rs
-assertion_line: 68
 expression: "compile_fixture(\"12_no_persist\", \"cpp\")"
 ---
 #include <string>
@@ -191,8 +190,13 @@ public:
         NoPersistFrameEvent __e("bump");
         NoPersistFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        _context_stack.pop_back();
+        try {
+            __kernel(_context_stack.back()._event);
+            _context_stack.pop_back();
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 
@@ -200,8 +204,13 @@ public:
         NoPersistFrameEvent __e("set_cache", std::vector<std::any>{v});
         NoPersistFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        _context_stack.pop_back();
+        try {
+            __kernel(_context_stack.back()._event);
+            _context_stack.pop_back();
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 
@@ -209,10 +218,15 @@ public:
         NoPersistFrameEvent __e("get_count");
         NoPersistFrameContext __ctx(std::move(__e), std::any(int()));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
-        _context_stack.pop_back();
-        return __result;
+        try {
+            __kernel(_context_stack.back()._event);
+            auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
+            _context_stack.pop_back();
+            return __result;
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 
@@ -220,10 +234,15 @@ public:
         NoPersistFrameEvent __e("get_cache");
         NoPersistFrameContext __ctx(std::move(__e), std::any(int()));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
-        _context_stack.pop_back();
-        return __result;
+        try {
+            __kernel(_context_stack.back()._event);
+            auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
+            _context_stack.pop_back();
+            return __result;
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 

--- a/framec/tests/snapshots/cpp_snapshots__persist.snap
+++ b/framec/tests/snapshots/cpp_snapshots__persist.snap
@@ -1,6 +1,5 @@
 ---
 source: framec/tests/cpp_snapshots.rs
-assertion_line: 23
 expression: "compile_fixture(\"03_persist\", \"cpp\")"
 ---
 #include <string>
@@ -172,8 +171,13 @@ public:
         CounterFrameEvent __e("increment", std::vector<std::any>{by});
         CounterFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        _context_stack.pop_back();
+        try {
+            __kernel(_context_stack.back()._event);
+            _context_stack.pop_back();
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 
@@ -181,10 +185,15 @@ public:
         CounterFrameEvent __e("value");
         CounterFrameContext __ctx(std::move(__e), std::any(0));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
-        _context_stack.pop_back();
-        return __result;
+        try {
+            __kernel(_context_stack.back()._event);
+            auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
+            _context_stack.pop_back();
+            return __result;
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 

--- a/framec/tests/snapshots/cpp_snapshots__pushpop.snap
+++ b/framec/tests/snapshots/cpp_snapshots__pushpop.snap
@@ -1,6 +1,5 @@
 ---
 source: framec/tests/cpp_snapshots.rs
-assertion_line: 33
 expression: "compile_fixture(\"05_pushpop\", \"cpp\")"
 ---
 #include <string>
@@ -202,8 +201,13 @@ public:
         PushPopFrameEvent __e("ping");
         PushPopFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        _context_stack.pop_back();
+        try {
+            __kernel(_context_stack.back()._event);
+            _context_stack.pop_back();
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 
@@ -211,8 +215,13 @@ public:
         PushPopFrameEvent __e("nest");
         PushPopFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        _context_stack.pop_back();
+        try {
+            __kernel(_context_stack.back()._event);
+            _context_stack.pop_back();
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 
@@ -220,8 +229,13 @@ public:
         PushPopFrameEvent __e("unnest");
         PushPopFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        _context_stack.pop_back();
+        try {
+            __kernel(_context_stack.back()._event);
+            _context_stack.pop_back();
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 
@@ -229,8 +243,13 @@ public:
         PushPopFrameEvent __e("leaf");
         PushPopFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        _context_stack.pop_back();
+        try {
+            __kernel(_context_stack.back()._event);
+            _context_stack.pop_back();
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 };

--- a/framec/tests/snapshots/cpp_snapshots__return_explicit.snap
+++ b/framec/tests/snapshots/cpp_snapshots__return_explicit.snap
@@ -1,6 +1,5 @@
 ---
 source: framec/tests/cpp_snapshots.rs
-assertion_line: 53
 expression: "compile_fixture(\"09_return_explicit\", \"cpp\")"
 ---
 #include <string>
@@ -166,10 +165,15 @@ public:
         ReturnExplicitFrameEvent __e("decide", std::vector<std::any>{score});
         ReturnExplicitFrameContext __ctx(std::move(__e), std::any(std::string()));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        auto __result = std::any_cast<std::string>(std::move(_context_stack.back()._return));
-        _context_stack.pop_back();
-        return __result;
+        try {
+            __kernel(_context_stack.back()._event);
+            auto __result = std::any_cast<std::string>(std::move(_context_stack.back()._return));
+            _context_stack.pop_back();
+            return __result;
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 };

--- a/framec/tests/snapshots/cpp_snapshots__selfcall.snap
+++ b/framec/tests/snapshots/cpp_snapshots__selfcall.snap
@@ -1,6 +1,5 @@
 ---
 source: framec/tests/cpp_snapshots.rs
-assertion_line: 38
 expression: "compile_fixture(\"06_selfcall\", \"cpp\")"
 ---
 #include <string>
@@ -173,8 +172,13 @@ public:
         SelfCallFrameEvent __e("kick");
         SelfCallFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        _context_stack.pop_back();
+        try {
+            __kernel(_context_stack.back()._event);
+            _context_stack.pop_back();
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 
@@ -182,10 +186,15 @@ public:
         SelfCallFrameEvent __e("report");
         SelfCallFrameContext __ctx(std::move(__e), std::any(int()));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
-        _context_stack.pop_back();
-        return __result;
+        try {
+            __kernel(_context_stack.back()._event);
+            auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
+            _context_stack.pop_back();
+            return __result;
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 };

--- a/framec/tests/snapshots/cpp_snapshots__state_args.snap
+++ b/framec/tests/snapshots/cpp_snapshots__state_args.snap
@@ -1,6 +1,5 @@
 ---
 source: framec/tests/cpp_snapshots.rs
-assertion_line: 28
 expression: "compile_fixture(\"04_state_args\", \"cpp\")"
 ---
 #include <string>
@@ -194,8 +193,13 @@ public:
         StateArgsFrameEvent __e("load", std::vector<std::any>{initial});
         StateArgsFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        _context_stack.pop_back();
+        try {
+            __kernel(_context_stack.back()._event);
+            _context_stack.pop_back();
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 
@@ -203,8 +207,13 @@ public:
         StateArgsFrameEvent __e("adjust", std::vector<std::any>{delta});
         StateArgsFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        _context_stack.pop_back();
+        try {
+            __kernel(_context_stack.back()._event);
+            _context_stack.pop_back();
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 
@@ -212,10 +221,15 @@ public:
         StateArgsFrameEvent __e("peek");
         StateArgsFrameContext __ctx(std::move(__e), std::any(int()));
         _context_stack.push_back(std::move(__ctx));
-        __kernel(_context_stack.back()._event);
-        auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
-        _context_stack.pop_back();
-        return __result;
+        try {
+            __kernel(_context_stack.back()._event);
+            auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
+            _context_stack.pop_back();
+            return __result;
+        } catch (...) {
+            _context_stack.pop_back();
+            throw;
+        }
 
     }
 };

--- a/framec/tests/snapshots/csharp_snapshots__actions.snap
+++ b/framec/tests/snapshots/csharp_snapshots__actions.snap
@@ -169,18 +169,28 @@ public class Actions {
         ActionsFrameEvent __e = new ActionsFrameEvent("increment", new List<object> { n });
         ActionsFrameContext __ctx = new ActionsFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        _context_stack.RemoveAt(_context_stack.Count - 1);
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     public int get_total() {
         ActionsFrameEvent __e = new ActionsFrameEvent("get_total", new List<object>());
         ActionsFrameContext __ctx = new ActionsFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        var __result = (int) _context_stack[_context_stack.Count - 1]._return;
-        _context_stack.RemoveAt(_context_stack.Count - 1);
-        return __result;
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            var __result = (int) _context_stack[_context_stack.Count - 1]._return;
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            return __result;
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     private void _state_Counting(ActionsFrameEvent __e, ActionsCompartment compartment) {

--- a/framec/tests/snapshots/csharp_snapshots__consts.snap
+++ b/framec/tests/snapshots/csharp_snapshots__consts.snap
@@ -173,18 +173,28 @@ public class Consts {
         ConstsFrameEvent __e = new ConstsFrameEvent("tick", new List<object>());
         ConstsFrameContext __ctx = new ConstsFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        _context_stack.RemoveAt(_context_stack.Count - 1);
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     public int get_count() {
         ConstsFrameEvent __e = new ConstsFrameEvent("get_count", new List<object>());
         ConstsFrameContext __ctx = new ConstsFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        var __result = (int) _context_stack[_context_stack.Count - 1]._return;
-        _context_stack.RemoveAt(_context_stack.Count - 1);
-        return __result;
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            var __result = (int) _context_stack[_context_stack.Count - 1]._return;
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            return __result;
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     private void _state_Running(ConstsFrameEvent __e, ConstsCompartment compartment) {

--- a/framec/tests/snapshots/csharp_snapshots__forward.snap
+++ b/framec/tests/snapshots/csharp_snapshots__forward.snap
@@ -176,16 +176,26 @@ public class Forward {
         ForwardFrameEvent __e = new ForwardFrameEvent("run", new List<object>());
         ForwardFrameContext __ctx = new ForwardFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        _context_stack.RemoveAt(_context_stack.Count - 1);
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     public void finish() {
         ForwardFrameEvent __e = new ForwardFrameEvent("finish", new List<object>());
         ForwardFrameContext __ctx = new ForwardFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        _context_stack.RemoveAt(_context_stack.Count - 1);
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     private void _state_Start(ForwardFrameEvent __e, ForwardCompartment compartment) {

--- a/framec/tests/snapshots/csharp_snapshots__hsm.snap
+++ b/framec/tests/snapshots/csharp_snapshots__hsm.snap
@@ -177,24 +177,39 @@ public class MiniHsm {
         MiniHsmFrameEvent __e = new MiniHsmFrameEvent("wake", new List<object>());
         MiniHsmFrameContext __ctx = new MiniHsmFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        _context_stack.RemoveAt(_context_stack.Count - 1);
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     public void sleep() {
         MiniHsmFrameEvent __e = new MiniHsmFrameEvent("sleep", new List<object>());
         MiniHsmFrameContext __ctx = new MiniHsmFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        _context_stack.RemoveAt(_context_stack.Count - 1);
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     public void signal() {
         MiniHsmFrameEvent __e = new MiniHsmFrameEvent("signal", new List<object>());
         MiniHsmFrameContext __ctx = new MiniHsmFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        _context_stack.RemoveAt(_context_stack.Count - 1);
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     private void _state_Live(MiniHsmFrameEvent __e, MiniHsmCompartment compartment) {

--- a/framec/tests/snapshots/csharp_snapshots__lifecycle.snap
+++ b/framec/tests/snapshots/csharp_snapshots__lifecycle.snap
@@ -174,16 +174,26 @@ public class Lifecycle {
         LifecycleFrameEvent __e = new LifecycleFrameEvent("start", new List<object> { label });
         LifecycleFrameContext __ctx = new LifecycleFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        _context_stack.RemoveAt(_context_stack.Count - 1);
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     public void stop() {
         LifecycleFrameEvent __e = new LifecycleFrameEvent("stop", new List<object>());
         LifecycleFrameContext __ctx = new LifecycleFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        _context_stack.RemoveAt(_context_stack.Count - 1);
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     private void _state_Idle(LifecycleFrameEvent __e, LifecycleCompartment compartment) {

--- a/framec/tests/snapshots/csharp_snapshots__lifecycle_args.snap
+++ b/framec/tests/snapshots/csharp_snapshots__lifecycle_args.snap
@@ -173,28 +173,43 @@ public class LifecycleArgs {
         LifecycleArgsFrameEvent __e = new LifecycleArgsFrameEvent("load", new List<object> { n, label });
         LifecycleArgsFrameContext __ctx = new LifecycleArgsFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        _context_stack.RemoveAt(_context_stack.Count - 1);
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     public int total() {
         LifecycleArgsFrameEvent __e = new LifecycleArgsFrameEvent("total", new List<object>());
         LifecycleArgsFrameContext __ctx = new LifecycleArgsFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        var __result = (int) _context_stack[_context_stack.Count - 1]._return;
-        _context_stack.RemoveAt(_context_stack.Count - 1);
-        return __result;
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            var __result = (int) _context_stack[_context_stack.Count - 1]._return;
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            return __result;
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     public string tag() {
         LifecycleArgsFrameEvent __e = new LifecycleArgsFrameEvent("tag", new List<object>());
         LifecycleArgsFrameContext __ctx = new LifecycleArgsFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        var __result = (string) _context_stack[_context_stack.Count - 1]._return;
-        _context_stack.RemoveAt(_context_stack.Count - 1);
-        return __result;
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            var __result = (string) _context_stack[_context_stack.Count - 1]._return;
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            return __result;
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     private void _state_Idle(LifecycleArgsFrameEvent __e, LifecycleArgsCompartment compartment) {

--- a/framec/tests/snapshots/csharp_snapshots__linear_fsm.snap
+++ b/framec/tests/snapshots/csharp_snapshots__linear_fsm.snap
@@ -175,24 +175,39 @@ public class LinearFsm {
         LinearFsmFrameEvent __e = new LinearFsmFrameEvent("start", new List<object>());
         LinearFsmFrameContext __ctx = new LinearFsmFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        _context_stack.RemoveAt(_context_stack.Count - 1);
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     public void progress(int amount) {
         LinearFsmFrameEvent __e = new LinearFsmFrameEvent("progress", new List<object> { amount });
         LinearFsmFrameContext __ctx = new LinearFsmFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        _context_stack.RemoveAt(_context_stack.Count - 1);
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     public void finish() {
         LinearFsmFrameEvent __e = new LinearFsmFrameEvent("finish", new List<object>());
         LinearFsmFrameContext __ctx = new LinearFsmFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        _context_stack.RemoveAt(_context_stack.Count - 1);
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     private void _state_Idle(LinearFsmFrameEvent __e, LinearFsmCompartment compartment) {

--- a/framec/tests/snapshots/csharp_snapshots__no_persist.snap
+++ b/framec/tests/snapshots/csharp_snapshots__no_persist.snap
@@ -170,36 +170,56 @@ public class NoPersist {
         NoPersistFrameEvent __e = new NoPersistFrameEvent("bump", new List<object>());
         NoPersistFrameContext __ctx = new NoPersistFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        _context_stack.RemoveAt(_context_stack.Count - 1);
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     public void set_cache(int v) {
         NoPersistFrameEvent __e = new NoPersistFrameEvent("set_cache", new List<object> { v });
         NoPersistFrameContext __ctx = new NoPersistFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        _context_stack.RemoveAt(_context_stack.Count - 1);
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     public int get_count() {
         NoPersistFrameEvent __e = new NoPersistFrameEvent("get_count", new List<object>());
         NoPersistFrameContext __ctx = new NoPersistFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        var __result = (int) _context_stack[_context_stack.Count - 1]._return;
-        _context_stack.RemoveAt(_context_stack.Count - 1);
-        return __result;
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            var __result = (int) _context_stack[_context_stack.Count - 1]._return;
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            return __result;
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     public int get_cache() {
         NoPersistFrameEvent __e = new NoPersistFrameEvent("get_cache", new List<object>());
         NoPersistFrameContext __ctx = new NoPersistFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        var __result = (int) _context_stack[_context_stack.Count - 1]._return;
-        _context_stack.RemoveAt(_context_stack.Count - 1);
-        return __result;
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            var __result = (int) _context_stack[_context_stack.Count - 1]._return;
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            return __result;
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     private void _state_Active(NoPersistFrameEvent __e, NoPersistCompartment compartment) {

--- a/framec/tests/snapshots/csharp_snapshots__persist.snap
+++ b/framec/tests/snapshots/csharp_snapshots__persist.snap
@@ -169,18 +169,28 @@ public class Counter {
         CounterFrameEvent __e = new CounterFrameEvent("increment", new List<object> { by });
         CounterFrameContext __ctx = new CounterFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        _context_stack.RemoveAt(_context_stack.Count - 1);
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     public int value() {
         CounterFrameEvent __e = new CounterFrameEvent("value", new List<object>());
         CounterFrameContext __ctx = new CounterFrameContext(__e, 0);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        var __result = (int) _context_stack[_context_stack.Count - 1]._return;
-        _context_stack.RemoveAt(_context_stack.Count - 1);
-        return __result;
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            var __result = (int) _context_stack[_context_stack.Count - 1]._return;
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            return __result;
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     private void _state_Counting(CounterFrameEvent __e, CounterCompartment compartment) {

--- a/framec/tests/snapshots/csharp_snapshots__pushpop.snap
+++ b/framec/tests/snapshots/csharp_snapshots__pushpop.snap
@@ -173,32 +173,52 @@ public class PushPop {
         PushPopFrameEvent __e = new PushPopFrameEvent("ping", new List<object>());
         PushPopFrameContext __ctx = new PushPopFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        _context_stack.RemoveAt(_context_stack.Count - 1);
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     public void nest() {
         PushPopFrameEvent __e = new PushPopFrameEvent("nest", new List<object>());
         PushPopFrameContext __ctx = new PushPopFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        _context_stack.RemoveAt(_context_stack.Count - 1);
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     public void unnest() {
         PushPopFrameEvent __e = new PushPopFrameEvent("unnest", new List<object>());
         PushPopFrameContext __ctx = new PushPopFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        _context_stack.RemoveAt(_context_stack.Count - 1);
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     public void leaf() {
         PushPopFrameEvent __e = new PushPopFrameEvent("leaf", new List<object>());
         PushPopFrameContext __ctx = new PushPopFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        _context_stack.RemoveAt(_context_stack.Count - 1);
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     private void _state_Idle(PushPopFrameEvent __e, PushPopCompartment compartment) {

--- a/framec/tests/snapshots/csharp_snapshots__return_explicit.snap
+++ b/framec/tests/snapshots/csharp_snapshots__return_explicit.snap
@@ -168,10 +168,15 @@ public class ReturnExplicit {
         ReturnExplicitFrameEvent __e = new ReturnExplicitFrameEvent("decide", new List<object> { score });
         ReturnExplicitFrameContext __ctx = new ReturnExplicitFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        var __result = (string) _context_stack[_context_stack.Count - 1]._return;
-        _context_stack.RemoveAt(_context_stack.Count - 1);
-        return __result;
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            var __result = (string) _context_stack[_context_stack.Count - 1]._return;
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            return __result;
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     private void _state_Judging(ReturnExplicitFrameEvent __e, ReturnExplicitCompartment compartment) {

--- a/framec/tests/snapshots/csharp_snapshots__selfcall.snap
+++ b/framec/tests/snapshots/csharp_snapshots__selfcall.snap
@@ -169,18 +169,28 @@ public class SelfCall {
         SelfCallFrameEvent __e = new SelfCallFrameEvent("kick", new List<object>());
         SelfCallFrameContext __ctx = new SelfCallFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        _context_stack.RemoveAt(_context_stack.Count - 1);
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     public int report() {
         SelfCallFrameEvent __e = new SelfCallFrameEvent("report", new List<object>());
         SelfCallFrameContext __ctx = new SelfCallFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        var __result = (int) _context_stack[_context_stack.Count - 1]._return;
-        _context_stack.RemoveAt(_context_stack.Count - 1);
-        return __result;
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            var __result = (int) _context_stack[_context_stack.Count - 1]._return;
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            return __result;
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     private void _state_Active(SelfCallFrameEvent __e, SelfCallCompartment compartment) {

--- a/framec/tests/snapshots/csharp_snapshots__state_args.snap
+++ b/framec/tests/snapshots/csharp_snapshots__state_args.snap
@@ -171,26 +171,41 @@ public class StateArgs {
         StateArgsFrameEvent __e = new StateArgsFrameEvent("load", new List<object> { initial });
         StateArgsFrameContext __ctx = new StateArgsFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        _context_stack.RemoveAt(_context_stack.Count - 1);
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     public void adjust(int delta) {
         StateArgsFrameEvent __e = new StateArgsFrameEvent("adjust", new List<object> { delta });
         StateArgsFrameContext __ctx = new StateArgsFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        _context_stack.RemoveAt(_context_stack.Count - 1);
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     public int peek() {
         StateArgsFrameEvent __e = new StateArgsFrameEvent("peek", new List<object>());
         StateArgsFrameContext __ctx = new StateArgsFrameContext(__e, null);
         _context_stack.Add(__ctx);
-        __kernel(_context_stack[_context_stack.Count - 1]._event);
-        var __result = (int) _context_stack[_context_stack.Count - 1]._return;
-        _context_stack.RemoveAt(_context_stack.Count - 1);
-        return __result;
+        try {
+            __kernel(_context_stack[_context_stack.Count - 1]._event);
+            var __result = (int) _context_stack[_context_stack.Count - 1]._return;
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            return __result;
+        } catch {
+            _context_stack.RemoveAt(_context_stack.Count - 1);
+            throw;
+        }
     }
 
     private void _state_Idle(StateArgsFrameEvent __e, StateArgsCompartment compartment) {

--- a/framec/tests/snapshots/dart_snapshots__actions.snap
+++ b/framec/tests/snapshots/dart_snapshots__actions.snap
@@ -164,16 +164,24 @@ class Actions {
         final __e = ActionsFrameEvent("increment", [n]);
         final __ctx = ActionsFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        _context_stack.removeLast();
+        try {
+            __kernel(__e);
+        } finally {
+            _context_stack.removeLast();
+        }
     }
 
     int get_total() {
         final __e = ActionsFrameEvent("get_total", []);
         final __ctx = ActionsFrameContext(__e, 0);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        return _context_stack.removeLast()._return;
+        try {
+            __kernel(__e);
+            return _context_stack.removeLast()._return;
+        } catch (__frame_err) {
+            _context_stack.removeLast();
+            rethrow;
+        }
     }
 
     void _state_Counting(ActionsFrameEvent __e, ActionsCompartment compartment) {

--- a/framec/tests/snapshots/dart_snapshots__consts.snap
+++ b/framec/tests/snapshots/dart_snapshots__consts.snap
@@ -168,16 +168,24 @@ class Consts {
         final __e = ConstsFrameEvent("tick", []);
         final __ctx = ConstsFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        _context_stack.removeLast();
+        try {
+            __kernel(__e);
+        } finally {
+            _context_stack.removeLast();
+        }
     }
 
     int get_count() {
         final __e = ConstsFrameEvent("get_count", []);
         final __ctx = ConstsFrameContext(__e, 0);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        return _context_stack.removeLast()._return;
+        try {
+            __kernel(__e);
+            return _context_stack.removeLast()._return;
+        } catch (__frame_err) {
+            _context_stack.removeLast();
+            rethrow;
+        }
     }
 
     void _state_Running(ConstsFrameEvent __e, ConstsCompartment compartment) {

--- a/framec/tests/snapshots/dart_snapshots__forward.snap
+++ b/framec/tests/snapshots/dart_snapshots__forward.snap
@@ -173,16 +173,22 @@ class Forward {
         final __e = ForwardFrameEvent("run", []);
         final __ctx = ForwardFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        _context_stack.removeLast();
+        try {
+            __kernel(__e);
+        } finally {
+            _context_stack.removeLast();
+        }
     }
 
     void finish() {
         final __e = ForwardFrameEvent("finish", []);
         final __ctx = ForwardFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        _context_stack.removeLast();
+        try {
+            __kernel(__e);
+        } finally {
+            _context_stack.removeLast();
+        }
     }
 
     void _state_Start(ForwardFrameEvent __e, ForwardCompartment compartment) {

--- a/framec/tests/snapshots/dart_snapshots__hsm.snap
+++ b/framec/tests/snapshots/dart_snapshots__hsm.snap
@@ -174,24 +174,33 @@ class MiniHsm {
         final __e = MiniHsmFrameEvent("wake", []);
         final __ctx = MiniHsmFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        _context_stack.removeLast();
+        try {
+            __kernel(__e);
+        } finally {
+            _context_stack.removeLast();
+        }
     }
 
     void sleep() {
         final __e = MiniHsmFrameEvent("sleep", []);
         final __ctx = MiniHsmFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        _context_stack.removeLast();
+        try {
+            __kernel(__e);
+        } finally {
+            _context_stack.removeLast();
+        }
     }
 
     void signal() {
         final __e = MiniHsmFrameEvent("signal", []);
         final __ctx = MiniHsmFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        _context_stack.removeLast();
+        try {
+            __kernel(__e);
+        } finally {
+            _context_stack.removeLast();
+        }
     }
 
     void _state_Live(MiniHsmFrameEvent __e, MiniHsmCompartment compartment) {

--- a/framec/tests/snapshots/dart_snapshots__lifecycle.snap
+++ b/framec/tests/snapshots/dart_snapshots__lifecycle.snap
@@ -170,16 +170,22 @@ class Lifecycle {
         final __e = LifecycleFrameEvent("start", [label]);
         final __ctx = LifecycleFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        _context_stack.removeLast();
+        try {
+            __kernel(__e);
+        } finally {
+            _context_stack.removeLast();
+        }
     }
 
     void stop() {
         final __e = LifecycleFrameEvent("stop", []);
         final __ctx = LifecycleFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        _context_stack.removeLast();
+        try {
+            __kernel(__e);
+        } finally {
+            _context_stack.removeLast();
+        }
     }
 
     void _state_Idle(LifecycleFrameEvent __e, LifecycleCompartment compartment) {

--- a/framec/tests/snapshots/dart_snapshots__lifecycle_args.snap
+++ b/framec/tests/snapshots/dart_snapshots__lifecycle_args.snap
@@ -169,24 +169,37 @@ class LifecycleArgs {
         final __e = LifecycleArgsFrameEvent("load", [n, label]);
         final __ctx = LifecycleArgsFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        _context_stack.removeLast();
+        try {
+            __kernel(__e);
+        } finally {
+            _context_stack.removeLast();
+        }
     }
 
     int total() {
         final __e = LifecycleArgsFrameEvent("total", []);
         final __ctx = LifecycleArgsFrameContext(__e, 0);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        return _context_stack.removeLast()._return;
+        try {
+            __kernel(__e);
+            return _context_stack.removeLast()._return;
+        } catch (__frame_err) {
+            _context_stack.removeLast();
+            rethrow;
+        }
     }
 
     String tag() {
         final __e = LifecycleArgsFrameEvent("tag", []);
         final __ctx = LifecycleArgsFrameContext(__e, '');
         _context_stack.add(__ctx);
-        __kernel(__e);
-        return _context_stack.removeLast()._return;
+        try {
+            __kernel(__e);
+            return _context_stack.removeLast()._return;
+        } catch (__frame_err) {
+            _context_stack.removeLast();
+            rethrow;
+        }
     }
 
     void _state_Idle(LifecycleArgsFrameEvent __e, LifecycleArgsCompartment compartment) {

--- a/framec/tests/snapshots/dart_snapshots__linear_fsm.snap
+++ b/framec/tests/snapshots/dart_snapshots__linear_fsm.snap
@@ -172,24 +172,33 @@ class LinearFsm {
         final __e = LinearFsmFrameEvent("start", []);
         final __ctx = LinearFsmFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        _context_stack.removeLast();
+        try {
+            __kernel(__e);
+        } finally {
+            _context_stack.removeLast();
+        }
     }
 
     void progress(int amount) {
         final __e = LinearFsmFrameEvent("progress", [amount]);
         final __ctx = LinearFsmFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        _context_stack.removeLast();
+        try {
+            __kernel(__e);
+        } finally {
+            _context_stack.removeLast();
+        }
     }
 
     void finish() {
         final __e = LinearFsmFrameEvent("finish", []);
         final __ctx = LinearFsmFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        _context_stack.removeLast();
+        try {
+            __kernel(__e);
+        } finally {
+            _context_stack.removeLast();
+        }
     }
 
     void _state_Idle(LinearFsmFrameEvent __e, LinearFsmCompartment compartment) {

--- a/framec/tests/snapshots/dart_snapshots__no_persist.snap
+++ b/framec/tests/snapshots/dart_snapshots__no_persist.snap
@@ -165,32 +165,48 @@ class NoPersist {
         final __e = NoPersistFrameEvent("bump", []);
         final __ctx = NoPersistFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        _context_stack.removeLast();
+        try {
+            __kernel(__e);
+        } finally {
+            _context_stack.removeLast();
+        }
     }
 
     void set_cache(int v) {
         final __e = NoPersistFrameEvent("set_cache", [v]);
         final __ctx = NoPersistFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        _context_stack.removeLast();
+        try {
+            __kernel(__e);
+        } finally {
+            _context_stack.removeLast();
+        }
     }
 
     int get_count() {
         final __e = NoPersistFrameEvent("get_count", []);
         final __ctx = NoPersistFrameContext(__e, 0);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        return _context_stack.removeLast()._return;
+        try {
+            __kernel(__e);
+            return _context_stack.removeLast()._return;
+        } catch (__frame_err) {
+            _context_stack.removeLast();
+            rethrow;
+        }
     }
 
     int get_cache() {
         final __e = NoPersistFrameEvent("get_cache", []);
         final __ctx = NoPersistFrameContext(__e, 0);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        return _context_stack.removeLast()._return;
+        try {
+            __kernel(__e);
+            return _context_stack.removeLast()._return;
+        } catch (__frame_err) {
+            _context_stack.removeLast();
+            rethrow;
+        }
     }
 
     void _state_Active(NoPersistFrameEvent __e, NoPersistCompartment compartment) {

--- a/framec/tests/snapshots/dart_snapshots__persist.snap
+++ b/framec/tests/snapshots/dart_snapshots__persist.snap
@@ -164,8 +164,11 @@ class Counter {
         final __e = CounterFrameEvent("increment", [by]);
         final __ctx = CounterFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        _context_stack.removeLast();
+        try {
+            __kernel(__e);
+        } finally {
+            _context_stack.removeLast();
+        }
     }
 
     int value() {
@@ -173,8 +176,13 @@ class Counter {
         final __ctx = CounterFrameContext(__e, 0);
         __ctx._return = 0;
         _context_stack.add(__ctx);
-        __kernel(__e);
-        return _context_stack.removeLast()._return;
+        try {
+            __kernel(__e);
+            return _context_stack.removeLast()._return;
+        } catch (__frame_err) {
+            _context_stack.removeLast();
+            rethrow;
+        }
     }
 
     void _state_Counting(CounterFrameEvent __e, CounterCompartment compartment) {

--- a/framec/tests/snapshots/dart_snapshots__pushpop.snap
+++ b/framec/tests/snapshots/dart_snapshots__pushpop.snap
@@ -169,32 +169,44 @@ class PushPop {
         final __e = PushPopFrameEvent("ping", []);
         final __ctx = PushPopFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        _context_stack.removeLast();
+        try {
+            __kernel(__e);
+        } finally {
+            _context_stack.removeLast();
+        }
     }
 
     void nest() {
         final __e = PushPopFrameEvent("nest", []);
         final __ctx = PushPopFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        _context_stack.removeLast();
+        try {
+            __kernel(__e);
+        } finally {
+            _context_stack.removeLast();
+        }
     }
 
     void unnest() {
         final __e = PushPopFrameEvent("unnest", []);
         final __ctx = PushPopFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        _context_stack.removeLast();
+        try {
+            __kernel(__e);
+        } finally {
+            _context_stack.removeLast();
+        }
     }
 
     void leaf() {
         final __e = PushPopFrameEvent("leaf", []);
         final __ctx = PushPopFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        _context_stack.removeLast();
+        try {
+            __kernel(__e);
+        } finally {
+            _context_stack.removeLast();
+        }
     }
 
     void _state_Idle(PushPopFrameEvent __e, PushPopCompartment compartment) {

--- a/framec/tests/snapshots/dart_snapshots__return_explicit.snap
+++ b/framec/tests/snapshots/dart_snapshots__return_explicit.snap
@@ -163,8 +163,13 @@ class ReturnExplicit {
         final __e = ReturnExplicitFrameEvent("decide", [score]);
         final __ctx = ReturnExplicitFrameContext(__e, '');
         _context_stack.add(__ctx);
-        __kernel(__e);
-        return _context_stack.removeLast()._return;
+        try {
+            __kernel(__e);
+            return _context_stack.removeLast()._return;
+        } catch (__frame_err) {
+            _context_stack.removeLast();
+            rethrow;
+        }
     }
 
     void _state_Judging(ReturnExplicitFrameEvent __e, ReturnExplicitCompartment compartment) {

--- a/framec/tests/snapshots/dart_snapshots__selfcall.snap
+++ b/framec/tests/snapshots/dart_snapshots__selfcall.snap
@@ -164,16 +164,24 @@ class SelfCall {
         final __e = SelfCallFrameEvent("kick", []);
         final __ctx = SelfCallFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        _context_stack.removeLast();
+        try {
+            __kernel(__e);
+        } finally {
+            _context_stack.removeLast();
+        }
     }
 
     int report() {
         final __e = SelfCallFrameEvent("report", []);
         final __ctx = SelfCallFrameContext(__e, 0);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        return _context_stack.removeLast()._return;
+        try {
+            __kernel(__e);
+            return _context_stack.removeLast()._return;
+        } catch (__frame_err) {
+            _context_stack.removeLast();
+            rethrow;
+        }
     }
 
     void _state_Active(SelfCallFrameEvent __e, SelfCallCompartment compartment) {

--- a/framec/tests/snapshots/dart_snapshots__state_args.snap
+++ b/framec/tests/snapshots/dart_snapshots__state_args.snap
@@ -167,24 +167,35 @@ class StateArgs {
         final __e = StateArgsFrameEvent("load", [initial]);
         final __ctx = StateArgsFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        _context_stack.removeLast();
+        try {
+            __kernel(__e);
+        } finally {
+            _context_stack.removeLast();
+        }
     }
 
     void adjust(int delta) {
         final __e = StateArgsFrameEvent("adjust", [delta]);
         final __ctx = StateArgsFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        _context_stack.removeLast();
+        try {
+            __kernel(__e);
+        } finally {
+            _context_stack.removeLast();
+        }
     }
 
     int peek() {
         final __e = StateArgsFrameEvent("peek", []);
         final __ctx = StateArgsFrameContext(__e, 0);
         _context_stack.add(__ctx);
-        __kernel(__e);
-        return _context_stack.removeLast()._return;
+        try {
+            __kernel(__e);
+            return _context_stack.removeLast()._return;
+        } catch (__frame_err) {
+            _context_stack.removeLast();
+            rethrow;
+        }
     }
 
     void _state_Idle(StateArgsFrameEvent __e, StateArgsCompartment compartment) {

--- a/framec/tests/snapshots/go_snapshots__actions.snap
+++ b/framec/tests/snapshots/go_snapshots__actions.snap
@@ -153,18 +153,18 @@ func (s *Actions) Increment(n int) {
     __e := ActionsFrameEvent{_message: "increment", _parameters: []any{n}}
     __ctx := ActionsFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
 }
 
 func (s *Actions) Get_total() int {
     __e := ActionsFrameEvent{_message: "get_total", _parameters: []any{}}
     __ctx := ActionsFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
     var __result int
     if __rv := s._context_stack[len(s._context_stack)-1]._return; __rv != nil { __result = __rv.(int) }
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
     return __result
 }
 

--- a/framec/tests/snapshots/go_snapshots__consts.snap
+++ b/framec/tests/snapshots/go_snapshots__consts.snap
@@ -159,18 +159,18 @@ func (s *Consts) Tick() {
     __e := ConstsFrameEvent{_message: "tick", _parameters: []any{}}
     __ctx := ConstsFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
 }
 
 func (s *Consts) Get_count() int {
     __e := ConstsFrameEvent{_message: "get_count", _parameters: []any{}}
     __ctx := ConstsFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
     var __result int
     if __rv := s._context_stack[len(s._context_stack)-1]._return; __rv != nil { __result = __rv.(int) }
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
     return __result
 }
 

--- a/framec/tests/snapshots/go_snapshots__forward.snap
+++ b/framec/tests/snapshots/go_snapshots__forward.snap
@@ -161,16 +161,16 @@ func (s *Forward) Run() {
     __e := ForwardFrameEvent{_message: "run", _parameters: []any{}}
     __ctx := ForwardFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
 }
 
 func (s *Forward) Finish() {
     __e := ForwardFrameEvent{_message: "finish", _parameters: []any{}}
     __ctx := ForwardFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
 }
 
 func (s *Forward) _state_Start(__e *ForwardFrameEvent, compartment *ForwardCompartment) {

--- a/framec/tests/snapshots/go_snapshots__hsm.snap
+++ b/framec/tests/snapshots/go_snapshots__hsm.snap
@@ -163,24 +163,24 @@ func (s *MiniHsm) Wake() {
     __e := MiniHsmFrameEvent{_message: "wake", _parameters: []any{}}
     __ctx := MiniHsmFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
 }
 
 func (s *MiniHsm) Sleep() {
     __e := MiniHsmFrameEvent{_message: "sleep", _parameters: []any{}}
     __ctx := MiniHsmFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
 }
 
 func (s *MiniHsm) Signal() {
     __e := MiniHsmFrameEvent{_message: "signal", _parameters: []any{}}
     __ctx := MiniHsmFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
 }
 
 func (s *MiniHsm) _state_Live(__e *MiniHsmFrameEvent, compartment *MiniHsmCompartment) {

--- a/framec/tests/snapshots/go_snapshots__lifecycle.snap
+++ b/framec/tests/snapshots/go_snapshots__lifecycle.snap
@@ -160,16 +160,16 @@ func (s *Lifecycle) Start(label string) {
     __e := LifecycleFrameEvent{_message: "start", _parameters: []any{label}}
     __ctx := LifecycleFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
 }
 
 func (s *Lifecycle) Stop() {
     __e := LifecycleFrameEvent{_message: "stop", _parameters: []any{}}
     __ctx := LifecycleFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
 }
 
 func (s *Lifecycle) _state_Idle(__e *LifecycleFrameEvent, compartment *LifecycleCompartment) {

--- a/framec/tests/snapshots/go_snapshots__lifecycle_args.snap
+++ b/framec/tests/snapshots/go_snapshots__lifecycle_args.snap
@@ -158,18 +158,18 @@ func (s *LifecycleArgs) Load(n int, label string) {
     __e := LifecycleArgsFrameEvent{_message: "load", _parameters: []any{n, label}}
     __ctx := LifecycleArgsFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
 }
 
 func (s *LifecycleArgs) Total() int {
     __e := LifecycleArgsFrameEvent{_message: "total", _parameters: []any{}}
     __ctx := LifecycleArgsFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
     var __result int
     if __rv := s._context_stack[len(s._context_stack)-1]._return; __rv != nil { __result = __rv.(int) }
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
     return __result
 }
 
@@ -177,10 +177,10 @@ func (s *LifecycleArgs) Tag() string {
     __e := LifecycleArgsFrameEvent{_message: "tag", _parameters: []any{}}
     __ctx := LifecycleArgsFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
     var __result string
     if __rv := s._context_stack[len(s._context_stack)-1]._return; __rv != nil { __result = __rv.(string) }
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
     return __result
 }
 

--- a/framec/tests/snapshots/go_snapshots__linear_fsm.snap
+++ b/framec/tests/snapshots/go_snapshots__linear_fsm.snap
@@ -159,24 +159,24 @@ func (s *LinearFsm) Start() {
     __e := LinearFsmFrameEvent{_message: "start", _parameters: []any{}}
     __ctx := LinearFsmFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
 }
 
 func (s *LinearFsm) Progress(amount int) {
     __e := LinearFsmFrameEvent{_message: "progress", _parameters: []any{amount}}
     __ctx := LinearFsmFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
 }
 
 func (s *LinearFsm) Finish() {
     __e := LinearFsmFrameEvent{_message: "finish", _parameters: []any{}}
     __ctx := LinearFsmFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
 }
 
 func (s *LinearFsm) _state_Idle(__e *LinearFsmFrameEvent, compartment *LinearFsmCompartment) {

--- a/framec/tests/snapshots/go_snapshots__no_persist.snap
+++ b/framec/tests/snapshots/go_snapshots__no_persist.snap
@@ -155,26 +155,26 @@ func (s *NoPersist) Bump() {
     __e := NoPersistFrameEvent{_message: "bump", _parameters: []any{}}
     __ctx := NoPersistFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
 }
 
 func (s *NoPersist) Set_cache(v int) {
     __e := NoPersistFrameEvent{_message: "set_cache", _parameters: []any{v}}
     __ctx := NoPersistFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
 }
 
 func (s *NoPersist) Get_count() int {
     __e := NoPersistFrameEvent{_message: "get_count", _parameters: []any{}}
     __ctx := NoPersistFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
     var __result int
     if __rv := s._context_stack[len(s._context_stack)-1]._return; __rv != nil { __result = __rv.(int) }
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
     return __result
 }
 
@@ -182,10 +182,10 @@ func (s *NoPersist) Get_cache() int {
     __e := NoPersistFrameEvent{_message: "get_cache", _parameters: []any{}}
     __ctx := NoPersistFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
     var __result int
     if __rv := s._context_stack[len(s._context_stack)-1]._return; __rv != nil { __result = __rv.(int) }
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
     return __result
 }
 

--- a/framec/tests/snapshots/go_snapshots__persist.snap
+++ b/framec/tests/snapshots/go_snapshots__persist.snap
@@ -153,18 +153,18 @@ func (s *Counter) Increment(by int) {
     __e := CounterFrameEvent{_message: "increment", _parameters: []any{by}}
     __ctx := CounterFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
 }
 
 func (s *Counter) Value() int {
     __e := CounterFrameEvent{_message: "value", _parameters: []any{}}
     __ctx := CounterFrameContext{_event: __e, _return: 0, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
     var __result int
     if __rv := s._context_stack[len(s._context_stack)-1]._return; __rv != nil { __result = __rv.(int) }
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
     return __result
 }
 

--- a/framec/tests/snapshots/go_snapshots__pushpop.snap
+++ b/framec/tests/snapshots/go_snapshots__pushpop.snap
@@ -158,32 +158,32 @@ func (s *PushPop) Ping() {
     __e := PushPopFrameEvent{_message: "ping", _parameters: []any{}}
     __ctx := PushPopFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
 }
 
 func (s *PushPop) Nest() {
     __e := PushPopFrameEvent{_message: "nest", _parameters: []any{}}
     __ctx := PushPopFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
 }
 
 func (s *PushPop) Unnest() {
     __e := PushPopFrameEvent{_message: "unnest", _parameters: []any{}}
     __ctx := PushPopFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
 }
 
 func (s *PushPop) Leaf() {
     __e := PushPopFrameEvent{_message: "leaf", _parameters: []any{}}
     __ctx := PushPopFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
 }
 
 func (s *PushPop) _state_Idle(__e *PushPopFrameEvent, compartment *PushPopCompartment) {

--- a/framec/tests/snapshots/go_snapshots__return_explicit.snap
+++ b/framec/tests/snapshots/go_snapshots__return_explicit.snap
@@ -151,10 +151,10 @@ func (s *ReturnExplicit) Decide(score int) string {
     __e := ReturnExplicitFrameEvent{_message: "decide", _parameters: []any{score}}
     __ctx := ReturnExplicitFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
     var __result string
     if __rv := s._context_stack[len(s._context_stack)-1]._return; __rv != nil { __result = __rv.(string) }
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
     return __result
 }
 

--- a/framec/tests/snapshots/go_snapshots__selfcall.snap
+++ b/framec/tests/snapshots/go_snapshots__selfcall.snap
@@ -153,18 +153,18 @@ func (s *SelfCall) Kick() {
     __e := SelfCallFrameEvent{_message: "kick", _parameters: []any{}}
     __ctx := SelfCallFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
 }
 
 func (s *SelfCall) Report() int {
     __e := SelfCallFrameEvent{_message: "report", _parameters: []any{}}
     __ctx := SelfCallFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
     var __result int
     if __rv := s._context_stack[len(s._context_stack)-1]._return; __rv != nil { __result = __rv.(int) }
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
     return __result
 }
 

--- a/framec/tests/snapshots/go_snapshots__state_args.snap
+++ b/framec/tests/snapshots/go_snapshots__state_args.snap
@@ -154,26 +154,26 @@ func (s *StateArgs) Load(initial int) {
     __e := StateArgsFrameEvent{_message: "load", _parameters: []any{initial}}
     __ctx := StateArgsFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
 }
 
 func (s *StateArgs) Adjust(delta int) {
     __e := StateArgsFrameEvent{_message: "adjust", _parameters: []any{delta}}
     __ctx := StateArgsFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
 }
 
 func (s *StateArgs) Peek() int {
     __e := StateArgsFrameEvent{_message: "peek", _parameters: []any{}}
     __ctx := StateArgsFrameContext{_event: __e, _data: make(map[string]any)}
     s._context_stack = append(s._context_stack, __ctx)
+    defer func() { s._context_stack = s._context_stack[:len(s._context_stack)-1] }()
     s.__kernel(&s._context_stack[len(s._context_stack)-1]._event)
     var __result int
     if __rv := s._context_stack[len(s._context_stack)-1]._return; __rv != nil { __result = __rv.(int) }
-    s._context_stack = s._context_stack[:len(s._context_stack)-1]
     return __result
 }
 

--- a/framec/tests/snapshots/java_snapshots__actions.snap
+++ b/framec/tests/snapshots/java_snapshots__actions.snap
@@ -161,18 +161,28 @@ public class Actions {
         ActionsFrameEvent __e = new ActionsFrameEvent("increment", new java.util.ArrayList<>(java.util.Arrays.asList(n)));
         ActionsFrameContext __ctx = new ActionsFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        _context_stack.remove(_context_stack.size() - 1);
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            _context_stack.remove(_context_stack.size() - 1);
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     public int get_total() {
         ActionsFrameEvent __e = new ActionsFrameEvent("get_total", new java.util.ArrayList<>());
         ActionsFrameContext __ctx = new ActionsFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        int __result = (int) _context_stack.get(_context_stack.size() - 1)._return;
-        _context_stack.remove(_context_stack.size() - 1);
-        return __result;
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            int __result = (int) _context_stack.get(_context_stack.size() - 1)._return;
+            _context_stack.remove(_context_stack.size() - 1);
+            return __result;
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     private void _state_Counting(ActionsFrameEvent __e, ActionsCompartment compartment) {

--- a/framec/tests/snapshots/java_snapshots__consts.snap
+++ b/framec/tests/snapshots/java_snapshots__consts.snap
@@ -165,18 +165,28 @@ public class Consts {
         ConstsFrameEvent __e = new ConstsFrameEvent("tick", new java.util.ArrayList<>());
         ConstsFrameContext __ctx = new ConstsFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        _context_stack.remove(_context_stack.size() - 1);
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            _context_stack.remove(_context_stack.size() - 1);
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     public int get_count() {
         ConstsFrameEvent __e = new ConstsFrameEvent("get_count", new java.util.ArrayList<>());
         ConstsFrameContext __ctx = new ConstsFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        int __result = (int) _context_stack.get(_context_stack.size() - 1)._return;
-        _context_stack.remove(_context_stack.size() - 1);
-        return __result;
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            int __result = (int) _context_stack.get(_context_stack.size() - 1)._return;
+            _context_stack.remove(_context_stack.size() - 1);
+            return __result;
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     private void _state_Running(ConstsFrameEvent __e, ConstsCompartment compartment) {

--- a/framec/tests/snapshots/java_snapshots__forward.snap
+++ b/framec/tests/snapshots/java_snapshots__forward.snap
@@ -168,16 +168,26 @@ public class Forward {
         ForwardFrameEvent __e = new ForwardFrameEvent("run", new java.util.ArrayList<>());
         ForwardFrameContext __ctx = new ForwardFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        _context_stack.remove(_context_stack.size() - 1);
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            _context_stack.remove(_context_stack.size() - 1);
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     public void finish() {
         ForwardFrameEvent __e = new ForwardFrameEvent("finish", new java.util.ArrayList<>());
         ForwardFrameContext __ctx = new ForwardFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        _context_stack.remove(_context_stack.size() - 1);
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            _context_stack.remove(_context_stack.size() - 1);
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     private void _state_Start(ForwardFrameEvent __e, ForwardCompartment compartment) {

--- a/framec/tests/snapshots/java_snapshots__hsm.snap
+++ b/framec/tests/snapshots/java_snapshots__hsm.snap
@@ -169,24 +169,39 @@ public class MiniHsm {
         MiniHsmFrameEvent __e = new MiniHsmFrameEvent("wake", new java.util.ArrayList<>());
         MiniHsmFrameContext __ctx = new MiniHsmFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        _context_stack.remove(_context_stack.size() - 1);
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            _context_stack.remove(_context_stack.size() - 1);
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     public void sleep() {
         MiniHsmFrameEvent __e = new MiniHsmFrameEvent("sleep", new java.util.ArrayList<>());
         MiniHsmFrameContext __ctx = new MiniHsmFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        _context_stack.remove(_context_stack.size() - 1);
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            _context_stack.remove(_context_stack.size() - 1);
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     public void signal() {
         MiniHsmFrameEvent __e = new MiniHsmFrameEvent("signal", new java.util.ArrayList<>());
         MiniHsmFrameContext __ctx = new MiniHsmFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        _context_stack.remove(_context_stack.size() - 1);
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            _context_stack.remove(_context_stack.size() - 1);
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     private void _state_Live(MiniHsmFrameEvent __e, MiniHsmCompartment compartment) {

--- a/framec/tests/snapshots/java_snapshots__lifecycle.snap
+++ b/framec/tests/snapshots/java_snapshots__lifecycle.snap
@@ -166,16 +166,26 @@ public class Lifecycle {
         LifecycleFrameEvent __e = new LifecycleFrameEvent("start", new java.util.ArrayList<>(java.util.Arrays.asList(label)));
         LifecycleFrameContext __ctx = new LifecycleFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        _context_stack.remove(_context_stack.size() - 1);
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            _context_stack.remove(_context_stack.size() - 1);
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     public void stop() {
         LifecycleFrameEvent __e = new LifecycleFrameEvent("stop", new java.util.ArrayList<>());
         LifecycleFrameContext __ctx = new LifecycleFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        _context_stack.remove(_context_stack.size() - 1);
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            _context_stack.remove(_context_stack.size() - 1);
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     private void _state_Idle(LifecycleFrameEvent __e, LifecycleCompartment compartment) {

--- a/framec/tests/snapshots/java_snapshots__lifecycle_args.snap
+++ b/framec/tests/snapshots/java_snapshots__lifecycle_args.snap
@@ -165,28 +165,43 @@ public class LifecycleArgs {
         LifecycleArgsFrameEvent __e = new LifecycleArgsFrameEvent("load", new java.util.ArrayList<>(java.util.Arrays.asList(n, label)));
         LifecycleArgsFrameContext __ctx = new LifecycleArgsFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        _context_stack.remove(_context_stack.size() - 1);
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            _context_stack.remove(_context_stack.size() - 1);
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     public int total() {
         LifecycleArgsFrameEvent __e = new LifecycleArgsFrameEvent("total", new java.util.ArrayList<>());
         LifecycleArgsFrameContext __ctx = new LifecycleArgsFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        int __result = (int) _context_stack.get(_context_stack.size() - 1)._return;
-        _context_stack.remove(_context_stack.size() - 1);
-        return __result;
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            int __result = (int) _context_stack.get(_context_stack.size() - 1)._return;
+            _context_stack.remove(_context_stack.size() - 1);
+            return __result;
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     public String tag() {
         LifecycleArgsFrameEvent __e = new LifecycleArgsFrameEvent("tag", new java.util.ArrayList<>());
         LifecycleArgsFrameContext __ctx = new LifecycleArgsFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        String __result = (String) _context_stack.get(_context_stack.size() - 1)._return;
-        _context_stack.remove(_context_stack.size() - 1);
-        return __result;
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            String __result = (String) _context_stack.get(_context_stack.size() - 1)._return;
+            _context_stack.remove(_context_stack.size() - 1);
+            return __result;
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     private void _state_Idle(LifecycleArgsFrameEvent __e, LifecycleArgsCompartment compartment) {

--- a/framec/tests/snapshots/java_snapshots__linear_fsm.snap
+++ b/framec/tests/snapshots/java_snapshots__linear_fsm.snap
@@ -167,24 +167,39 @@ public class LinearFsm {
         LinearFsmFrameEvent __e = new LinearFsmFrameEvent("start", new java.util.ArrayList<>());
         LinearFsmFrameContext __ctx = new LinearFsmFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        _context_stack.remove(_context_stack.size() - 1);
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            _context_stack.remove(_context_stack.size() - 1);
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     public void progress(int amount) {
         LinearFsmFrameEvent __e = new LinearFsmFrameEvent("progress", new java.util.ArrayList<>(java.util.Arrays.asList(amount)));
         LinearFsmFrameContext __ctx = new LinearFsmFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        _context_stack.remove(_context_stack.size() - 1);
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            _context_stack.remove(_context_stack.size() - 1);
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     public void finish() {
         LinearFsmFrameEvent __e = new LinearFsmFrameEvent("finish", new java.util.ArrayList<>());
         LinearFsmFrameContext __ctx = new LinearFsmFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        _context_stack.remove(_context_stack.size() - 1);
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            _context_stack.remove(_context_stack.size() - 1);
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     private void _state_Idle(LinearFsmFrameEvent __e, LinearFsmCompartment compartment) {

--- a/framec/tests/snapshots/java_snapshots__no_persist.snap
+++ b/framec/tests/snapshots/java_snapshots__no_persist.snap
@@ -162,36 +162,56 @@ public class NoPersist {
         NoPersistFrameEvent __e = new NoPersistFrameEvent("bump", new java.util.ArrayList<>());
         NoPersistFrameContext __ctx = new NoPersistFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        _context_stack.remove(_context_stack.size() - 1);
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            _context_stack.remove(_context_stack.size() - 1);
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     public void set_cache(int v) {
         NoPersistFrameEvent __e = new NoPersistFrameEvent("set_cache", new java.util.ArrayList<>(java.util.Arrays.asList(v)));
         NoPersistFrameContext __ctx = new NoPersistFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        _context_stack.remove(_context_stack.size() - 1);
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            _context_stack.remove(_context_stack.size() - 1);
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     public int get_count() {
         NoPersistFrameEvent __e = new NoPersistFrameEvent("get_count", new java.util.ArrayList<>());
         NoPersistFrameContext __ctx = new NoPersistFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        int __result = (int) _context_stack.get(_context_stack.size() - 1)._return;
-        _context_stack.remove(_context_stack.size() - 1);
-        return __result;
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            int __result = (int) _context_stack.get(_context_stack.size() - 1)._return;
+            _context_stack.remove(_context_stack.size() - 1);
+            return __result;
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     public int get_cache() {
         NoPersistFrameEvent __e = new NoPersistFrameEvent("get_cache", new java.util.ArrayList<>());
         NoPersistFrameContext __ctx = new NoPersistFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        int __result = (int) _context_stack.get(_context_stack.size() - 1)._return;
-        _context_stack.remove(_context_stack.size() - 1);
-        return __result;
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            int __result = (int) _context_stack.get(_context_stack.size() - 1)._return;
+            _context_stack.remove(_context_stack.size() - 1);
+            return __result;
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     private void _state_Active(NoPersistFrameEvent __e, NoPersistCompartment compartment) {

--- a/framec/tests/snapshots/java_snapshots__persist.snap
+++ b/framec/tests/snapshots/java_snapshots__persist.snap
@@ -161,18 +161,28 @@ public class Counter {
         CounterFrameEvent __e = new CounterFrameEvent("increment", new java.util.ArrayList<>(java.util.Arrays.asList(by)));
         CounterFrameContext __ctx = new CounterFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        _context_stack.remove(_context_stack.size() - 1);
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            _context_stack.remove(_context_stack.size() - 1);
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     public int value() {
         CounterFrameEvent __e = new CounterFrameEvent("value", new java.util.ArrayList<>());
         CounterFrameContext __ctx = new CounterFrameContext(__e, 0);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        int __result = (int) _context_stack.get(_context_stack.size() - 1)._return;
-        _context_stack.remove(_context_stack.size() - 1);
-        return __result;
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            int __result = (int) _context_stack.get(_context_stack.size() - 1)._return;
+            _context_stack.remove(_context_stack.size() - 1);
+            return __result;
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     private void _state_Counting(CounterFrameEvent __e, CounterCompartment compartment) {

--- a/framec/tests/snapshots/java_snapshots__pushpop.snap
+++ b/framec/tests/snapshots/java_snapshots__pushpop.snap
@@ -165,32 +165,52 @@ public class PushPop {
         PushPopFrameEvent __e = new PushPopFrameEvent("ping", new java.util.ArrayList<>());
         PushPopFrameContext __ctx = new PushPopFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        _context_stack.remove(_context_stack.size() - 1);
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            _context_stack.remove(_context_stack.size() - 1);
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     public void nest() {
         PushPopFrameEvent __e = new PushPopFrameEvent("nest", new java.util.ArrayList<>());
         PushPopFrameContext __ctx = new PushPopFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        _context_stack.remove(_context_stack.size() - 1);
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            _context_stack.remove(_context_stack.size() - 1);
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     public void unnest() {
         PushPopFrameEvent __e = new PushPopFrameEvent("unnest", new java.util.ArrayList<>());
         PushPopFrameContext __ctx = new PushPopFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        _context_stack.remove(_context_stack.size() - 1);
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            _context_stack.remove(_context_stack.size() - 1);
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     public void leaf() {
         PushPopFrameEvent __e = new PushPopFrameEvent("leaf", new java.util.ArrayList<>());
         PushPopFrameContext __ctx = new PushPopFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        _context_stack.remove(_context_stack.size() - 1);
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            _context_stack.remove(_context_stack.size() - 1);
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     private void _state_Idle(PushPopFrameEvent __e, PushPopCompartment compartment) {

--- a/framec/tests/snapshots/java_snapshots__return_explicit.snap
+++ b/framec/tests/snapshots/java_snapshots__return_explicit.snap
@@ -160,10 +160,15 @@ public class ReturnExplicit {
         ReturnExplicitFrameEvent __e = new ReturnExplicitFrameEvent("decide", new java.util.ArrayList<>(java.util.Arrays.asList(score)));
         ReturnExplicitFrameContext __ctx = new ReturnExplicitFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        String __result = (String) _context_stack.get(_context_stack.size() - 1)._return;
-        _context_stack.remove(_context_stack.size() - 1);
-        return __result;
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            String __result = (String) _context_stack.get(_context_stack.size() - 1)._return;
+            _context_stack.remove(_context_stack.size() - 1);
+            return __result;
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     private void _state_Judging(ReturnExplicitFrameEvent __e, ReturnExplicitCompartment compartment) {

--- a/framec/tests/snapshots/java_snapshots__selfcall.snap
+++ b/framec/tests/snapshots/java_snapshots__selfcall.snap
@@ -161,18 +161,28 @@ public class SelfCall {
         SelfCallFrameEvent __e = new SelfCallFrameEvent("kick", new java.util.ArrayList<>());
         SelfCallFrameContext __ctx = new SelfCallFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        _context_stack.remove(_context_stack.size() - 1);
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            _context_stack.remove(_context_stack.size() - 1);
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     public int report() {
         SelfCallFrameEvent __e = new SelfCallFrameEvent("report", new java.util.ArrayList<>());
         SelfCallFrameContext __ctx = new SelfCallFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        int __result = (int) _context_stack.get(_context_stack.size() - 1)._return;
-        _context_stack.remove(_context_stack.size() - 1);
-        return __result;
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            int __result = (int) _context_stack.get(_context_stack.size() - 1)._return;
+            _context_stack.remove(_context_stack.size() - 1);
+            return __result;
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     private void _state_Active(SelfCallFrameEvent __e, SelfCallCompartment compartment) {

--- a/framec/tests/snapshots/java_snapshots__state_args.snap
+++ b/framec/tests/snapshots/java_snapshots__state_args.snap
@@ -163,26 +163,41 @@ public class StateArgs {
         StateArgsFrameEvent __e = new StateArgsFrameEvent("load", new java.util.ArrayList<>(java.util.Arrays.asList(initial)));
         StateArgsFrameContext __ctx = new StateArgsFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        _context_stack.remove(_context_stack.size() - 1);
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            _context_stack.remove(_context_stack.size() - 1);
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     public void adjust(int delta) {
         StateArgsFrameEvent __e = new StateArgsFrameEvent("adjust", new java.util.ArrayList<>(java.util.Arrays.asList(delta)));
         StateArgsFrameContext __ctx = new StateArgsFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        _context_stack.remove(_context_stack.size() - 1);
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            _context_stack.remove(_context_stack.size() - 1);
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     public int peek() {
         StateArgsFrameEvent __e = new StateArgsFrameEvent("peek", new java.util.ArrayList<>());
         StateArgsFrameContext __ctx = new StateArgsFrameContext(__e, null);
         _context_stack.add(__ctx);
-        __kernel(_context_stack.get(_context_stack.size() - 1)._event);
-        int __result = (int) _context_stack.get(_context_stack.size() - 1)._return;
-        _context_stack.remove(_context_stack.size() - 1);
-        return __result;
+        try {
+            __kernel(_context_stack.get(_context_stack.size() - 1)._event);
+            int __result = (int) _context_stack.get(_context_stack.size() - 1)._return;
+            _context_stack.remove(_context_stack.size() - 1);
+            return __result;
+        } catch (RuntimeException __frame_err) {
+            _context_stack.remove(_context_stack.size() - 1);
+            throw __frame_err;
+        }
     }
 
     private void _state_Idle(StateArgsFrameEvent __e, StateArgsCompartment compartment) {

--- a/framec/tests/snapshots/javascript_snapshots__actions.snap
+++ b/framec/tests/snapshots/javascript_snapshots__actions.snap
@@ -162,16 +162,26 @@ export class Actions {
         const __e = new ActionsFrameEvent("increment", [n]);
         const __ctx = new ActionsFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     get_total() {
         const __e = new ActionsFrameEvent("get_total", []);
         const __ctx = new ActionsFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     _state_Counting(__e, compartment) {

--- a/framec/tests/snapshots/javascript_snapshots__consts.snap
+++ b/framec/tests/snapshots/javascript_snapshots__consts.snap
@@ -166,16 +166,26 @@ export class Consts {
         const __e = new ConstsFrameEvent("tick", []);
         const __ctx = new ConstsFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     get_count() {
         const __e = new ConstsFrameEvent("get_count", []);
         const __ctx = new ConstsFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     _state_Running(__e, compartment) {

--- a/framec/tests/snapshots/javascript_snapshots__forward.snap
+++ b/framec/tests/snapshots/javascript_snapshots__forward.snap
@@ -165,16 +165,26 @@ export class Forward {
         const __e = new ForwardFrameEvent("run", []);
         const __ctx = new ForwardFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     finish() {
         const __e = new ForwardFrameEvent("finish", []);
         const __ctx = new ForwardFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     _state_Start(__e, compartment) {

--- a/framec/tests/snapshots/javascript_snapshots__hsm.snap
+++ b/framec/tests/snapshots/javascript_snapshots__hsm.snap
@@ -166,24 +166,39 @@ export class MiniHsm {
         const __e = new MiniHsmFrameEvent("wake", []);
         const __ctx = new MiniHsmFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     sleep() {
         const __e = new MiniHsmFrameEvent("sleep", []);
         const __ctx = new MiniHsmFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     signal() {
         const __e = new MiniHsmFrameEvent("signal", []);
         const __ctx = new MiniHsmFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     _state_Live(__e, compartment) {

--- a/framec/tests/snapshots/javascript_snapshots__lifecycle.snap
+++ b/framec/tests/snapshots/javascript_snapshots__lifecycle.snap
@@ -165,16 +165,26 @@ export class Lifecycle {
         const __e = new LifecycleFrameEvent("start", [label]);
         const __ctx = new LifecycleFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     stop() {
         const __e = new LifecycleFrameEvent("stop", []);
         const __ctx = new LifecycleFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     _state_Idle(__e, compartment) {

--- a/framec/tests/snapshots/javascript_snapshots__lifecycle_args.snap
+++ b/framec/tests/snapshots/javascript_snapshots__lifecycle_args.snap
@@ -164,24 +164,39 @@ export class LifecycleArgs {
         const __e = new LifecycleArgsFrameEvent("load", [n, label]);
         const __ctx = new LifecycleArgsFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     total() {
         const __e = new LifecycleArgsFrameEvent("total", []);
         const __ctx = new LifecycleArgsFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     tag() {
         const __e = new LifecycleArgsFrameEvent("tag", []);
         const __ctx = new LifecycleArgsFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     _state_Idle(__e, compartment) {

--- a/framec/tests/snapshots/javascript_snapshots__linear_fsm.snap
+++ b/framec/tests/snapshots/javascript_snapshots__linear_fsm.snap
@@ -164,24 +164,39 @@ export class LinearFsm {
         const __e = new LinearFsmFrameEvent("start", []);
         const __ctx = new LinearFsmFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     progress(amount) {
         const __e = new LinearFsmFrameEvent("progress", [amount]);
         const __ctx = new LinearFsmFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     finish() {
         const __e = new LinearFsmFrameEvent("finish", []);
         const __ctx = new LinearFsmFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     _state_Idle(__e, compartment) {

--- a/framec/tests/snapshots/javascript_snapshots__no_persist.snap
+++ b/framec/tests/snapshots/javascript_snapshots__no_persist.snap
@@ -163,32 +163,52 @@ export class NoPersist {
         const __e = new NoPersistFrameEvent("bump", []);
         const __ctx = new NoPersistFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     set_cache(v) {
         const __e = new NoPersistFrameEvent("set_cache", [v]);
         const __ctx = new NoPersistFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     get_count() {
         const __e = new NoPersistFrameEvent("get_count", []);
         const __ctx = new NoPersistFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     get_cache() {
         const __e = new NoPersistFrameEvent("get_cache", []);
         const __ctx = new NoPersistFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     _state_Active(__e, compartment) {

--- a/framec/tests/snapshots/javascript_snapshots__persist.snap
+++ b/framec/tests/snapshots/javascript_snapshots__persist.snap
@@ -162,8 +162,13 @@ export class Counter {
         const __e = new CounterFrameEvent("increment", [by]);
         const __ctx = new CounterFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     value() {
@@ -171,8 +176,13 @@ export class Counter {
         const __ctx = new CounterFrameContext(__e, null);
         __ctx._return = 0;
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     _state_Counting(__e, compartment) {

--- a/framec/tests/snapshots/javascript_snapshots__pushpop.snap
+++ b/framec/tests/snapshots/javascript_snapshots__pushpop.snap
@@ -164,32 +164,52 @@ export class PushPop {
         const __e = new PushPopFrameEvent("ping", []);
         const __ctx = new PushPopFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     nest() {
         const __e = new PushPopFrameEvent("nest", []);
         const __ctx = new PushPopFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     unnest() {
         const __e = new PushPopFrameEvent("unnest", []);
         const __ctx = new PushPopFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     leaf() {
         const __e = new PushPopFrameEvent("leaf", []);
         const __ctx = new PushPopFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     _state_Idle(__e, compartment) {

--- a/framec/tests/snapshots/javascript_snapshots__return_explicit.snap
+++ b/framec/tests/snapshots/javascript_snapshots__return_explicit.snap
@@ -161,8 +161,13 @@ export class ReturnExplicit {
         const __e = new ReturnExplicitFrameEvent("decide", [score]);
         const __ctx = new ReturnExplicitFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     _state_Judging(__e, compartment) {

--- a/framec/tests/snapshots/javascript_snapshots__selfcall.snap
+++ b/framec/tests/snapshots/javascript_snapshots__selfcall.snap
@@ -162,16 +162,26 @@ export class SelfCall {
         const __e = new SelfCallFrameEvent("kick", []);
         const __ctx = new SelfCallFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     report() {
         const __e = new SelfCallFrameEvent("report", []);
         const __ctx = new SelfCallFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     _state_Active(__e, compartment) {

--- a/framec/tests/snapshots/javascript_snapshots__state_args.snap
+++ b/framec/tests/snapshots/javascript_snapshots__state_args.snap
@@ -162,24 +162,39 @@ export class StateArgs {
         const __e = new StateArgsFrameEvent("load", [initial]);
         const __ctx = new StateArgsFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     adjust(delta) {
         const __e = new StateArgsFrameEvent("adjust", [delta]);
         const __ctx = new StateArgsFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     peek() {
         const __e = new StateArgsFrameEvent("peek", []);
         const __ctx = new StateArgsFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     _state_Idle(__e, compartment) {

--- a/framec/tests/snapshots/kotlin_snapshots__actions.snap
+++ b/framec/tests/snapshots/kotlin_snapshots__actions.snap
@@ -127,18 +127,28 @@ class Actions {
         val __e = ActionsFrameEvent("increment", mutableListOf(n))
         val __ctx = ActionsFrameContext(__e, null)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        _context_stack.removeAt(_context_stack.size - 1)
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            _context_stack.removeAt(_context_stack.size - 1)
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     fun get_total(): Int {
         val __e = ActionsFrameEvent("get_total", mutableListOf())
         val __ctx = ActionsFrameContext(__e, 0)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        val __result = _context_stack[_context_stack.size - 1]._return as Int
-        _context_stack.removeAt(_context_stack.size - 1)
-        return __result
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            val __result = _context_stack[_context_stack.size - 1]._return as Int
+            _context_stack.removeAt(_context_stack.size - 1)
+            return __result
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     private fun _state_Counting(__e: ActionsFrameEvent, compartment: ActionsCompartment) {

--- a/framec/tests/snapshots/kotlin_snapshots__consts.snap
+++ b/framec/tests/snapshots/kotlin_snapshots__consts.snap
@@ -131,18 +131,28 @@ class Consts {
         val __e = ConstsFrameEvent("tick", mutableListOf())
         val __ctx = ConstsFrameContext(__e, null)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        _context_stack.removeAt(_context_stack.size - 1)
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            _context_stack.removeAt(_context_stack.size - 1)
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     fun get_count(): Int {
         val __e = ConstsFrameEvent("get_count", mutableListOf())
         val __ctx = ConstsFrameContext(__e, 0)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        val __result = _context_stack[_context_stack.size - 1]._return as Int
-        _context_stack.removeAt(_context_stack.size - 1)
-        return __result
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            val __result = _context_stack[_context_stack.size - 1]._return as Int
+            _context_stack.removeAt(_context_stack.size - 1)
+            return __result
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     private fun _state_Running(__e: ConstsFrameEvent, compartment: ConstsCompartment) {

--- a/framec/tests/snapshots/kotlin_snapshots__forward.snap
+++ b/framec/tests/snapshots/kotlin_snapshots__forward.snap
@@ -134,16 +134,26 @@ class Forward {
         val __e = ForwardFrameEvent("run", mutableListOf())
         val __ctx = ForwardFrameContext(__e, null)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        _context_stack.removeAt(_context_stack.size - 1)
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            _context_stack.removeAt(_context_stack.size - 1)
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     fun finish() {
         val __e = ForwardFrameEvent("finish", mutableListOf())
         val __ctx = ForwardFrameContext(__e, null)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        _context_stack.removeAt(_context_stack.size - 1)
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            _context_stack.removeAt(_context_stack.size - 1)
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     private fun _state_Start(__e: ForwardFrameEvent, compartment: ForwardCompartment) {

--- a/framec/tests/snapshots/kotlin_snapshots__hsm.snap
+++ b/framec/tests/snapshots/kotlin_snapshots__hsm.snap
@@ -135,24 +135,39 @@ class MiniHsm {
         val __e = MiniHsmFrameEvent("wake", mutableListOf())
         val __ctx = MiniHsmFrameContext(__e, null)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        _context_stack.removeAt(_context_stack.size - 1)
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            _context_stack.removeAt(_context_stack.size - 1)
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     fun sleep() {
         val __e = MiniHsmFrameEvent("sleep", mutableListOf())
         val __ctx = MiniHsmFrameContext(__e, null)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        _context_stack.removeAt(_context_stack.size - 1)
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            _context_stack.removeAt(_context_stack.size - 1)
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     fun signal() {
         val __e = MiniHsmFrameEvent("signal", mutableListOf())
         val __ctx = MiniHsmFrameContext(__e, null)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        _context_stack.removeAt(_context_stack.size - 1)
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            _context_stack.removeAt(_context_stack.size - 1)
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     private fun _state_Live(__e: MiniHsmFrameEvent, compartment: MiniHsmCompartment) {

--- a/framec/tests/snapshots/kotlin_snapshots__lifecycle.snap
+++ b/framec/tests/snapshots/kotlin_snapshots__lifecycle.snap
@@ -132,16 +132,26 @@ class Lifecycle {
         val __e = LifecycleFrameEvent("start", mutableListOf(label))
         val __ctx = LifecycleFrameContext(__e, null)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        _context_stack.removeAt(_context_stack.size - 1)
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            _context_stack.removeAt(_context_stack.size - 1)
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     fun stop() {
         val __e = LifecycleFrameEvent("stop", mutableListOf())
         val __ctx = LifecycleFrameContext(__e, null)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        _context_stack.removeAt(_context_stack.size - 1)
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            _context_stack.removeAt(_context_stack.size - 1)
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     private fun _state_Idle(__e: LifecycleFrameEvent, compartment: LifecycleCompartment) {

--- a/framec/tests/snapshots/kotlin_snapshots__lifecycle_args.snap
+++ b/framec/tests/snapshots/kotlin_snapshots__lifecycle_args.snap
@@ -131,28 +131,43 @@ class LifecycleArgs {
         val __e = LifecycleArgsFrameEvent("load", mutableListOf(n, label))
         val __ctx = LifecycleArgsFrameContext(__e, null)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        _context_stack.removeAt(_context_stack.size - 1)
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            _context_stack.removeAt(_context_stack.size - 1)
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     fun total(): Int {
         val __e = LifecycleArgsFrameEvent("total", mutableListOf())
         val __ctx = LifecycleArgsFrameContext(__e, 0)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        val __result = _context_stack[_context_stack.size - 1]._return as Int
-        _context_stack.removeAt(_context_stack.size - 1)
-        return __result
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            val __result = _context_stack[_context_stack.size - 1]._return as Int
+            _context_stack.removeAt(_context_stack.size - 1)
+            return __result
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     fun tag(): String {
         val __e = LifecycleArgsFrameEvent("tag", mutableListOf())
         val __ctx = LifecycleArgsFrameContext(__e, "")
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        val __result = _context_stack[_context_stack.size - 1]._return as String
-        _context_stack.removeAt(_context_stack.size - 1)
-        return __result
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            val __result = _context_stack[_context_stack.size - 1]._return as String
+            _context_stack.removeAt(_context_stack.size - 1)
+            return __result
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     private fun _state_Idle(__e: LifecycleArgsFrameEvent, compartment: LifecycleArgsCompartment) {

--- a/framec/tests/snapshots/kotlin_snapshots__linear_fsm.snap
+++ b/framec/tests/snapshots/kotlin_snapshots__linear_fsm.snap
@@ -133,24 +133,39 @@ class LinearFsm {
         val __e = LinearFsmFrameEvent("start", mutableListOf())
         val __ctx = LinearFsmFrameContext(__e, null)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        _context_stack.removeAt(_context_stack.size - 1)
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            _context_stack.removeAt(_context_stack.size - 1)
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     fun progress(amount: Int) {
         val __e = LinearFsmFrameEvent("progress", mutableListOf(amount))
         val __ctx = LinearFsmFrameContext(__e, null)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        _context_stack.removeAt(_context_stack.size - 1)
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            _context_stack.removeAt(_context_stack.size - 1)
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     fun finish() {
         val __e = LinearFsmFrameEvent("finish", mutableListOf())
         val __ctx = LinearFsmFrameContext(__e, null)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        _context_stack.removeAt(_context_stack.size - 1)
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            _context_stack.removeAt(_context_stack.size - 1)
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     private fun _state_Idle(__e: LinearFsmFrameEvent, compartment: LinearFsmCompartment) {

--- a/framec/tests/snapshots/kotlin_snapshots__no_persist.snap
+++ b/framec/tests/snapshots/kotlin_snapshots__no_persist.snap
@@ -128,36 +128,56 @@ class NoPersist {
         val __e = NoPersistFrameEvent("bump", mutableListOf())
         val __ctx = NoPersistFrameContext(__e, null)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        _context_stack.removeAt(_context_stack.size - 1)
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            _context_stack.removeAt(_context_stack.size - 1)
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     fun set_cache(v: Int) {
         val __e = NoPersistFrameEvent("set_cache", mutableListOf(v))
         val __ctx = NoPersistFrameContext(__e, null)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        _context_stack.removeAt(_context_stack.size - 1)
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            _context_stack.removeAt(_context_stack.size - 1)
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     fun get_count(): Int {
         val __e = NoPersistFrameEvent("get_count", mutableListOf())
         val __ctx = NoPersistFrameContext(__e, 0)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        val __result = _context_stack[_context_stack.size - 1]._return as Int
-        _context_stack.removeAt(_context_stack.size - 1)
-        return __result
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            val __result = _context_stack[_context_stack.size - 1]._return as Int
+            _context_stack.removeAt(_context_stack.size - 1)
+            return __result
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     fun get_cache(): Int {
         val __e = NoPersistFrameEvent("get_cache", mutableListOf())
         val __ctx = NoPersistFrameContext(__e, 0)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        val __result = _context_stack[_context_stack.size - 1]._return as Int
-        _context_stack.removeAt(_context_stack.size - 1)
-        return __result
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            val __result = _context_stack[_context_stack.size - 1]._return as Int
+            _context_stack.removeAt(_context_stack.size - 1)
+            return __result
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     private fun _state_Active(__e: NoPersistFrameEvent, compartment: NoPersistCompartment) {

--- a/framec/tests/snapshots/kotlin_snapshots__persist.snap
+++ b/framec/tests/snapshots/kotlin_snapshots__persist.snap
@@ -127,18 +127,28 @@ class Counter {
         val __e = CounterFrameEvent("increment", mutableListOf(by))
         val __ctx = CounterFrameContext(__e, null)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        _context_stack.removeAt(_context_stack.size - 1)
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            _context_stack.removeAt(_context_stack.size - 1)
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     fun value(): Int {
         val __e = CounterFrameEvent("value", mutableListOf())
         val __ctx = CounterFrameContext(__e, 0)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        val __result = _context_stack[_context_stack.size - 1]._return as Int
-        _context_stack.removeAt(_context_stack.size - 1)
-        return __result
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            val __result = _context_stack[_context_stack.size - 1]._return as Int
+            _context_stack.removeAt(_context_stack.size - 1)
+            return __result
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     private fun _state_Counting(__e: CounterFrameEvent, compartment: CounterCompartment) {

--- a/framec/tests/snapshots/kotlin_snapshots__pushpop.snap
+++ b/framec/tests/snapshots/kotlin_snapshots__pushpop.snap
@@ -131,32 +131,52 @@ class PushPop {
         val __e = PushPopFrameEvent("ping", mutableListOf())
         val __ctx = PushPopFrameContext(__e, null)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        _context_stack.removeAt(_context_stack.size - 1)
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            _context_stack.removeAt(_context_stack.size - 1)
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     fun nest() {
         val __e = PushPopFrameEvent("nest", mutableListOf())
         val __ctx = PushPopFrameContext(__e, null)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        _context_stack.removeAt(_context_stack.size - 1)
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            _context_stack.removeAt(_context_stack.size - 1)
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     fun unnest() {
         val __e = PushPopFrameEvent("unnest", mutableListOf())
         val __ctx = PushPopFrameContext(__e, null)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        _context_stack.removeAt(_context_stack.size - 1)
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            _context_stack.removeAt(_context_stack.size - 1)
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     fun leaf() {
         val __e = PushPopFrameEvent("leaf", mutableListOf())
         val __ctx = PushPopFrameContext(__e, null)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        _context_stack.removeAt(_context_stack.size - 1)
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            _context_stack.removeAt(_context_stack.size - 1)
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     private fun _state_Idle(__e: PushPopFrameEvent, compartment: PushPopCompartment) {

--- a/framec/tests/snapshots/kotlin_snapshots__return_explicit.snap
+++ b/framec/tests/snapshots/kotlin_snapshots__return_explicit.snap
@@ -126,10 +126,15 @@ class ReturnExplicit {
         val __e = ReturnExplicitFrameEvent("decide", mutableListOf(score))
         val __ctx = ReturnExplicitFrameContext(__e, "")
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        val __result = _context_stack[_context_stack.size - 1]._return as String
-        _context_stack.removeAt(_context_stack.size - 1)
-        return __result
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            val __result = _context_stack[_context_stack.size - 1]._return as String
+            _context_stack.removeAt(_context_stack.size - 1)
+            return __result
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     private fun _state_Judging(__e: ReturnExplicitFrameEvent, compartment: ReturnExplicitCompartment) {

--- a/framec/tests/snapshots/kotlin_snapshots__selfcall.snap
+++ b/framec/tests/snapshots/kotlin_snapshots__selfcall.snap
@@ -127,18 +127,28 @@ class SelfCall {
         val __e = SelfCallFrameEvent("kick", mutableListOf())
         val __ctx = SelfCallFrameContext(__e, null)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        _context_stack.removeAt(_context_stack.size - 1)
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            _context_stack.removeAt(_context_stack.size - 1)
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     fun report(): Int {
         val __e = SelfCallFrameEvent("report", mutableListOf())
         val __ctx = SelfCallFrameContext(__e, 0)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        val __result = _context_stack[_context_stack.size - 1]._return as Int
-        _context_stack.removeAt(_context_stack.size - 1)
-        return __result
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            val __result = _context_stack[_context_stack.size - 1]._return as Int
+            _context_stack.removeAt(_context_stack.size - 1)
+            return __result
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     private fun _state_Active(__e: SelfCallFrameEvent, compartment: SelfCallCompartment) {

--- a/framec/tests/snapshots/kotlin_snapshots__state_args.snap
+++ b/framec/tests/snapshots/kotlin_snapshots__state_args.snap
@@ -129,26 +129,41 @@ class StateArgs {
         val __e = StateArgsFrameEvent("load", mutableListOf(initial))
         val __ctx = StateArgsFrameContext(__e, null)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        _context_stack.removeAt(_context_stack.size - 1)
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            _context_stack.removeAt(_context_stack.size - 1)
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     fun adjust(delta: Int) {
         val __e = StateArgsFrameEvent("adjust", mutableListOf(delta))
         val __ctx = StateArgsFrameContext(__e, null)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        _context_stack.removeAt(_context_stack.size - 1)
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            _context_stack.removeAt(_context_stack.size - 1)
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     fun peek(): Int {
         val __e = StateArgsFrameEvent("peek", mutableListOf())
         val __ctx = StateArgsFrameContext(__e, 0)
         _context_stack.add(__ctx)
-        __kernel(_context_stack[_context_stack.size - 1]._event)
-        val __result = _context_stack[_context_stack.size - 1]._return as Int
-        _context_stack.removeAt(_context_stack.size - 1)
-        return __result
+        try {
+            __kernel(_context_stack[_context_stack.size - 1]._event)
+            val __result = _context_stack[_context_stack.size - 1]._return as Int
+            _context_stack.removeAt(_context_stack.size - 1)
+            return __result
+        } catch (__frame_err: Throwable) {
+            _context_stack.removeAt(_context_stack.size - 1)
+            throw __frame_err
+        }
     }
 
     private fun _state_Idle(__e: StateArgsFrameEvent, compartment: StateArgsCompartment) {

--- a/framec/tests/snapshots/lua_snapshots__actions.snap
+++ b/framec/tests/snapshots/lua_snapshots__actions.snap
@@ -157,7 +157,11 @@ function Actions:increment(n)
     local __e = ActionsFrameEvent.new("increment", {n})
     local __ctx = ActionsFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 
@@ -165,7 +169,11 @@ function Actions:get_total()
     local __e = ActionsFrameEvent.new("get_total", {})
     local __ctx = ActionsFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 

--- a/framec/tests/snapshots/lua_snapshots__consts.snap
+++ b/framec/tests/snapshots/lua_snapshots__consts.snap
@@ -161,7 +161,11 @@ function Consts:tick()
     local __e = ConstsFrameEvent.new("tick", {})
     local __ctx = ConstsFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 
@@ -169,7 +173,11 @@ function Consts:get_count()
     local __e = ConstsFrameEvent.new("get_count", {})
     local __ctx = ConstsFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 

--- a/framec/tests/snapshots/lua_snapshots__forward.snap
+++ b/framec/tests/snapshots/lua_snapshots__forward.snap
@@ -160,7 +160,11 @@ function Forward:run()
     local __e = ForwardFrameEvent.new("run", {})
     local __ctx = ForwardFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 
@@ -168,7 +172,11 @@ function Forward:finish()
     local __e = ForwardFrameEvent.new("finish", {})
     local __ctx = ForwardFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 

--- a/framec/tests/snapshots/lua_snapshots__hsm.snap
+++ b/framec/tests/snapshots/lua_snapshots__hsm.snap
@@ -161,7 +161,11 @@ function MiniHsm:wake()
     local __e = MiniHsmFrameEvent.new("wake", {})
     local __ctx = MiniHsmFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 
@@ -169,7 +173,11 @@ function MiniHsm:sleep()
     local __e = MiniHsmFrameEvent.new("sleep", {})
     local __ctx = MiniHsmFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 
@@ -177,7 +185,11 @@ function MiniHsm:signal()
     local __e = MiniHsmFrameEvent.new("signal", {})
     local __ctx = MiniHsmFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 

--- a/framec/tests/snapshots/lua_snapshots__lifecycle.snap
+++ b/framec/tests/snapshots/lua_snapshots__lifecycle.snap
@@ -160,7 +160,11 @@ function Lifecycle:start(label)
     local __e = LifecycleFrameEvent.new("start", {label})
     local __ctx = LifecycleFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 
@@ -168,7 +172,11 @@ function Lifecycle:stop()
     local __e = LifecycleFrameEvent.new("stop", {})
     local __ctx = LifecycleFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 

--- a/framec/tests/snapshots/lua_snapshots__lifecycle_args.snap
+++ b/framec/tests/snapshots/lua_snapshots__lifecycle_args.snap
@@ -159,7 +159,11 @@ function LifecycleArgs:load(n, label)
     local __e = LifecycleArgsFrameEvent.new("load", {n, label})
     local __ctx = LifecycleArgsFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 
@@ -167,7 +171,11 @@ function LifecycleArgs:total()
     local __e = LifecycleArgsFrameEvent.new("total", {})
     local __ctx = LifecycleArgsFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 
@@ -175,7 +183,11 @@ function LifecycleArgs:tag()
     local __e = LifecycleArgsFrameEvent.new("tag", {})
     local __ctx = LifecycleArgsFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 

--- a/framec/tests/snapshots/lua_snapshots__linear_fsm.snap
+++ b/framec/tests/snapshots/lua_snapshots__linear_fsm.snap
@@ -159,7 +159,11 @@ function LinearFsm:start()
     local __e = LinearFsmFrameEvent.new("start", {})
     local __ctx = LinearFsmFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 
@@ -167,7 +171,11 @@ function LinearFsm:progress(amount)
     local __e = LinearFsmFrameEvent.new("progress", {amount})
     local __ctx = LinearFsmFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 
@@ -175,7 +183,11 @@ function LinearFsm:finish()
     local __e = LinearFsmFrameEvent.new("finish", {})
     local __ctx = LinearFsmFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 

--- a/framec/tests/snapshots/lua_snapshots__no_persist.snap
+++ b/framec/tests/snapshots/lua_snapshots__no_persist.snap
@@ -158,7 +158,11 @@ function NoPersist:bump()
     local __e = NoPersistFrameEvent.new("bump", {})
     local __ctx = NoPersistFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 
@@ -166,7 +170,11 @@ function NoPersist:set_cache(v)
     local __e = NoPersistFrameEvent.new("set_cache", {v})
     local __ctx = NoPersistFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 
@@ -174,7 +182,11 @@ function NoPersist:get_count()
     local __e = NoPersistFrameEvent.new("get_count", {})
     local __ctx = NoPersistFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 
@@ -182,7 +194,11 @@ function NoPersist:get_cache()
     local __e = NoPersistFrameEvent.new("get_cache", {})
     local __ctx = NoPersistFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 

--- a/framec/tests/snapshots/lua_snapshots__persist.snap
+++ b/framec/tests/snapshots/lua_snapshots__persist.snap
@@ -157,7 +157,11 @@ function Counter:increment(by)
     local __e = CounterFrameEvent.new("increment", {by})
     local __ctx = CounterFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 
@@ -166,7 +170,11 @@ function Counter:value()
     local __ctx = CounterFrameContext.new(__e, nil)
     __ctx._return = 0
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 

--- a/framec/tests/snapshots/lua_snapshots__pushpop.snap
+++ b/framec/tests/snapshots/lua_snapshots__pushpop.snap
@@ -159,7 +159,11 @@ function PushPop:ping()
     local __e = PushPopFrameEvent.new("ping", {})
     local __ctx = PushPopFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 
@@ -167,7 +171,11 @@ function PushPop:nest()
     local __e = PushPopFrameEvent.new("nest", {})
     local __ctx = PushPopFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 
@@ -175,7 +183,11 @@ function PushPop:unnest()
     local __e = PushPopFrameEvent.new("unnest", {})
     local __ctx = PushPopFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 
@@ -183,7 +195,11 @@ function PushPop:leaf()
     local __e = PushPopFrameEvent.new("leaf", {})
     local __ctx = PushPopFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 

--- a/framec/tests/snapshots/lua_snapshots__return_explicit.snap
+++ b/framec/tests/snapshots/lua_snapshots__return_explicit.snap
@@ -156,7 +156,11 @@ function ReturnExplicit:decide(score)
     local __e = ReturnExplicitFrameEvent.new("decide", {score})
     local __ctx = ReturnExplicitFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 

--- a/framec/tests/snapshots/lua_snapshots__selfcall.snap
+++ b/framec/tests/snapshots/lua_snapshots__selfcall.snap
@@ -157,7 +157,11 @@ function SelfCall:kick()
     local __e = SelfCallFrameEvent.new("kick", {})
     local __ctx = SelfCallFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 
@@ -165,7 +169,11 @@ function SelfCall:report()
     local __e = SelfCallFrameEvent.new("report", {})
     local __ctx = SelfCallFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 

--- a/framec/tests/snapshots/lua_snapshots__state_args.snap
+++ b/framec/tests/snapshots/lua_snapshots__state_args.snap
@@ -157,7 +157,11 @@ function StateArgs:load(initial)
     local __e = StateArgsFrameEvent.new("load", {initial})
     local __ctx = StateArgsFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 
@@ -165,7 +169,11 @@ function StateArgs:adjust(delta)
     local __e = StateArgsFrameEvent.new("adjust", {delta})
     local __ctx = StateArgsFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 
@@ -173,7 +181,11 @@ function StateArgs:peek()
     local __e = StateArgsFrameEvent.new("peek", {})
     local __ctx = StateArgsFrameContext.new(__e, nil)
     self._context_stack[#self._context_stack + 1] = __ctx
-    self:__kernel(__e)
+    local __ok, __err = pcall(self.__kernel, self, __e)
+    if not __ok then
+        self._context_stack[#self._context_stack] = nil
+        error(__err)
+    end
     return table.remove(self._context_stack)._return
 end
 

--- a/framec/tests/snapshots/php_snapshots__actions.snap
+++ b/framec/tests/snapshots/php_snapshots__actions.snap
@@ -157,16 +157,26 @@ class Actions {
         $__e = new ActionsFrameEvent("increment", [$n]);
         $__ctx = new ActionsFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     public function get_total() {
         $__e = new ActionsFrameEvent("get_total", []);
         $__ctx = new ActionsFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     private function _state_Counting($__e, $compartment) {

--- a/framec/tests/snapshots/php_snapshots__consts.snap
+++ b/framec/tests/snapshots/php_snapshots__consts.snap
@@ -161,16 +161,26 @@ class Consts {
         $__e = new ConstsFrameEvent("tick", []);
         $__ctx = new ConstsFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     public function get_count() {
         $__e = new ConstsFrameEvent("get_count", []);
         $__ctx = new ConstsFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     private function _state_Running($__e, $compartment) {

--- a/framec/tests/snapshots/php_snapshots__forward.snap
+++ b/framec/tests/snapshots/php_snapshots__forward.snap
@@ -160,16 +160,26 @@ class Forward {
         $__e = new ForwardFrameEvent("run", []);
         $__ctx = new ForwardFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     public function finish() {
         $__e = new ForwardFrameEvent("finish", []);
         $__ctx = new ForwardFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     private function _state_Start($__e, $compartment) {

--- a/framec/tests/snapshots/php_snapshots__hsm.snap
+++ b/framec/tests/snapshots/php_snapshots__hsm.snap
@@ -161,24 +161,39 @@ class MiniHsm {
         $__e = new MiniHsmFrameEvent("wake", []);
         $__ctx = new MiniHsmFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     public function sleep() {
         $__e = new MiniHsmFrameEvent("sleep", []);
         $__ctx = new MiniHsmFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     public function signal() {
         $__e = new MiniHsmFrameEvent("signal", []);
         $__ctx = new MiniHsmFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     private function _state_Live($__e, $compartment) {

--- a/framec/tests/snapshots/php_snapshots__lifecycle.snap
+++ b/framec/tests/snapshots/php_snapshots__lifecycle.snap
@@ -160,16 +160,26 @@ class Lifecycle {
         $__e = new LifecycleFrameEvent("start", [$label]);
         $__ctx = new LifecycleFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     public function stop() {
         $__e = new LifecycleFrameEvent("stop", []);
         $__ctx = new LifecycleFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     private function _state_Idle($__e, $compartment) {

--- a/framec/tests/snapshots/php_snapshots__lifecycle_args.snap
+++ b/framec/tests/snapshots/php_snapshots__lifecycle_args.snap
@@ -159,24 +159,39 @@ class LifecycleArgs {
         $__e = new LifecycleArgsFrameEvent("load", [$n, $label]);
         $__ctx = new LifecycleArgsFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     public function total() {
         $__e = new LifecycleArgsFrameEvent("total", []);
         $__ctx = new LifecycleArgsFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     public function tag() {
         $__e = new LifecycleArgsFrameEvent("tag", []);
         $__ctx = new LifecycleArgsFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     private function _state_Idle($__e, $compartment) {

--- a/framec/tests/snapshots/php_snapshots__linear_fsm.snap
+++ b/framec/tests/snapshots/php_snapshots__linear_fsm.snap
@@ -159,24 +159,39 @@ class LinearFsm {
         $__e = new LinearFsmFrameEvent("start", []);
         $__ctx = new LinearFsmFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     public function progress($amount) {
         $__e = new LinearFsmFrameEvent("progress", [$amount]);
         $__ctx = new LinearFsmFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     public function finish() {
         $__e = new LinearFsmFrameEvent("finish", []);
         $__ctx = new LinearFsmFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     private function _state_Idle($__e, $compartment) {

--- a/framec/tests/snapshots/php_snapshots__no_persist.snap
+++ b/framec/tests/snapshots/php_snapshots__no_persist.snap
@@ -158,32 +158,52 @@ class NoPersist {
         $__e = new NoPersistFrameEvent("bump", []);
         $__ctx = new NoPersistFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     public function set_cache($v) {
         $__e = new NoPersistFrameEvent("set_cache", [$v]);
         $__ctx = new NoPersistFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     public function get_count() {
         $__e = new NoPersistFrameEvent("get_count", []);
         $__ctx = new NoPersistFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     public function get_cache() {
         $__e = new NoPersistFrameEvent("get_cache", []);
         $__ctx = new NoPersistFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     private function _state_Active($__e, $compartment) {

--- a/framec/tests/snapshots/php_snapshots__persist.snap
+++ b/framec/tests/snapshots/php_snapshots__persist.snap
@@ -157,8 +157,13 @@ class Counter {
         $__e = new CounterFrameEvent("increment", [$by]);
         $__ctx = new CounterFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     public function value() {
@@ -166,8 +171,13 @@ class Counter {
         $__ctx = new CounterFrameContext($__e, null);
         $__ctx->_return = 0;
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     private function _state_Counting($__e, $compartment) {

--- a/framec/tests/snapshots/php_snapshots__pushpop.snap
+++ b/framec/tests/snapshots/php_snapshots__pushpop.snap
@@ -159,32 +159,52 @@ class PushPop {
         $__e = new PushPopFrameEvent("ping", []);
         $__ctx = new PushPopFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     public function nest() {
         $__e = new PushPopFrameEvent("nest", []);
         $__ctx = new PushPopFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     public function unnest() {
         $__e = new PushPopFrameEvent("unnest", []);
         $__ctx = new PushPopFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     public function leaf() {
         $__e = new PushPopFrameEvent("leaf", []);
         $__ctx = new PushPopFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     private function _state_Idle($__e, $compartment) {

--- a/framec/tests/snapshots/php_snapshots__return_explicit.snap
+++ b/framec/tests/snapshots/php_snapshots__return_explicit.snap
@@ -156,8 +156,13 @@ class ReturnExplicit {
         $__e = new ReturnExplicitFrameEvent("decide", [$score]);
         $__ctx = new ReturnExplicitFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     private function _state_Judging($__e, $compartment) {

--- a/framec/tests/snapshots/php_snapshots__selfcall.snap
+++ b/framec/tests/snapshots/php_snapshots__selfcall.snap
@@ -157,16 +157,26 @@ class SelfCall {
         $__e = new SelfCallFrameEvent("kick", []);
         $__ctx = new SelfCallFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     public function report() {
         $__e = new SelfCallFrameEvent("report", []);
         $__ctx = new SelfCallFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     private function _state_Active($__e, $compartment) {

--- a/framec/tests/snapshots/php_snapshots__state_args.snap
+++ b/framec/tests/snapshots/php_snapshots__state_args.snap
@@ -157,24 +157,39 @@ class StateArgs {
         $__e = new StateArgsFrameEvent("load", [$initial]);
         $__ctx = new StateArgsFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     public function adjust($delta) {
         $__e = new StateArgsFrameEvent("adjust", [$delta]);
         $__ctx = new StateArgsFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     public function peek() {
         $__e = new StateArgsFrameEvent("peek", []);
         $__ctx = new StateArgsFrameContext($__e, null);
         $this->_context_stack[] = $__ctx;
-        $this->__kernel($__e);
-        return array_pop($this->_context_stack)->_return;
+        try {
+            $this->__kernel($__e);
+            return array_pop($this->_context_stack)->_return;
+        } catch (\Throwable $__frame_err) {
+            array_pop($this->_context_stack);
+            throw $__frame_err;
+        }
     }
 
     private function _state_Idle($__e, $compartment) {

--- a/framec/tests/snapshots/python_snapshots__actions.snap
+++ b/framec/tests/snapshots/python_snapshots__actions.snap
@@ -115,15 +115,21 @@ class Actions:
         __e = ActionsFrameEvent("increment", [n])
         __ctx = ActionsFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def get_total(self) -> int:
         __e = ActionsFrameEvent("get_total", [])
         __ctx = ActionsFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def _state_Counting(self, __e, compartment):
         if __e._message == "get_total":

--- a/framec/tests/snapshots/python_snapshots__consts.snap
+++ b/framec/tests/snapshots/python_snapshots__consts.snap
@@ -119,15 +119,21 @@ class Consts:
         __e = ConstsFrameEvent("tick", [])
         __ctx = ConstsFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def get_count(self) -> int:
         __e = ConstsFrameEvent("get_count", [])
         __ctx = ConstsFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def _state_Running(self, __e, compartment):
         if __e._message == "get_count":

--- a/framec/tests/snapshots/python_snapshots__forward.snap
+++ b/framec/tests/snapshots/python_snapshots__forward.snap
@@ -122,15 +122,21 @@ class Forward:
         __e = ForwardFrameEvent("run", [])
         __ctx = ForwardFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def finish(self):
         __e = ForwardFrameEvent("finish", [])
         __ctx = ForwardFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def _state_Start(self, __e, compartment):
         if __e._message == "run":

--- a/framec/tests/snapshots/python_snapshots__hsm.snap
+++ b/framec/tests/snapshots/python_snapshots__hsm.snap
@@ -123,22 +123,31 @@ class MiniHsm:
         __e = MiniHsmFrameEvent("wake", [])
         __ctx = MiniHsmFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def sleep(self):
         __e = MiniHsmFrameEvent("sleep", [])
         __ctx = MiniHsmFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def signal(self):
         __e = MiniHsmFrameEvent("signal", [])
         __ctx = MiniHsmFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def _state_Live(self, __e, compartment):
         if __e._message == "signal":

--- a/framec/tests/snapshots/python_snapshots__lifecycle.snap
+++ b/framec/tests/snapshots/python_snapshots__lifecycle.snap
@@ -120,15 +120,21 @@ class Lifecycle:
         __e = LifecycleFrameEvent("start", [label])
         __ctx = LifecycleFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def stop(self):
         __e = LifecycleFrameEvent("stop", [])
         __ctx = LifecycleFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def _state_Idle(self, __e, compartment):
         if __e._message == "start":

--- a/framec/tests/snapshots/python_snapshots__lifecycle_args.snap
+++ b/framec/tests/snapshots/python_snapshots__lifecycle_args.snap
@@ -119,22 +119,31 @@ class LifecycleArgs:
         __e = LifecycleArgsFrameEvent("load", [n, label])
         __ctx = LifecycleArgsFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def total(self) -> int:
         __e = LifecycleArgsFrameEvent("total", [])
         __ctx = LifecycleArgsFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def tag(self) -> str:
         __e = LifecycleArgsFrameEvent("tag", [])
         __ctx = LifecycleArgsFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def _state_Idle(self, __e, compartment):
         if __e._message == "load":

--- a/framec/tests/snapshots/python_snapshots__linear_fsm.snap
+++ b/framec/tests/snapshots/python_snapshots__linear_fsm.snap
@@ -121,22 +121,31 @@ class LinearFsm:
         __e = LinearFsmFrameEvent("start", [])
         __ctx = LinearFsmFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def progress(self, amount: int):
         __e = LinearFsmFrameEvent("progress", [amount])
         __ctx = LinearFsmFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def finish(self):
         __e = LinearFsmFrameEvent("finish", [])
         __ctx = LinearFsmFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def _state_Idle(self, __e, compartment):
         if __e._message == "start":

--- a/framec/tests/snapshots/python_snapshots__no_persist.snap
+++ b/framec/tests/snapshots/python_snapshots__no_persist.snap
@@ -116,29 +116,41 @@ class NoPersist:
         __e = NoPersistFrameEvent("bump", [])
         __ctx = NoPersistFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def set_cache(self, v: int):
         __e = NoPersistFrameEvent("set_cache", [v])
         __ctx = NoPersistFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def get_count(self) -> int:
         __e = NoPersistFrameEvent("get_count", [])
         __ctx = NoPersistFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def get_cache(self) -> int:
         __e = NoPersistFrameEvent("get_cache", [])
         __ctx = NoPersistFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def _state_Active(self, __e, compartment):
         if __e._message == "bump":

--- a/framec/tests/snapshots/python_snapshots__persist.snap
+++ b/framec/tests/snapshots/python_snapshots__persist.snap
@@ -115,16 +115,22 @@ class Counter:
         __e = CounterFrameEvent("increment", [by])
         __ctx = CounterFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def value(self) -> int:
         __e = CounterFrameEvent("value", [])
         __ctx = CounterFrameContext(__e, None)
         __ctx._return = 0
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def _state_Counting(self, __e, compartment):
         if __e._message == "increment":

--- a/framec/tests/snapshots/python_snapshots__pushpop.snap
+++ b/framec/tests/snapshots/python_snapshots__pushpop.snap
@@ -119,29 +119,41 @@ class PushPop:
         __e = PushPopFrameEvent("ping", [])
         __ctx = PushPopFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def nest(self):
         __e = PushPopFrameEvent("nest", [])
         __ctx = PushPopFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def unnest(self):
         __e = PushPopFrameEvent("unnest", [])
         __ctx = PushPopFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def leaf(self):
         __e = PushPopFrameEvent("leaf", [])
         __ctx = PushPopFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def _state_Idle(self, __e, compartment):
         if __e._message == "nest":

--- a/framec/tests/snapshots/python_snapshots__return_explicit.snap
+++ b/framec/tests/snapshots/python_snapshots__return_explicit.snap
@@ -114,8 +114,11 @@ class ReturnExplicit:
         __e = ReturnExplicitFrameEvent("decide", [score])
         __ctx = ReturnExplicitFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def _state_Judging(self, __e, compartment):
         if __e._message == "decide":

--- a/framec/tests/snapshots/python_snapshots__selfcall.snap
+++ b/framec/tests/snapshots/python_snapshots__selfcall.snap
@@ -115,15 +115,21 @@ class SelfCall:
         __e = SelfCallFrameEvent("kick", [])
         __ctx = SelfCallFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def report(self) -> int:
         __e = SelfCallFrameEvent("report", [])
         __ctx = SelfCallFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def _state_Active(self, __e, compartment):
         if __e._message == "kick":

--- a/framec/tests/snapshots/python_snapshots__state_args.snap
+++ b/framec/tests/snapshots/python_snapshots__state_args.snap
@@ -117,22 +117,31 @@ class StateArgs:
         __e = StateArgsFrameEvent("load", [initial])
         __ctx = StateArgsFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def adjust(self, delta: int):
         __e = StateArgsFrameEvent("adjust", [delta])
         __ctx = StateArgsFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def peek(self) -> int:
         __e = StateArgsFrameEvent("peek", [])
         __ctx = StateArgsFrameContext(__e, None)
         self._context_stack.append(__ctx)
-        self.__kernel(__e)
-        return self._context_stack.pop()._return
+        try:
+            self.__kernel(__e)
+        finally:
+            __frame_ctx = self._context_stack.pop()
+        return __frame_ctx._return
 
     def _state_Idle(self, __e, compartment):
         if __e._message == "load":

--- a/framec/tests/snapshots/ruby_snapshots__actions.snap
+++ b/framec/tests/snapshots/ruby_snapshots__actions.snap
@@ -154,16 +154,24 @@ class Actions
         __e = ActionsFrameEvent.new("increment", [n])
         __ctx = ActionsFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def get_total
         __e = ActionsFrameEvent.new("get_total", [])
         __ctx = ActionsFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def _state_Counting(__e, compartment)

--- a/framec/tests/snapshots/ruby_snapshots__consts.snap
+++ b/framec/tests/snapshots/ruby_snapshots__consts.snap
@@ -160,16 +160,24 @@ class Consts
         __e = ConstsFrameEvent.new("tick", [])
         __ctx = ConstsFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def get_count
         __e = ConstsFrameEvent.new("get_count", [])
         __ctx = ConstsFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def _state_Running(__e, compartment)

--- a/framec/tests/snapshots/ruby_snapshots__forward.snap
+++ b/framec/tests/snapshots/ruby_snapshots__forward.snap
@@ -158,16 +158,24 @@ class Forward
         __e = ForwardFrameEvent.new("run", [])
         __ctx = ForwardFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def finish
         __e = ForwardFrameEvent.new("finish", [])
         __ctx = ForwardFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def _state_Start(__e, compartment)

--- a/framec/tests/snapshots/ruby_snapshots__hsm.snap
+++ b/framec/tests/snapshots/ruby_snapshots__hsm.snap
@@ -160,24 +160,36 @@ class MiniHsm
         __e = MiniHsmFrameEvent.new("wake", [])
         __ctx = MiniHsmFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def sleep
         __e = MiniHsmFrameEvent.new("sleep", [])
         __ctx = MiniHsmFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def signal
         __e = MiniHsmFrameEvent.new("signal", [])
         __ctx = MiniHsmFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def _state_Live(__e, compartment)

--- a/framec/tests/snapshots/ruby_snapshots__lifecycle.snap
+++ b/framec/tests/snapshots/ruby_snapshots__lifecycle.snap
@@ -159,16 +159,24 @@ class Lifecycle
         __e = LifecycleFrameEvent.new("start", [label])
         __ctx = LifecycleFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def stop
         __e = LifecycleFrameEvent.new("stop", [])
         __ctx = LifecycleFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def _state_Idle(__e, compartment)

--- a/framec/tests/snapshots/ruby_snapshots__lifecycle_args.snap
+++ b/framec/tests/snapshots/ruby_snapshots__lifecycle_args.snap
@@ -157,24 +157,36 @@ class LifecycleArgs
         __e = LifecycleArgsFrameEvent.new("load", [n, label])
         __ctx = LifecycleArgsFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def total
         __e = LifecycleArgsFrameEvent.new("total", [])
         __ctx = LifecycleArgsFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def tag
         __e = LifecycleArgsFrameEvent.new("tag", [])
         __ctx = LifecycleArgsFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def _state_Idle(__e, compartment)

--- a/framec/tests/snapshots/ruby_snapshots__linear_fsm.snap
+++ b/framec/tests/snapshots/ruby_snapshots__linear_fsm.snap
@@ -156,24 +156,36 @@ class LinearFsm
         __e = LinearFsmFrameEvent.new("start", [])
         __ctx = LinearFsmFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def progress(amount)
         __e = LinearFsmFrameEvent.new("progress", [amount])
         __ctx = LinearFsmFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def finish
         __e = LinearFsmFrameEvent.new("finish", [])
         __ctx = LinearFsmFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def _state_Idle(__e, compartment)

--- a/framec/tests/snapshots/ruby_snapshots__no_persist.snap
+++ b/framec/tests/snapshots/ruby_snapshots__no_persist.snap
@@ -156,32 +156,48 @@ class NoPersist
         __e = NoPersistFrameEvent.new("bump", [])
         __ctx = NoPersistFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def set_cache(v)
         __e = NoPersistFrameEvent.new("set_cache", [v])
         __ctx = NoPersistFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def get_count
         __e = NoPersistFrameEvent.new("get_count", [])
         __ctx = NoPersistFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def get_cache
         __e = NoPersistFrameEvent.new("get_cache", [])
         __ctx = NoPersistFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def _state_Active(__e, compartment)

--- a/framec/tests/snapshots/ruby_snapshots__persist.snap
+++ b/framec/tests/snapshots/ruby_snapshots__persist.snap
@@ -154,8 +154,12 @@ class Counter
         __e = CounterFrameEvent.new("increment", [by])
         __ctx = CounterFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def value
@@ -163,8 +167,12 @@ class Counter
         __ctx = CounterFrameContext.new(__e, nil)
         __ctx._return = 0
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def _state_Counting(__e, compartment)

--- a/framec/tests/snapshots/ruby_snapshots__pushpop.snap
+++ b/framec/tests/snapshots/ruby_snapshots__pushpop.snap
@@ -157,32 +157,48 @@ class PushPop
         __e = PushPopFrameEvent.new("ping", [])
         __ctx = PushPopFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def nest
         __e = PushPopFrameEvent.new("nest", [])
         __ctx = PushPopFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def unnest
         __e = PushPopFrameEvent.new("unnest", [])
         __ctx = PushPopFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def leaf
         __e = PushPopFrameEvent.new("leaf", [])
         __ctx = PushPopFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def _state_Idle(__e, compartment)

--- a/framec/tests/snapshots/ruby_snapshots__return_explicit.snap
+++ b/framec/tests/snapshots/ruby_snapshots__return_explicit.snap
@@ -152,8 +152,12 @@ class ReturnExplicit
         __e = ReturnExplicitFrameEvent.new("decide", [score])
         __ctx = ReturnExplicitFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def _state_Judging(__e, compartment)

--- a/framec/tests/snapshots/ruby_snapshots__selfcall.snap
+++ b/framec/tests/snapshots/ruby_snapshots__selfcall.snap
@@ -154,16 +154,24 @@ class SelfCall
         __e = SelfCallFrameEvent.new("kick", [])
         __ctx = SelfCallFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def report
         __e = SelfCallFrameEvent.new("report", [])
         __ctx = SelfCallFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def _state_Active(__e, compartment)

--- a/framec/tests/snapshots/ruby_snapshots__state_args.snap
+++ b/framec/tests/snapshots/ruby_snapshots__state_args.snap
@@ -153,24 +153,36 @@ class StateArgs
         __e = StateArgsFrameEvent.new("load", [initial])
         __ctx = StateArgsFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def adjust(delta)
         __e = StateArgsFrameEvent.new("adjust", [delta])
         __ctx = StateArgsFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def peek
         __e = StateArgsFrameEvent.new("peek", [])
         __ctx = StateArgsFrameContext.new(__e, nil)
         @_context_stack.push(__ctx)
-        __kernel(__e)
-        return @_context_stack.pop._return
+        begin
+            __kernel(__e)
+            return @_context_stack.last._return
+        ensure
+            @_context_stack.pop
+        end
     end
 
     def _state_Idle(__e, compartment)

--- a/framec/tests/snapshots/typescript_snapshots__actions.snap
+++ b/framec/tests/snapshots/typescript_snapshots__actions.snap
@@ -162,16 +162,24 @@ export class Actions {
         const __e = new ActionsFrameEvent("increment", [n]);
         const __ctx = new ActionsFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        this._context_stack.pop();
+        try {
+            this.__kernel(__e);
+        } finally {
+            this._context_stack.pop();
+        }
     }
 
     public get_total(): number {
         const __e = new ActionsFrameEvent("get_total", []);
         const __ctx = new ActionsFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()!._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()!._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     private _state_Counting(__e: ActionsFrameEvent, compartment: ActionsCompartment) {

--- a/framec/tests/snapshots/typescript_snapshots__consts.snap
+++ b/framec/tests/snapshots/typescript_snapshots__consts.snap
@@ -166,16 +166,24 @@ export class Consts {
         const __e = new ConstsFrameEvent("tick", []);
         const __ctx = new ConstsFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        this._context_stack.pop();
+        try {
+            this.__kernel(__e);
+        } finally {
+            this._context_stack.pop();
+        }
     }
 
     public get_count(): number {
         const __e = new ConstsFrameEvent("get_count", []);
         const __ctx = new ConstsFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()!._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()!._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     private _state_Running(__e: ConstsFrameEvent, compartment: ConstsCompartment) {

--- a/framec/tests/snapshots/typescript_snapshots__forward.snap
+++ b/framec/tests/snapshots/typescript_snapshots__forward.snap
@@ -165,16 +165,22 @@ export class Forward {
         const __e = new ForwardFrameEvent("run", []);
         const __ctx = new ForwardFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        this._context_stack.pop();
+        try {
+            this.__kernel(__e);
+        } finally {
+            this._context_stack.pop();
+        }
     }
 
     public finish() {
         const __e = new ForwardFrameEvent("finish", []);
         const __ctx = new ForwardFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        this._context_stack.pop();
+        try {
+            this.__kernel(__e);
+        } finally {
+            this._context_stack.pop();
+        }
     }
 
     private _state_Start(__e: ForwardFrameEvent, compartment: ForwardCompartment) {

--- a/framec/tests/snapshots/typescript_snapshots__hsm.snap
+++ b/framec/tests/snapshots/typescript_snapshots__hsm.snap
@@ -166,24 +166,33 @@ export class MiniHsm {
         const __e = new MiniHsmFrameEvent("wake", []);
         const __ctx = new MiniHsmFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        this._context_stack.pop();
+        try {
+            this.__kernel(__e);
+        } finally {
+            this._context_stack.pop();
+        }
     }
 
     public sleep() {
         const __e = new MiniHsmFrameEvent("sleep", []);
         const __ctx = new MiniHsmFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        this._context_stack.pop();
+        try {
+            this.__kernel(__e);
+        } finally {
+            this._context_stack.pop();
+        }
     }
 
     public signal() {
         const __e = new MiniHsmFrameEvent("signal", []);
         const __ctx = new MiniHsmFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        this._context_stack.pop();
+        try {
+            this.__kernel(__e);
+        } finally {
+            this._context_stack.pop();
+        }
     }
 
     private _state_Live(__e: MiniHsmFrameEvent, compartment: MiniHsmCompartment) {

--- a/framec/tests/snapshots/typescript_snapshots__lifecycle.snap
+++ b/framec/tests/snapshots/typescript_snapshots__lifecycle.snap
@@ -165,16 +165,22 @@ export class Lifecycle {
         const __e = new LifecycleFrameEvent("start", [label]);
         const __ctx = new LifecycleFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        this._context_stack.pop();
+        try {
+            this.__kernel(__e);
+        } finally {
+            this._context_stack.pop();
+        }
     }
 
     public stop() {
         const __e = new LifecycleFrameEvent("stop", []);
         const __ctx = new LifecycleFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        this._context_stack.pop();
+        try {
+            this.__kernel(__e);
+        } finally {
+            this._context_stack.pop();
+        }
     }
 
     private _state_Idle(__e: LifecycleFrameEvent, compartment: LifecycleCompartment) {

--- a/framec/tests/snapshots/typescript_snapshots__lifecycle_args.snap
+++ b/framec/tests/snapshots/typescript_snapshots__lifecycle_args.snap
@@ -164,24 +164,37 @@ export class LifecycleArgs {
         const __e = new LifecycleArgsFrameEvent("load", [n, label]);
         const __ctx = new LifecycleArgsFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        this._context_stack.pop();
+        try {
+            this.__kernel(__e);
+        } finally {
+            this._context_stack.pop();
+        }
     }
 
     public total(): number {
         const __e = new LifecycleArgsFrameEvent("total", []);
         const __ctx = new LifecycleArgsFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()!._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()!._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     public tag(): string {
         const __e = new LifecycleArgsFrameEvent("tag", []);
         const __ctx = new LifecycleArgsFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()!._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()!._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     private _state_Idle(__e: LifecycleArgsFrameEvent, compartment: LifecycleArgsCompartment) {

--- a/framec/tests/snapshots/typescript_snapshots__linear_fsm.snap
+++ b/framec/tests/snapshots/typescript_snapshots__linear_fsm.snap
@@ -164,24 +164,33 @@ export class LinearFsm {
         const __e = new LinearFsmFrameEvent("start", []);
         const __ctx = new LinearFsmFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        this._context_stack.pop();
+        try {
+            this.__kernel(__e);
+        } finally {
+            this._context_stack.pop();
+        }
     }
 
     public progress(amount: number) {
         const __e = new LinearFsmFrameEvent("progress", [amount]);
         const __ctx = new LinearFsmFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        this._context_stack.pop();
+        try {
+            this.__kernel(__e);
+        } finally {
+            this._context_stack.pop();
+        }
     }
 
     public finish() {
         const __e = new LinearFsmFrameEvent("finish", []);
         const __ctx = new LinearFsmFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        this._context_stack.pop();
+        try {
+            this.__kernel(__e);
+        } finally {
+            this._context_stack.pop();
+        }
     }
 
     private _state_Idle(__e: LinearFsmFrameEvent, compartment: LinearFsmCompartment) {

--- a/framec/tests/snapshots/typescript_snapshots__no_persist.snap
+++ b/framec/tests/snapshots/typescript_snapshots__no_persist.snap
@@ -163,32 +163,48 @@ export class NoPersist {
         const __e = new NoPersistFrameEvent("bump", []);
         const __ctx = new NoPersistFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        this._context_stack.pop();
+        try {
+            this.__kernel(__e);
+        } finally {
+            this._context_stack.pop();
+        }
     }
 
     public set_cache(v: number) {
         const __e = new NoPersistFrameEvent("set_cache", [v]);
         const __ctx = new NoPersistFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        this._context_stack.pop();
+        try {
+            this.__kernel(__e);
+        } finally {
+            this._context_stack.pop();
+        }
     }
 
     public get_count(): number {
         const __e = new NoPersistFrameEvent("get_count", []);
         const __ctx = new NoPersistFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()!._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()!._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     public get_cache(): number {
         const __e = new NoPersistFrameEvent("get_cache", []);
         const __ctx = new NoPersistFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()!._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()!._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     private _state_Active(__e: NoPersistFrameEvent, compartment: NoPersistCompartment) {

--- a/framec/tests/snapshots/typescript_snapshots__persist.snap
+++ b/framec/tests/snapshots/typescript_snapshots__persist.snap
@@ -162,8 +162,11 @@ export class Counter {
         const __e = new CounterFrameEvent("increment", [by]);
         const __ctx = new CounterFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        this._context_stack.pop();
+        try {
+            this.__kernel(__e);
+        } finally {
+            this._context_stack.pop();
+        }
     }
 
     public value(): number {
@@ -171,8 +174,13 @@ export class Counter {
         const __ctx = new CounterFrameContext(__e, null);
         __ctx._return = 0;
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()!._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()!._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     private _state_Counting(__e: CounterFrameEvent, compartment: CounterCompartment) {

--- a/framec/tests/snapshots/typescript_snapshots__pushpop.snap
+++ b/framec/tests/snapshots/typescript_snapshots__pushpop.snap
@@ -164,32 +164,44 @@ export class PushPop {
         const __e = new PushPopFrameEvent("ping", []);
         const __ctx = new PushPopFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        this._context_stack.pop();
+        try {
+            this.__kernel(__e);
+        } finally {
+            this._context_stack.pop();
+        }
     }
 
     public nest() {
         const __e = new PushPopFrameEvent("nest", []);
         const __ctx = new PushPopFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        this._context_stack.pop();
+        try {
+            this.__kernel(__e);
+        } finally {
+            this._context_stack.pop();
+        }
     }
 
     public unnest() {
         const __e = new PushPopFrameEvent("unnest", []);
         const __ctx = new PushPopFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        this._context_stack.pop();
+        try {
+            this.__kernel(__e);
+        } finally {
+            this._context_stack.pop();
+        }
     }
 
     public leaf() {
         const __e = new PushPopFrameEvent("leaf", []);
         const __ctx = new PushPopFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        this._context_stack.pop();
+        try {
+            this.__kernel(__e);
+        } finally {
+            this._context_stack.pop();
+        }
     }
 
     private _state_Idle(__e: PushPopFrameEvent, compartment: PushPopCompartment) {

--- a/framec/tests/snapshots/typescript_snapshots__return_explicit.snap
+++ b/framec/tests/snapshots/typescript_snapshots__return_explicit.snap
@@ -161,8 +161,13 @@ export class ReturnExplicit {
         const __e = new ReturnExplicitFrameEvent("decide", [score]);
         const __ctx = new ReturnExplicitFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()!._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()!._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     private _state_Judging(__e: ReturnExplicitFrameEvent, compartment: ReturnExplicitCompartment) {

--- a/framec/tests/snapshots/typescript_snapshots__selfcall.snap
+++ b/framec/tests/snapshots/typescript_snapshots__selfcall.snap
@@ -162,16 +162,24 @@ export class SelfCall {
         const __e = new SelfCallFrameEvent("kick", []);
         const __ctx = new SelfCallFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        this._context_stack.pop();
+        try {
+            this.__kernel(__e);
+        } finally {
+            this._context_stack.pop();
+        }
     }
 
     public report(): number {
         const __e = new SelfCallFrameEvent("report", []);
         const __ctx = new SelfCallFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()!._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()!._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     private _state_Active(__e: SelfCallFrameEvent, compartment: SelfCallCompartment) {

--- a/framec/tests/snapshots/typescript_snapshots__state_args.snap
+++ b/framec/tests/snapshots/typescript_snapshots__state_args.snap
@@ -162,24 +162,35 @@ export class StateArgs {
         const __e = new StateArgsFrameEvent("load", [initial]);
         const __ctx = new StateArgsFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        this._context_stack.pop();
+        try {
+            this.__kernel(__e);
+        } finally {
+            this._context_stack.pop();
+        }
     }
 
     public adjust(delta: number) {
         const __e = new StateArgsFrameEvent("adjust", [delta]);
         const __ctx = new StateArgsFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        this._context_stack.pop();
+        try {
+            this.__kernel(__e);
+        } finally {
+            this._context_stack.pop();
+        }
     }
 
     public peek(): number {
         const __e = new StateArgsFrameEvent("peek", []);
         const __ctx = new StateArgsFrameContext(__e, null);
         this._context_stack.push(__ctx);
-        this.__kernel(__e);
-        return this._context_stack.pop()!._return;
+        try {
+            this.__kernel(__e);
+            return this._context_stack.pop()!._return;
+        } catch (__frame_err) {
+            this._context_stack.pop();
+            throw __frame_err;
+        }
     }
 
     private _state_Idle(__e: StateArgsFrameEvent, compartment: StateArgsCompartment) {


### PR DESCRIPTION
Carries the breaking language work for **4.4.0**, on top of RFC-0043 (already on main).

## RFC-0045 — reserve `@@:system.state`, relocate name to `@@:system.state.name` (BREAKING)
- The current-state name accessor moves from `@@:system.state` to **`@@:system.state.name`**.
- Bare `@@:system.state` is now **reserved** (future direct compartment reference) and a hard error (**E608**) with a fix-it message.
- Generated output for `.state.name` is **byte-identical** on all 17 backends to what `@@:system.state` produced before.
- Grammar change in the dogfooded `context_parser.frs` (+ regenerated `.gen.rs`); E604 hint + E421 retargeted.
- Pre-public-beta: no published program affected. Docs migrated; RFC-0045 doc added.

## RFC-0044 / D-PY-1 — context stack cleans up on a handler exception
- The interface dispatch wrapper now pops the context stack even when a handler **throws** — previously a throwing handler leaked a stale entry per call (the leak RFC-0043's casing surfaced; RFC-0044 documents it).
- Fixed across **12 backends** with each language's idiom (try/finally, try/catch+rethrow, begin/ensure, `defer`, `pcall`+re-raise). Holds under RFC-0043's casing (the machine layer carries the guard).
- C / GDScript / Swift / Erlang are exempt (no catchable exception through dispatch).

## Release
- `Cargo.toml` 4.3.0 → **4.4.0** (framec + framec-wasm; Cargo.lock); README badge; CHANGELOG `[4.4.0]`.

## Validation
- `cargo test --lib` **518** + 46 snapshots + **118 doc samples** green.
- **Full 17-language matrix: 17/17, 0 failures** on the rebased stack (RFC-0045 + D-PY-1 on top of RFC-0043), incl. 14 per-backend throw-leak fixtures (see the paired test-env PR).

> Paired with test-env PR (fixture migration + per-backend throw fixtures + rust-runner hardening) — should land together. CHANGELOG `[4.4.0]` overlaps the graphviz PR (#40); trivial merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)