### PR TITLE
fix(validator): E604/E608 in return expressions (RFC-0045 gap)

### DIFF
--- a/framec/src/frame_c/compiler/frame_validator/system_checks.rs
+++ b/framec/src/frame_c/compiler/frame_validator/system_checks.rs
@@ -218,6 +218,82 @@ impl FrameValidator {
         }
     }
 
+    /// Re-scan the inner text of return-expression segments to catch a
+    /// reserved `@@:system` (E604) / `@@:system.state` (E608) form nested
+    /// inside `@@:(…)`, `@@:return(…)`, or `@@:return = …`.
+    ///
+    /// The top-level segment walk only sees the return segment, not the
+    /// reserved form *inside* it, so without this pass those forms slip
+    /// past the validator and codegen falls back to emitting a
+    /// `/* ERROR: bare @@:system */` placeholder into the output
+    /// (RFC-0045 expression-context gap). Reuses the scanner rather than
+    /// re-deriving the `@@:system` classification, and recurses so
+    /// arbitrarily-nested return expressions (`@@:(@@:(…))`) are covered.
+    fn check_reserved_system_in_expr(
+        &mut self,
+        regions: &[Region],
+        scope_outer: &str,
+        scope_inner: &str,
+        target: crate::frame_c::visitors::TargetLanguage,
+    ) {
+        for region in regions {
+            if let Region::FrameSegment { kind, metadata, .. } = region {
+                let inner = match (kind, metadata) {
+                    (FrameSegmentKind::ContextReturnExpr, SegmentMetadata::ReturnExpr { expr }) => {
+                        Some(expr.as_str())
+                    }
+                    (FrameSegmentKind::ReturnCall, SegmentMetadata::ReturnCall { expr }) => {
+                        Some(expr.as_str())
+                    }
+                    (
+                        FrameSegmentKind::ContextReturn,
+                        SegmentMetadata::ContextReturn {
+                            assign_expr: Some(expr),
+                        },
+                    ) => Some(expr.as_str()),
+                    _ => None,
+                };
+                let Some(inner) = inner else { continue };
+
+                // Wrap in a synthetic body so the scanner classifies the
+                // inner text exactly as it would in statement position.
+                let synthetic = format!("{{{}}}", inner);
+                let mut scanner = get_native_scanner(target);
+                let scan = match scanner.scan(synthetic.as_bytes(), 0) {
+                    Ok(s) => s,
+                    Err(_) => continue,
+                };
+                for r in &scan.regions {
+                    if let Region::FrameSegment { kind: k, .. } = r {
+                        match k {
+                            FrameSegmentKind::ContextSystemBare => {
+                                self.errors.push(ValidationError::new(
+                                    "E604",
+                                    format!(
+                                        "bare `@@:system` in {}/{} — `@@:system` requires a member access (e.g. `@@:system.state.name`)",
+                                        scope_outer, scope_inner
+                                    ),
+                                ));
+                            }
+                            FrameSegmentKind::ContextSystemStateReserved => {
+                                self.errors.push(ValidationError::new(
+                                    "E608",
+                                    format!(
+                                        "`@@:system.state` in {}/{} is reserved for future use; use `@@:system.state.name` to read the current state name",
+                                        scope_outer, scope_inner
+                                    ),
+                                ));
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                // Recurse for nested return expressions.
+                self.check_reserved_system_in_expr(&scan.regions, scope_outer, scope_inner, target);
+            }
+        }
+    }
+
     /// Validate Frame segments in a handler/action body using the scanner.
     /// Runs the language-specific scanner on the body text, then walks the
     /// identified segments. No byte-level scanning — the scanner handles
@@ -312,6 +388,13 @@ impl FrameValidator {
                 }
             }
         }
+
+        // Close the E604/E608 expression-context gap (RFC-0045): a reserved
+        // `@@:system` / `@@:system.state` nested inside a return expression
+        // (`@@:(…)`, `@@:return(…)`, `@@:return = …`) is not a top-level
+        // segment, so the walk above can't see it. Re-scan each return
+        // expression's inner text and raise there too.
+        self.check_reserved_system_in_expr(&scan_result.regions, scope_outer, scope_inner, target);
 
         // W705: transition in a non-void handler without a preceding
         // `@@:(value)` may leak the return type's default (None /

--- a/framec/tests/common/mod.rs
+++ b/framec/tests/common/mod.rs
@@ -72,6 +72,21 @@ pub fn compile_source(source: &str, target: &str) -> String {
     }
 }
 
+/// Compile inline source expecting framec to REJECT it, returning the
+/// error text for assertion. Panics if the source unexpectedly compiles —
+/// the inverse of `compile_source`, for negative (diagnostic) tests.
+pub fn compile_expect_error(source: &str, target: &str) -> String {
+    let lang = TargetLanguage::try_from(target)
+        .unwrap_or_else(|e| panic!("unknown target language '{}': {}", target, e));
+    match compile_module(source, lang) {
+        Ok(_) => panic!(
+            "expected a compile error for target {}, but it transpiled successfully:\n--- source ---\n{}",
+            target, source
+        ),
+        Err(RunError { error, .. }) => error,
+    }
+}
+
 // ─── RFC-0034: per-backend in-process compile checks ─────────────────
 //
 // Snapshot tests historically only diff TEXT; the .snap file could

--- a/framec/tests/rfc0045_reserved_system.rs
+++ b/framec/tests/rfc0045_reserved_system.rs
@@ -1,0 +1,89 @@
+//! RFC-0045 — reserved `@@:system` / `@@:system.state` diagnostics.
+//!
+//! `@@:system` requires a member access → **E604**.
+//! `@@:system.state` is reserved (use `.name`) → **E608**.
+//!
+//! Regression for the expression-context gap: these forms were only
+//! caught in statement position. Nested inside a return expression
+//! (`@@:(…)`, `@@:return(…)`, `@@:return = …`) they slipped past the
+//! validator and codegen emitted a `/* ERROR: bare @@:system */`
+//! placeholder into the output. The validator now re-scans
+//! return-expression text, so both contexts are rejected.
+
+mod common;
+
+use common::{compile_expect_error, compile_source};
+
+fn sys_stmt(body: &str) -> String {
+    format!("@@system S {{\n    interface: c()\n    machine: $A {{ c() {{ {body} }} }}\n}}")
+}
+
+fn sys_expr(ret_stmt: &str) -> String {
+    // A value-returning handler whose body is a single return statement.
+    format!(
+        "@@system S {{\n    interface: c(): str\n    machine: $A {{ c(): str {{ {ret_stmt} }} }}\n}}"
+    )
+}
+
+// ── statement position (the path that always worked) ──────────────────
+
+#[test]
+fn e604_bare_system_statement() {
+    let err = compile_expect_error(&sys_stmt("@@:system"), "python_3");
+    assert!(err.contains("E604"), "expected E604, got:\n{err}");
+}
+
+#[test]
+fn e608_reserved_state_statement() {
+    let err = compile_expect_error(&sys_stmt("@@:system.state"), "python_3");
+    assert!(err.contains("E608"), "expected E608, got:\n{err}");
+}
+
+// ── expression position (the gap this fix closes) ─────────────────────
+
+#[test]
+fn e604_bare_system_in_return_expr() {
+    let err = compile_expect_error(&sys_expr("@@:(@@:system)"), "python_3");
+    assert!(err.contains("E604"), "expected E604, got:\n{err}");
+}
+
+#[test]
+fn e608_reserved_state_in_return_expr() {
+    let err = compile_expect_error(&sys_expr("@@:(@@:system.state)"), "python_3");
+    assert!(err.contains("E608"), "expected E608, got:\n{err}");
+}
+
+#[test]
+fn e608_reserved_state_in_return_call() {
+    // `@@:return(expr)` form.
+    let err = compile_expect_error(&sys_expr("@@:return(@@:system.state)"), "python_3");
+    assert!(err.contains("E608"), "expected E608, got:\n{err}");
+}
+
+#[test]
+fn e604_bare_system_in_return_assign() {
+    // `@@:return = expr` form.
+    let err = compile_expect_error(&sys_expr("@@:return = @@:system"), "python_3");
+    assert!(err.contains("E604"), "expected E604, got:\n{err}");
+}
+
+// ── cross-scanner: the validator re-scans with the target's own scanner ──
+
+#[test]
+fn e608_in_return_expr_rust_scanner() {
+    let err = compile_expect_error(&sys_expr("@@:(@@:system.state)"), "rust");
+    assert!(err.contains("E608"), "expected E608 (rust), got:\n{err}");
+}
+
+// ── the valid accessor must still compile in every position ───────────
+
+#[test]
+fn valid_state_name_accessor_compiles() {
+    // statement and expression positions both fine.
+    let _ = compile_source(&sys_stmt("@@:system.state.name"), "python_3");
+    let out = compile_source(&sys_expr("@@:(@@:system.state.name)"), "python_3");
+    assert!(
+        !out.contains("/* ERROR"),
+        "valid accessor must not emit an error placeholder:\n{out}"
+    );
+}


### PR DESCRIPTION
## Bug (RFC-0045 regression, shipping on main for 4.4.0)
`@@:system` (E604) and `@@:system.state` (E608) are reserved, but the guard only fired in **statement** position. Nested inside a return expression they bypassed the validator and codegen emitted garbage:
```python
self._context_stack[-1]._return = /* ERROR: bare @@:system */   # C-comment in Python
```
Affects `@@:(…)`, `@@:return(…)`, and `@@:return = …`. Surfaced by the full-fuzz negative phase (`e608_reserved_system_state` expected E608 but transpiled); missed by smoke CI.

## Root cause
`validate_frame_segments_in_body` walks only **top-level** scanner segments. `@@:(expr)` is a single `ContextReturnExpr`; the nested `@@:system…` isn't a top-level segment, so the E604/E608 arms never see it. Codegen's `context_data.rs` fallback then emits the `/* ERROR */` placeholder.

## Fix
New `check_reserved_system_in_expr` pass re-scans the inner text of the three return-expression forms with the target's **own scanner** (reuses the scanner, doesn't re-derive the classification) and raises E604/E608 there too; recurses for nested forms.

## Verification
- Both codes fire in all three return forms, on both Python and Rust scanners; valid `@@:system.state.name` still compiles.
- New `tests/rfc0045_reserved_system.rs` (8 cases) + `compile_expect_error` helper. Full suite + clippy + fmt green.
- The test-env negative phase that originally failed now passes (python_3 49/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)