### PR TITLE
docs(rfc-0043): align async docs with shipped @@[async] casing/machine

### DIFF
--- a/docs/frame_cookbook.md
+++ b/docs/frame_cookbook.md
@@ -1197,6 +1197,7 @@ if __name__ == '__main__':
 
 ```frame
 @@[target("python_3")]
+@@[async]
 
 import aiohttp
 import asyncio
@@ -1224,7 +1225,7 @@ import asyncio
             fetch(path: str): str {
                 async with aiohttp.ClientSession() as session:
                     async with session.get(self.base_url + path) as resp:
-                        return await resp.text()
+                        @@:(await resp.text())
             }
             disconnect() { -> $Idle }
         }
@@ -1244,9 +1245,9 @@ async def main():
 asyncio.run(main())
 ```
 
-**How it works:** `async` on interface methods makes the entire dispatch chain async. The constructor is synchronous — `await client.init()` fires the enter event separately (two-phase init). Native `await` in handler bodies works because the generated methods are async.
+**How it works:** The `@@[async]` header marks this as an async system (required — without it framec raises E720). `async` on interface methods makes the entire dispatch chain async. framec emits a public casing (`HttpClient`) that enforces single-driver entry over a private machine; the constructor is synchronous — `await client.init()` fires the enter event separately (two-phase init). Native `await` in handler bodies works because the generated methods are async.
 
-**Features used:** `async` interface methods, two-phase init, native async code in handlers
+**Features used:** `@@[async]` system attribute, `async` interface methods, two-phase init, native async code in handlers
 
 -----
 

--- a/docs/frame_getting_started.md
+++ b/docs/frame_getting_started.md
@@ -1552,14 +1552,32 @@ Some state machines need to do asynchronous work — network calls, file I/O, ti
 
 ### Declaring Async Methods
 
-Add `async` before interface methods, actions, or operations:
+Add `async` before interface methods, actions, or operations — and mark the
+system itself with `@@[async]` on the line just above `@@system`:
 
 ```frame
-interface:
-    async connect(url: str)
-    async receive(): Message
-    get_state(): str          # This one stays sync
+@@[async]
+@@system Connection {
+    interface:
+        async connect(url: str)
+        async receive(): Message
+        get_state(): str          # This one stays sync
+
+    machine:
+        $Idle { ... }
+}
 ```
+
+The `@@[async]` attribute is **required** whenever a system has any async member.
+Forget it and the compiler stops you with a clear error:
+
+```
+E720: @@system 'Connection' declares async member(s) but lacks the
+       `@@[async]` system-header attribute (RFC-0043).
+```
+
+If you're migrating older Frame sources, `framec project add-async-attr <path>`
+inserts the attribute for you across a whole tree.
 
 ### How Async Propagates
 
@@ -1569,10 +1587,31 @@ This means callers must `await` every method on an async system, even `get_state
 
 Sync methods on an async system still work correctly — awaiting a synchronous function is a no-op in most languages.
 
+### One Driver at a Time
+
+An `@@[async]` system is generated as two classes: the **casing** (the public
+class with the name you declared) and a private **machine** (`_Connection­Machine`)
+that holds the actual state-machine dispatch. You only ever touch the casing.
+
+The casing enforces a **single-driver** rule: only one interface call may be in
+flight at a time. If a second call arrives while the first is still running —
+for example, awaiting a slow `connect()` and then calling `receive()` before it
+finishes — the casing raises `E703`:
+
+```
+E703: system busy: cannot enter 'receive' while 'connect' is in flight
+```
+
+This catches a common async bug — accidentally driving one state machine from
+two concurrent tasks. Each backend raises `E703` as a normal, catchable error
+(a `RuntimeError` in Python, an `Error` in TypeScript, `Err(FrameE703Error)` in
+Rust, and so on), so you can recover from it if a retry makes sense.
+
 ### Example
 
 ```frame
 @@[target("python_3")]
+@@[async]
 
 @@system HttpClient {
     interface:

--- a/docs/frame_language.md
+++ b/docs/frame_language.md
@@ -929,46 +929,131 @@ system-level *inclusion* list — `@@[persist_fields([...])]` — is tracked in
 
 ## Async
 
-Interface methods, actions, and operations can be declared `async`:
+Interface methods, actions, and operations can be declared `async`. A system
+that declares **any** async member **must** carry the `@@[async]` attribute on a
+line immediately preceding `@@system` (RFC-0043):
 
 ```frame
-interface:
-    async connect(url: str)
-    async receive(): Message
+@@[async]
+@@system HttpClient {
+    interface:
+        async connect(url: str)
+        async receive(): Message
 
-actions:
-    async fetch_data() {
-        return await http.get("/data")
-    }
+    machine:
+        $Idle {
+            connect(url: str) { ... }
+        }
+
+    actions:
+        async fetch_data() {
+            return await http.get("/data")
+        }
+}
 ```
 
-If ANY interface method is `async`, the entire dispatch chain becomes async (with a couple of per-language carve-outs noted below). Async systems use a two-phase init: `s = @@System()` (sync construct), then `await s.init()` (async — fires the `$>` enter event). Swift is the exception: `init` is a reserved keyword, so the async entry point is named `initAsync()`.
+`@@[async]` opts the system into the async **layered codegen architecture** (see
+below). It takes no arguments. A system that declares no async members **may**
+still carry `@@[async]` to opt into the single-driver gate without becoming
+async.
 
-| Target | Supported | Mechanism | Caller pattern |
+If ANY interface method is `async`, the entire dispatch chain becomes async
+(with a couple of per-language carve-outs noted below). Async systems use a
+two-phase init: `s = @@System()` (sync construct), then `await s.init()` (async
+— fires the `$>` enter event). Swift is the exception: `init` is a reserved
+keyword, so the async entry point is named `initAsync()`.
+
+### Layered architecture: casing + machine
+
+Framec emits an async system `<Name>` as **two classes**:
+
+- **`<Name>` — the casing.** The user-facing class, with the name you declared
+  (`HttpClient`). Each interface method is a *gated wrapper*: it enforces the
+  single-driver contract (below), then delegates to the machine and clears the
+  gate on the way out — on both the happy and the error path. This is the only
+  surface external callers touch; `@@<Other>()` composition and `@@import`
+  resolution always reference this name.
+- **`_<Name>Machine` — the machine.** A private class holding the actual
+  dispatch core — `__kernel`, `__router`, the state methods, the transition
+  loop, the lifecycle cascades. It is byte-for-byte the previous-release
+  single-class emission, minus the public name. Self-calls and kernel-internal
+  dispatch run against the machine directly and **never** touch the gate.
+
+The machine is internal — private to the file / module / namespace per the
+target's privacy unit. **User code must not name `_<Name>Machine` directly**;
+its surface is unstable between releases.
+
+### The single-driver gate (`E703`)
+
+The casing permits **at most one external dispatch in flight at a time**. If an
+interface method is entered while another is already running (re-entrant or
+concurrent external entry), the casing raises **`E703`**:
+
+```
+E703: system busy: cannot enter '<method>' while '<in-flight method>' is in flight
+```
+
+`E703` reports a programming error — a violation of the single-driver contract,
+not a recoverable runtime condition. Operations and persist save/load pass
+through to the machine **without** the gate (they're explicitly non-dispatching).
+
+Two validator errors guard the attribute itself:
+
+- **`E720`** — a system declares an async member but lacks `@@[async]`. This is
+  a **hard cut**: no warning grace period. Add the attribute, or run the
+  migration codemod (below).
+- **`E721`** — a *sync* system has a domain field whose type names an `@@[async]`
+  system declared in the same file. A sync holder can't await the async
+  system's wrappers without itself becoming async; add `@@[async]` to the
+  holder. (Same-file only — cross-file composition via `@@import` is not yet
+  resolved.)
+
+### Per-target support
+
+| Target | Supported | Mechanism | `E703` surface |
 |---|---|---|---|
-| Python | Yes | `async def` + `await` | `asyncio.run(main())` |
-| TypeScript | Yes | `async` + `await`, `Promise<T>` | `await worker.get_status()` |
-| JavaScript | Yes | `async` + `await`, `Promise<T>` | `await worker.get_status()` |
-| Rust | Yes | `async fn` + `.await`, boxed futures for recursion | runtime-dependent (tokio / async-std) |
-| Dart | Yes | `Future<T> foo() async` + `await` | `await worker.get_status()` |
-| GDScript | Yes | bare `await` on dispatch calls (no keyword) | `await worker.get_status()` |
-| Kotlin | Yes | `suspend fun` — suspend→suspend calls are bare, no `await` keyword | `runBlocking { worker.get_status() }` |
-| Swift | Yes | `func foo() async -> T`; async entry is `initAsync()` (not `init()`) | `Task { await worker.get_status() }` |
-| C# | Yes | `async Task<T>` | `await worker.get_status()` (inside an async method) |
-| Java | Yes | `CompletableFuture<T>` on the public interface only — internal dispatch (`__kernel`, `__router`, `_state_X`) stays synchronous. Bodies run sync and wrap the result via `CompletableFuture.completedFuture(...)`. | `worker.get_status().get()` |
-| C++ | Yes (C++23) | `FrameTask<T>` coroutine promise emitted header-guarded at file scope. `suspend_never` initial + `suspend_always` final — bodies run sync until a real `co_await`; callers extract via `.get()`. | `worker.get_status().get()` |
-| C | No | No native async/await. `async` on an interface method is a framec error (the test environment marks these with `@@skip`). | — |
+| Python | Yes | `async def` + `await` | `RuntimeError` |
+| TypeScript | Yes | `async` + `await`, `Promise<T>` | `Error` |
+| JavaScript | Yes | `async` + `await`, `Promise<T>` | `Error` |
+| Rust | Yes | `async fn` + `.await`, boxed futures for recursion | `Err(FrameE703Error)` — recoverable via `?` (D5) |
+| Dart | Yes | `Future<T> foo() async` + `await` | `StateError` |
+| GDScript | Yes | bare `await` on dispatch calls (no keyword) | `push_error(...)` + typed-zero return (D3) |
+| Kotlin | Yes | `suspend fun` — suspend→suspend calls are bare, no `await` keyword | `IllegalStateException` |
+| Swift | Yes | `func foo() async throws -> T`; async entry is `initAsync()` (not `init()`) | `throws FrameE703Error` (D2) |
+| C# | Yes | `async Task<T>` | `InvalidOperationException` |
+| Java | Yes | `CompletableFuture<T>` on the casing only — the machine's internal dispatch (`__kernel`, `__router`, `_state_X`) stays synchronous. Bodies run sync and wrap the result via `CompletableFuture.completedFuture(...)`. | `CompletableFuture.failedFuture(RuntimeException)` |
+| C++ | Yes (C++23) | `FrameTask<T>` coroutine promise emitted header-guarded at file scope. `suspend_never` initial + `suspend_always` final — bodies run sync until a real `co_await`; callers extract via `.get()`. | `std::runtime_error` |
+| C | No | No native async/await. `async` members are a framec error (the test environment marks these with `@@skip`). | — |
 | Go | No | No `async`/`await` keyword. Goroutines + channels model concurrency differently. | — |
 | PHP | No | No native async. Fibers (PHP 8.1+) exist but framec has no PHP fiber backend. | — |
 | Ruby | No | No native async. Fibers/Async gem exist but framec has no Ruby fiber backend. | — |
 | Lua | No | No native async. Coroutines exist but framec has no Lua coroutine backend. | — |
 | Erlang | No | gen_statem is a one-color functional async model — `async` isn't applicable. | — |
 
+The `E703` surface is **recoverable** on every layered backend: callers can
+catch it (`try`/`catch`), `?`-chain it (Rust), or `try?` it (Swift). It is never
+a process-aborting `panic!`/`fatalError`/stripped-`assert`.
+
 **Notes:**
 
 - **Kotlin** is the one supported language that does *not* take an `await` keyword on internal dispatch calls — a `suspend fun` calling another `suspend fun` is bare syntax. This is handled by the framec backend.
-- **Java** (no native async/await) uses `CompletableFuture<T>` for the public interface only; the dispatch chain stays sync so the call graph doesn't explode through `.thenCompose(...)`. Net cost: callers `.get()`.
+- **Java** (no native async/await) uses `CompletableFuture<T>` for the casing only; the machine's dispatch chain stays sync so the call graph doesn't explode through `.thenCompose(...)`. Net cost: callers `.get()`.
 - **C++** target must be `cpp_23` (the default `cpp`/`cpp_17` aliases also work, but the compiler needs ≥ C++20 for coroutines — see `framepiler_design.md` for the `FrameTask<T>` model).
+
+### Migration
+
+Existing pre-RFC-0043 sources that declare async members without `@@[async]` are
+mechanically migrated — the codemod inserts a single `@@[async]` line above each
+affected `@@system` header and changes nothing else:
+
+```bash
+framec project add-async-attr path/to/source-tree
+```
+
+```javascript
+import { migrate_async_attr } from "@frame-lang/framec-wasm";
+const migrated = migrate_async_attr(originalSource);
+```
 
 ---
 

--- a/docs/frame_quickstart.md
+++ b/docs/frame_quickstart.md
@@ -89,7 +89,7 @@ interface:
     event(a: T, b: U)                 # typed params (types are opaque strings)
     event(): ret                      # return type, no default
     event(): ret = "default"          # return type with default value
-    async event()                     # async variant
+    async event()                     # async variant — requires @@[async] on the system header
 ```
 
 ---

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -32,10 +32,14 @@ read domain variables and the system / self / return accessors but cannot fire
 
 ### async system
 
-A [system](#system) whose [interface](#interface) methods are generated as the
-host language's asynchronous form (`async`/`await`, `CompletableFuture`,
-`Future`, …) while its internal [dispatch](#dispatch) stays synchronous. Enabled
-by an `async` modifier on interface methods. See
+A [system](#system) that declares one or more `async` members (interface
+method, [action](#action), or [operation](#operation)) and carries the
+**required** `@@[async]` header attribute. Its public methods are generated as
+the host language's asynchronous form (`async`/`await`, `CompletableFuture`,
+`Future`, …). An async system is emitted as two classes — a public
+[casing](#casing) that enforces single-driver entry and a private
+[machine](#machine-async-system) that holds the dispatch core. Declaring an async
+member without `@@[async]` is the hard error **E720**. See
 [language reference § Async](frame_language.md#async).
 
 ### backbone
@@ -47,6 +51,18 @@ to [oracles](#oracle). Named for being the structural spine the specialists
 attach to. framec's own parser is organized this way — one `SystemBackbone`
 system whose flat self-looping states cover the entire token-level outer grammar.
 See [RFC-0039](rfcs/rfc-0039.md#terminology).
+
+### casing
+
+The public class framec emits for an [async system](#async-system) — the one
+bearing the user-declared name. Each [interface](#interface) method is a gated
+wrapper that enforces the single-driver contract (raising **E703** on
+concurrent external entry), then delegates to the private
+[machine](#machine-async-system) and clears the gate on both the success and
+the error path. [Operations](#operation) and persist save/load pass through
+without the gate. The casing is the only surface external callers and
+[composition](#composed-system) touch. Introduced in
+[RFC-0043](rfcs/rfc-0043.md). See [language reference § Async](frame_language.md#async).
 
 ### compartment
 
@@ -186,6 +202,16 @@ A [system](#system)'s state machine, declared in the `machine:` block: its
 [states](#state), their [handlers](#event-handler), and the
 [transitions](#transition) between them. See
 [language reference § Machine Section](frame_language.md#machine-section).
+
+### machine (async system)
+
+The private class (`_<Name>Machine`) framec emits for an
+[async system](#async-system), holding the actual dispatch core — kernel,
+router, state methods, transition loop, and lifecycle cascades. It is the
+previous-release single-class emission minus the public name; self-calls
+and kernel-internal dispatch run against it directly, bypassing the
+[casing](#casing)'s gate. It is internal: user code must not name
+`_<Name>Machine` directly. Introduced in [RFC-0043](rfcs/rfc-0043.md).
 
 ### no-initialization
 

--- a/docs/per_language_guides/cpp.md
+++ b/docs/per_language_guides/cpp.md
@@ -258,6 +258,18 @@ For the Frame test matrix, this is wired up via
 `memory/audit_phase8_2026_04_26.md` for the C++ async wiring
 context.
 
+### Single-driver gate (`@@[async]`)
+
+An `@@[async]` system is emitted as a public **casing** (`class
+<Name>`) wrapping a private **`_<Name>Machine`**. Each casing method
+returns `FrameTask<T>` and gates external entry: if the system is
+already `busy` when a second call arrives, it throws
+`std::runtime_error("E703: …")` (the single-driver contract,
+**E703**). The casing wraps the machine's `co_await` in a
+`try/catch(...)` that clears the `busy` flag and rethrows, so the
+gate clears on both the normal and the throwing path. See
+[language reference § Async](../frame_language.md#async).
+
 ---
 
 ## Loop idioms — both work; idiom 1 is natural

--- a/docs/per_language_guides/csharp.md
+++ b/docs/per_language_guides/csharp.md
@@ -157,6 +157,16 @@ on C# (unlike Java's `CompletableFuture.completedFuture(...)`)
 because C#'s compiler-generated state machine handles the
 synchronous-completion case efficiently.
 
+### Single-driver gate (`@@[async]`)
+
+An `@@[async]` system is emitted as a public **casing** (`public
+class <Name>`) wrapping a private **`_<Name>Machine`**. Each
+interface method gates external entry: if the system is already
+`busy` when a second call arrives, it throws
+`new InvalidOperationException("E703: …")` (the single-driver
+contract, **E703**). The gate is set on entry and cleared in a
+`finally`. See [language reference § Async](../frame_language.md#async).
+
 ---
 
 ## Cross-system fields: direct instantiation

--- a/docs/per_language_guides/dart.md
+++ b/docs/per_language_guides/dart.md
@@ -178,6 +178,16 @@ Dart async is mature:
 - The matrix harness drives async tests via `await` from a
   `Future<void> main()`.
 
+### Single-driver gate (`@@[async]`)
+
+An `@@[async]` system is emitted as a public **casing** (`class
+<Name>`) wrapping a private **`_<Name>Machine`**. Each interface
+method gates external entry: if the system is already `busy` when a
+second call arrives, it throws `StateError("E703: …")` (the
+single-driver contract, **E703**). The gate is set on entry and
+cleared in a `finally`. See
+[language reference § Async](../frame_language.md#async).
+
 ---
 
 ## Cross-system fields: direct instantiation

--- a/docs/per_language_guides/gdscript.md
+++ b/docs/per_language_guides/gdscript.md
@@ -283,6 +283,17 @@ The capability matrix shows GDScript async as ✅ (Stage 5 of Phase 6
 async wiring). See `tests/common/positive/cross_backend/`
 async fixtures for canonical examples.
 
+### Single-driver gate (`@@[async]`)
+
+An `@@[async]` system is emitted as a public **casing** (`class
+<Name>`) wrapping a private **`_<Name>Machine`**. Each interface
+method gates external entry: if the system is already `busy` when a
+second call arrives, it calls `push_error("E703: …")` and returns a
+typed-zero value (the single-driver contract, **E703**). GDScript
+uses `push_error` rather than `assert` because Godot strips `assert`
+in release/`--remap` builds, which would silently drop the gate
+(D3). See [language reference § Async](../frame_language.md#async).
+
 ---
 
 ## Multi-system per file: pick a primary with `@@[main]`

--- a/docs/per_language_guides/java.md
+++ b/docs/per_language_guides/java.md
@@ -231,6 +231,19 @@ yield, restructure to dispatch the work to an executor inside
 the handler body and chain via `.thenApply(...)` —
 framec doesn't auto-emit this pattern.
 
+### Single-driver gate (`@@[async]`)
+
+An `@@[async]` system is emitted as a public **casing** (`public
+class <Name>`) wrapping a private **`_<Name>Machine`** — the casing
+is the only async layer; the machine stays synchronous as described
+above. Each casing method gates external entry: if the system is
+already `busy` when a second call arrives, it returns
+`CompletableFuture.failedFuture(new RuntimeException("E703: …"))` (the
+single-driver contract, **E703**). A real exception thrown by the
+machine is likewise funneled into a `failedFuture`, and the `busy`
+flag is cleared in a `finally`. See
+[language reference § Async](../frame_language.md#async).
+
 ---
 
 ## Loop idioms — both work

--- a/docs/per_language_guides/javascript.md
+++ b/docs/per_language_guides/javascript.md
@@ -108,6 +108,17 @@ async fetch(key) {
 The matrix harness drives async tests via `(async () => { ... })()`
 or by exporting an async `main()` that the runner awaits.
 
+### Single-driver gate (`@@[async]`)
+
+An `@@[async]` system is emitted as a public **casing** (`export
+class <Name>`) wrapping a private **`_<Name>Machine`**. Each
+interface method gates external entry: if the system is already
+`busy` when a second call arrives, it throws
+`` new Error(`E703: …`) `` (the single-driver contract, **E703**) — a
+normal, catchable error. The gate is set on entry and cleared in a
+`finally`, so it clears on both the resolved and the rejected path.
+See [language reference § Async](../frame_language.md#async).
+
 ---
 
 ## Cross-system fields: direct instantiation

--- a/docs/per_language_guides/kotlin.md
+++ b/docs/per_language_guides/kotlin.md
@@ -191,6 +191,16 @@ must be on the classpath. The matrix harness configures this
 via `kotlinx-coroutines-core-*.jar` in
 `docker/runners/kotlin_runner.sh`.
 
+### Single-driver gate (`@@[async]`)
+
+An `@@[async]` system is emitted as a public **casing** (`class
+<Name>`) wrapping a private **`_<Name>Machine`**. Each `suspend fun`
+on the casing gates external entry: if the system is already `busy`
+when a second call arrives, it throws
+`IllegalStateException("E703: …")` (the single-driver contract,
+**E703**). The gate is set on entry and cleared in a `finally`. See
+[language reference § Async](../frame_language.md#async).
+
 ---
 
 ## Companion objects: where state-name constants and trailing comments live

--- a/docs/per_language_guides/python.md
+++ b/docs/per_language_guides/python.md
@@ -123,10 +123,10 @@ Python async is mature:
 
 ## Concurrency and re-entrancy
 
-Frame does **not** manage concurrency. The Python runtime is
-single-threaded by design — the context stack, compartment, and
-state-variable storage on a system instance are **not** guarded
-by locks or atomics. The intended deployment model is:
+Frame does **not** provide thread-level concurrency control — the
+context stack, compartment, and state-variable storage on a system
+instance are **not** guarded by locks or atomics. The intended
+deployment model is:
 
 > **One system instance per session, driven by a single sequential
 > driver.**
@@ -135,6 +135,15 @@ For an automation pipeline, a long-running daemon, or a background
 worker, that typically means one `asyncio` task or one Python
 thread owns each `@@Counter()` instance and serializes events
 through it.
+
+For an `@@[async]` system (RFC-0043), the generated **casing**
+*enforces* this contract on a single event loop: each interface
+method checks a `busy` flag on entry and raises
+`RuntimeError("E703: …")` if a second external call arrives while
+the first is still in flight, then clears the flag in a `finally`.
+This is a cooperative single-driver gate, not a lock — it catches
+the accidental re-entry described below rather than serializing
+true OS-thread parallelism.
 
 ### What's safe
 
@@ -154,13 +163,17 @@ through it.
 - **External re-entry during `await`.** If interface method `A` is
   an `async` method and is currently suspended on
   `await self.cache.get(...)`, calling interface method `B` on the
-  *same* instance from another `asyncio` task will execute `B`
-  against a partially-progressed context stack. The runtime does
-  not detect this.
+  *same* instance from another `asyncio` task re-enters dispatch
+  against a partially-progressed context stack. On an `@@[async]`
+  system the casing **detects** this and raises
+  `RuntimeError("E703: …")` — the corruption is turned into a loud,
+  catchable error. On a non-`@@[async]` system there is no gate and
+  the re-entry runs silently; serialize externally.
 - **Multi-threaded access to one instance.** Frame's generated
-  Python code has no `threading.Lock` around dispatch. Two OS
-  threads calling methods on the same instance race on the
-  compartment and state vars.
+  Python code has no `threading.Lock` around dispatch — the E703
+  gate is a plain boolean, not an atomic, so it does not make an
+  instance thread-safe. Two OS threads calling methods on the same
+  instance still race on the compartment and state vars.
 
 ### Pattern: serialize external events
 

--- a/docs/per_language_guides/rust.md
+++ b/docs/per_language_guides/rust.md
@@ -200,6 +200,19 @@ shape. The Phase 6 fuzz `two_awaits` pattern (`await A; await B;`)
 exercises sequential awaits — landed in commit referenced in
 `memory/rust_full_parity_2026_04_26.md`.
 
+### Single-driver gate (`@@[async]`)
+
+An `@@[async]` system is emitted as a public **casing** (`pub struct
+<Name>`) wrapping a private **`_<Name>Machine`**. Each interface
+method on the casing returns `Result<T, FrameE703Error>`: if the
+system is already `busy` when a second external call enters, it
+returns `Err(FrameE703Error { .. })` (the single-driver contract,
+**E703**). Rust's surface is **recoverable** — callers `?`-chain or
+`match` the error rather than taking a `panic!` (D5). The gate is
+cleared on the way out by a `_GateGuard` whose `Drop` runs even on an
+early-return or unwind. See
+[language reference § Async](../frame_language.md#async).
+
 ---
 
 ## Cross-system fields use `Rc<RefCell<...>>`

--- a/docs/per_language_guides/swift.md
+++ b/docs/per_language_guides/swift.md
@@ -175,6 +175,18 @@ is used (no `throws`). Frame doesn't add `throws` to non-async
 methods; if you need to throw from a sync handler, write the
 declaration explicitly via Oceans Model passthrough.
 
+### Single-driver gate (`@@[async]`)
+
+An `@@[async]` system is emitted as a public **casing** (`public
+class <Name>`) wrapping a private **`_<Name>Machine`**. The casing
+declares a nested `enum FrameE703Error: Error`, and each interface
+method is `async throws`: if the system is already `busy` when a
+second call arrives, it throws `FrameE703Error.busy(...)` (the
+single-driver contract, **E703**) — which is why the methods carry
+`throws` even when the handler itself can't fail (D2). The gate is
+cleared in a `defer` block. See
+[language reference § Async](../frame_language.md#async).
+
 ---
 
 ## Cross-system fields: direct instantiation

--- a/docs/per_language_guides/typescript.md
+++ b/docs/per_language_guides/typescript.md
@@ -131,6 +131,17 @@ async fetch(key: string): Promise<string> {
 Promises are first-class in TS; `Promise<T>` is the standard
 async return shape.
 
+### Single-driver gate (`@@[async]`)
+
+An `@@[async]` system is emitted as a public **casing** (`export
+class <Name>`) wrapping a private **`_<Name>Machine`**. Each
+interface method gates external entry: if the system is already
+`busy` when a second call arrives, it throws
+`new Error("E703: …")` (the single-driver contract, **E703**) — a
+normal, catchable error. The gate is set on entry and cleared in a
+`finally`, so it clears on both the resolved and the rejected path.
+See [language reference § Async](../frame_language.md#async).
+
 ---
 
 ## Cross-system fields: direct instantiation


### PR DESCRIPTION
## What

Brings the async documentation in line with the behavior shipped in **4.4.0 (RFC-0043)**. The reference previously described the pre-RFC-0043 model — async auto-detected from interface methods — which now actively misleads: async members without `@@[async]` are a hard **E720**, and async systems are emitted as a layered **casing + machine** with a single-driver **E703** gate.

## Changes (16 files)

- **`frame_language.md`** § Async — rewritten around `@@[async]`; adds the casing/machine architecture, the E703 gate, E720/E721, a per-target E703-surface table, and the `add-async-attr` migration.
- **`frame_getting_started.md`** — tutorial + example now require `@@[async]`; new "One Driver at a Time" gate section.
- **`glossary.md`** — fixed `async system`; added `casing` and `machine (async system)` entries.
- **`frame_cookbook.md`** — recipe 19 gains `@@[async]`; fixes its pre-existing **W415** (`return await …` → `@@:(await …)`) so the fetched text is actually returned.
- **`frame_quickstart.md`** — notes `async` requires `@@[async]`.
- **`per_language_guides/*`** — a "Single-driver gate" subsection added to all 11 async backends, each with its **compiler-verified** E703 surface (Rust `Result<FrameE703Error>`, Swift `throws`, Java `failedFuture(RuntimeException)`, GDScript `push_error` + typed-zero, …); corrected Python's re-entrancy section.

## Verification

- Every E703 surface was read from generated output, not just the RFC table. (Notably corrected: Java's surface is `failedFuture(RuntimeException)`, not `IllegalStateException`.)
- **Doc-sample validator: 118/118** (pre-commit hook).
- Cookbook recipe 19 compiles **warning-free**.

Docs-only — no Rust touched, so no matrix run needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)