### PR TITLE
fix(python): f-string state-var quote swap (FRAMEC_BUGS #47)

### DIFF
--- a/framec/src/frame_c/compiler/codegen/frame_expansion/expression.rs
+++ b/framec/src/frame_c/compiler/codegen/frame_expansion/expression.rs
@@ -117,17 +117,26 @@ pub(super) fn expand_expression(expr: &str, lang: TargetLanguage, ctx: &HandlerC
 /// Uses compartment.state_vars for Python/TypeScript.
 /// For HSM: uses __sv_comp when ctx.use_sv_comp is true (navigates to correct parent compartment)
 fn expand_state_vars_in_expr(expr: &str, lang: TargetLanguage, ctx: &HandlerContext) -> String {
-    // Note: deliberately NOT string-literal-aware. `$.varName` is
-    // expanded even inside string literals because that's the contract
-    // for Frame interpolation — e.g. `f"count is {$.count}"` in Python
-    // needs `$.count` → `self.__compartment.state_vars["count"]` so the
-    // f-string interpolation resolves at runtime. Equivalent pattern
-    // applies to JS/TS backtick ``${ }``, Kotlin `"${ }"`, Ruby
+    // `$.varName` is expanded even inside string literals because that's
+    // the contract for Frame interpolation — e.g. `f"count is {$.count}"`
+    // in Python needs `$.count` → `self.__compartment.state_vars["count"]`
+    // so the f-string interpolation resolves at runtime. Equivalent
+    // pattern applies to JS/TS backtick ``${ }``, Kotlin `"${ }"`, Ruby
     // `"#{}"`, Swift `"\( )"`. Any false-match would require a user
     // literally writing `$.foo` inside a non-interpolating string —
     // exceedingly unusual, and not worth losing interpolation support.
+    //
+    // We DO track the currently-open string delimiter so the Python
+    // dict-subscript key can pick the *opposite* quote. A same-quote
+    // nested f-string (`f"...{d["k"]}..."`) is a SyntaxError before
+    // Python 3.12 / PEP 701 — FRAMEC_BUGS #47. Python is the only target
+    // affected; every other interpolating target tolerates nested
+    // same-quotes inside its substitution syntax.
     let mut result = String::new();
     let bytes = expr.as_bytes();
+
+    // None outside any string literal; Some(b'"') / Some(b'\'') while open.
+    let mut string_delim: Option<u8> = None;
 
     let mut i = 0;
     while i < bytes.len() {
@@ -141,12 +150,20 @@ fn expand_state_vars_in_expr(expr: &str, lang: TargetLanguage, ctx: &HandlerCont
             let var_name = String::from_utf8_lossy(&bytes[start..i]).to_string();
             match lang {
                 TargetLanguage::Python3 => {
+                    // Pick the opposite quote from any surrounding string so an
+                    // interpolated `$.var` inside an f-string doesn't nest
+                    // same-quotes (SyntaxError pre-3.12; FRAMEC_BUGS #47).
+                    let q = match string_delim {
+                        Some(b'"') => '\'',
+                        Some(b'\'') => '"',
+                        _ => '"',
+                    };
                     if ctx.per_handler {
-                        result.push_str(&format!("compartment.state_vars[\"{}\"]", var_name))
+                        result.push_str(&format!("compartment.state_vars[{q}{var_name}{q}]"))
                     } else if ctx.use_sv_comp {
-                        result.push_str(&format!("__sv_comp.state_vars[\"{}\"]", var_name))
+                        result.push_str(&format!("__sv_comp.state_vars[{q}{var_name}{q}]"))
                     } else {
-                        result.push_str(&format!("self.__compartment.state_vars[\"{}\"]", var_name))
+                        result.push_str(&format!("self.__compartment.state_vars[{q}{var_name}{q}]"))
                     }
                 }
                 TargetLanguage::TypeScript | TargetLanguage::JavaScript => {
@@ -393,7 +410,25 @@ fn expand_state_vars_in_expr(expr: &str, lang: TargetLanguage, ctx: &HandlerCont
                 TargetLanguage::Graphviz => unreachable!(),
             }
         } else {
-            result.push(bytes[i] as char);
+            let b = bytes[i];
+            // Maintain string-delimiter state for the Python key-quote swap.
+            if let Some(d) = string_delim {
+                // Inside a string: copy an escape pair verbatim so an
+                // escaped quote doesn't toggle the delimiter; a matching
+                // unescaped delimiter closes the string.
+                if b == b'\\' && i + 1 < bytes.len() {
+                    result.push(b as char);
+                    result.push(bytes[i + 1] as char);
+                    i += 2;
+                    continue;
+                }
+                if b == d {
+                    string_delim = None;
+                }
+            } else if b == b'"' || b == b'\'' {
+                string_delim = Some(b);
+            }
+            result.push(b as char);
             i += 1;
         }
     }

--- a/framec/tests/python_snapshots.rs
+++ b/framec/tests/python_snapshots.rs
@@ -195,6 +195,80 @@ fn rfc0034_all_fixtures_compile() {
 /// identifier and Python emitted `state_vars["x"] = list` (a
 /// reference to the type), not `state_vars["x"] = list()` (a fresh
 /// instance). Same parser bug — the user's code is silently wrong.
+/// Regression for FRAMEC_BUGS Issue #47: a `$.var` interpolated inside a
+/// double-quoted f-string used to lower its dict-subscript key with double
+/// quotes too (`f"...{state_vars["k"]}..."`) — a `SyntaxError` on Python
+/// < 3.12 (pre-PEP-701). The key must take the OPPOSITE quote of the
+/// surrounding string. This assertion is version-independent: it checks the
+/// emitted quote choice directly, so it fails on a 3.12 host where
+/// `py_compile` would wrongly pass (PEP 701 accepts the nested same-quote).
+#[test]
+fn fstring_state_var_quote_swap_47() {
+    // (a) double-quoted f-string -> key must use single quotes
+    let out_a = compile_source(
+        r#"
+@@system A {
+    interface: status(): str = ""
+    machine:
+        $Active {
+            $.failures: int = 0
+            status(): str { @@:(f"closed ({$.failures} failures)") }
+        }
+}
+"#,
+        "python_3",
+    );
+    // Scope to the f-string interpolation (the `} failures)` suffix) so the
+    // correctly double-quoted state-var INITIALIZER line
+    // (`state_vars["failures"] = 0`, not inside any string) isn't matched.
+    assert!(
+        out_a.contains("state_vars['failures']} failures)"),
+        "state-var key inside a double-quoted f-string must use single quotes:\n{out_a}"
+    );
+    assert!(
+        !out_a.contains("state_vars[\"failures\"]} failures)"),
+        "must not nest same-quote (double-in-double) — SyntaxError pre-3.12:\n{out_a}"
+    );
+
+    // (b) single-quoted f-string -> key must flip to double quotes
+    let out_b = compile_source(
+        r#"
+@@system B {
+    interface: status(): str = ""
+    machine:
+        $Active {
+            $.failures: int = 0
+            status(): str { @@:(f'closed ({$.failures} failures)') }
+        }
+}
+"#,
+        "python_3",
+    );
+    assert!(
+        out_b.contains("state_vars[\"failures\"]} failures)"),
+        "state-var key inside a single-quoted f-string must use double quotes:\n{out_b}"
+    );
+
+    // (c) plain (non-string) expression -> key stays double-quoted
+    let out_c = compile_source(
+        r#"
+@@system C {
+    interface: bump(): int = 0
+    machine:
+        $Active {
+            $.count: int = 0
+            bump(): int { @@:($.count + 1) }
+        }
+}
+"#,
+        "python_3",
+    );
+    assert!(
+        out_c.contains("state_vars[\"count\"] + 1"),
+        "state-var key outside any string must remain double-quoted:\n{out_c}"
+    );
+}
+
 #[test]
 fn rfc0033_state_var_call_initializers_python() {
     let src = r#"


### PR DESCRIPTION
## Bug
A `$.var` interpolated inside a double-quoted f-string lowered its dict-subscript key with double quotes too:
```python
f"closed ({compartment.state_vars["failures"]} failures)"   # SyntaxError on Python < 3.12
```
A `SyntaxError` on the framec-supported range (3.7+); only valid on 3.12+ (PEP 701). Masked everywhere because the doc-sample validator runs on Python 3.12.

## Root cause
`$.var` is lowered in **two** paths; only `state_var.rs` was quote-aware. The expression-context path `expand_state_vars_in_expr` (which f-strings flow through) hardcoded a double-quoted key.

## Fix
The byte-scan now tracks the open string delimiter (escape-aware); the **Python arm** picks the opposite quote. Python-only — other interpolating targets tolerate nested same-quotes, so no cross-backend snapshot churn.

## Verification
- Python 3.11 (Docker): fixed output `py_compile`s clean; the old shape throws `SyntaxError: f-string: unmatched '['`.
- `python_snapshots::fstring_state_var_quote_swap_47` — version-independent (asserts the quote choice, so it fails even on a 3.12 host). Full suite + clippy + fmt green; no existing snapshots changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)