### PR TITLE
fix(parser): transition across a newline (FRAMEC_BUGS #43)

### DIFF
--- a/framec/src/frame_c/compiler/lexer/frame_stmt.rs
+++ b/framec/src/frame_c/compiler/lexer/frame_stmt.rs
@@ -132,44 +132,44 @@ impl Lexer {
     ///
     /// `after_arrow` is the byte position immediately after `>` in `->`.
     pub(super) fn peek_frame_transition_target(&self, after_arrow: usize, end: usize) -> bool {
-        let mut k = after_arrow;
-        // Skip whitespace
-        while k < end && (self.source[k] == b' ' || self.source[k] == b'\t') {
-            k += 1;
+        // Newline-aware whitespace skip: a transition may be written across
+        // lines (`->` ⏎ `$State`), so detection must look past newlines too
+        // — whitespace-invariant parsing (FRAMEC_BUGS #43).
+        fn skip_wsnl(source: &[u8], mut k: usize, end: usize) -> usize {
+            while k < end && matches!(source[k], b' ' | b'\t' | b'\n' | b'\r') {
+                k += 1;
+            }
+            k
         }
+        let src = &self.source;
+        let mut k = skip_wsnl(src, after_arrow, end);
         if k >= end {
             return false;
         }
         // -> => $State (transition forward)
-        if k + 1 < end && self.source[k] == b'=' && self.source[k + 1] == b'>' {
-            k += 2;
-            while k < end && (self.source[k] == b' ' || self.source[k] == b'\t') {
-                k += 1;
-            }
-            return k < end && self.source[k] == b'$';
+        if k + 1 < end && src[k] == b'=' && src[k + 1] == b'>' {
+            k = skip_wsnl(src, k + 2, end);
+            return k < end && src[k] == b'$';
         }
         // -> pop$
         if k + 3 < end
-            && self.source[k] == b'p'
-            && self.source[k + 1] == b'o'
-            && self.source[k + 2] == b'p'
-            && self.source[k + 3] == b'$'
+            && src[k] == b'p'
+            && src[k + 1] == b'o'
+            && src[k + 2] == b'p'
+            && src[k + 3] == b'$'
         {
             return true;
         }
         // -> (args) ...  — skip balanced parens, then look for $
-        if self.source[k] == b'(' {
-            if let Some(k2) = self.skipper.balanced_paren_end(&self.source, k, end) {
-                k = k2;
-                while k < end && (self.source[k] == b' ' || self.source[k] == b'\t') {
-                    k += 1;
-                }
+        if src[k] == b'(' {
+            if let Some(k2) = self.skipper.balanced_paren_end(src, k, end) {
+                k = skip_wsnl(src, k2, end);
                 // After (args), skip optional "label"
-                if k < end && (self.source[k] == b'"' || self.source[k] == b'\'') {
-                    let quote = self.source[k];
+                if k < end && (src[k] == b'"' || src[k] == b'\'') {
+                    let quote = src[k];
                     k += 1;
-                    while k < end && self.source[k] != quote {
-                        if self.source[k] == b'\\' && k + 1 < end {
+                    while k < end && src[k] != quote {
+                        if src[k] == b'\\' && k + 1 < end {
                             k += 2;
                         } else {
                             k += 1;
@@ -178,20 +178,18 @@ impl Lexer {
                     if k < end {
                         k += 1;
                     }
-                    while k < end && (self.source[k] == b' ' || self.source[k] == b'\t') {
-                        k += 1;
-                    }
+                    k = skip_wsnl(src, k, end);
                 }
-                return k < end && self.source[k] == b'$';
+                return k < end && src[k] == b'$';
             }
             return false;
         }
         // -> "label" $State — skip label, check for $
-        if self.source[k] == b'"' || self.source[k] == b'\'' {
-            let quote = self.source[k];
+        if src[k] == b'"' || src[k] == b'\'' {
+            let quote = src[k];
             k += 1;
-            while k < end && self.source[k] != quote {
-                if self.source[k] == b'\\' && k + 1 < end {
+            while k < end && src[k] != quote {
+                if src[k] == b'\\' && k + 1 < end {
                     k += 2;
                 } else {
                     k += 1;
@@ -200,13 +198,11 @@ impl Lexer {
             if k < end {
                 k += 1;
             }
-            while k < end && (self.source[k] == b' ' || self.source[k] == b'\t') {
-                k += 1;
-            }
-            return k < end && self.source[k] == b'$';
+            k = skip_wsnl(src, k, end);
+            return k < end && src[k] == b'$';
         }
         // -> $State (simple)
-        self.source[k] == b'$'
+        src[k] == b'$'
     }
 
     /// Lex a transition statement: -> $State, -> (args) $State, -> pop$, -> => $State
@@ -221,7 +217,9 @@ impl Lexer {
             span: Span::new(arrow_pos, self.cursor),
         }];
 
-        self.skip_inline_whitespace();
+        // Newline-aware: a transition may span lines (`->` ⏎ `$State`),
+        // FRAMEC_BUGS #43. Same for the inter-token skips below.
+        self.skip_ws_and_newlines();
 
         // Check for -> => $State (transition forward)
         if self.cursor + 1 < end
@@ -234,7 +232,7 @@ impl Lexer {
                 token: Token::FatArrow,
                 span: Span::new(fa_start, self.cursor),
             });
-            self.skip_inline_whitespace();
+            self.skip_ws_and_newlines();
         }
 
         // Check for enter args: (args)
@@ -250,7 +248,7 @@ impl Lexer {
                     span: Span::new(self.cursor, paren_end),
                 });
                 self.cursor = paren_end;
-                self.skip_inline_whitespace();
+                self.skip_ws_and_newlines();
             }
         }
 
@@ -278,7 +276,7 @@ impl Lexer {
                 token: Token::StringLit(content),
                 span: Span::new(str_start, self.cursor),
             });
-            self.skip_inline_whitespace();
+            self.skip_ws_and_newlines();
         }
 
         // Check for pop$ after ->

--- a/framec/src/frame_c/compiler/lexer/mod.rs
+++ b/framec/src/frame_c/compiler/lexer/mod.rs
@@ -911,6 +911,26 @@ impl Lexer {
         }
     }
 
+    /// Like `skip_inline_whitespace` but also consumes newlines (LF/CR).
+    /// Used inside transition lexing so a transition written across lines
+    /// (`->` <newline> `$State`) tokenizes the same as the one-line form —
+    /// whitespace-invariant parsing (FRAMEC_BUGS #43).
+    pub(super) fn skip_ws_and_newlines(&mut self) {
+        let end = if self.mode == LexerMode::NativeAware {
+            self.native_end
+        } else {
+            self.end
+        };
+        while self.cursor < end {
+            let b = self.source[self.cursor];
+            if b == b' ' || b == b'\t' || b == b'\n' || b == b'\r' {
+                self.cursor += 1;
+            } else {
+                break;
+            }
+        }
+    }
+
     fn scan_identifier(&mut self) -> String {
         let start = self.cursor;
         let end = if self.mode == LexerMode::NativeAware {

--- a/framec/src/frame_c/compiler/native_region_scanner/unified.rs
+++ b/framec/src/frame_c/compiler/native_region_scanner/unified.rs
@@ -175,7 +175,7 @@ pub fn scan_native_regions<S: SyntaxSkipper>(
         // Frame statements (-> $, => $, push$, pop$, return) are detected at any position.
         // Closures are already skipped by skip_nested_scope() above.
         if matches!(b, b'-' | b'=' | b'(' | b'p' | b'r') {
-            if let Some((_new_i, kind)) = match_frame_statement(skipper, bytes, i, end) {
+            if let Some((match_pos, kind)) = match_frame_statement(skipper, bytes, i, end) {
                 // Calculate indent: count leading whitespace from start of
                 // current line.
                 //
@@ -240,8 +240,14 @@ pub fn scan_native_regions<S: SyntaxSkipper>(
                     }
                 }
 
-                // Find end of Frame statement.
-                let raw_stmt_end = skipper.find_line_end(bytes, i, end);
+                // Find end of Frame statement. Seed the line-end search from
+                // the matched construct position rather than `i`: when a
+                // transition spans a newline (`->` <newline> `$State`,
+                // FRAMEC_BUGS #43) the target lives on a later line, so the
+                // statement end is that line's end — not the `->` line's.
+                // For all same-line constructs `match_pos` is on the same line
+                // as `i`, so this is identical to `find_line_end(.., i, ..)`.
+                let raw_stmt_end = skipper.find_line_end(bytes, match_pos.max(i), end);
                 // Trim trailing inline whitespace from the Frame segment
                 // span so it stays in the *following* NativeText region.
                 // Without this, a same-line trailing comment after a Frame
@@ -775,11 +781,14 @@ fn match_frame_statement<S: SyntaxSkipper>(
 
     // Transition variants: -> $State, -> (args) $State, -> pop$, -> => $State
     if b == b'-' && pos + 1 < end && bytes[pos + 1] == b'>' {
-        let mut k = skip_ws(bytes, pos + 2, end);
+        // Newline-aware: a transition may be written `->` <newline> `$State`
+        // (FRAMEC_BUGS #43). The trailing-`$` requirement below still keeps
+        // native `->` forms (Rust `-> T`, Erlang `-> Expr`) from matching.
+        let mut k = skip_ws_nl(bytes, pos + 2, end);
 
         // Check for -> => $State (transition forward)
         if k + 1 < end && bytes[k] == b'=' && bytes[k + 1] == b'>' {
-            k = skip_ws(bytes, k + 2, end);
+            k = skip_ws_nl(bytes, k + 2, end);
             if k < end && bytes[k] == b'$' {
                 return Some((k, FrameSegmentKind::Transition));
             }
@@ -798,7 +807,7 @@ fn match_frame_statement<S: SyntaxSkipper>(
         // Check for optional enter args: -> (args) $State
         if k < end && bytes[k] == b'(' {
             if let Some(k2) = skipper.balanced_paren_end(bytes, k, end) {
-                k = skip_ws(bytes, k2, end);
+                k = skip_ws_nl(bytes, k2, end);
             }
         }
 
@@ -816,7 +825,7 @@ fn match_frame_statement<S: SyntaxSkipper>(
             if k < end {
                 k += 1;
             } // Skip closing quote
-            k = skip_ws(bytes, k, end);
+            k = skip_ws_nl(bytes, k, end);
         }
 
         // Regular transition: -> $State
@@ -955,6 +964,23 @@ fn match_frame_statement<S: SyntaxSkipper>(
 #[inline]
 pub fn skip_ws(bytes: &[u8], mut pos: usize, end: usize) -> usize {
     while pos < end && (bytes[pos] == b' ' || bytes[pos] == b'\t') {
+        pos += 1;
+    }
+    pos
+}
+
+/// Skip whitespace *including* newlines (space, tab, CR, LF). Returns new
+/// position. Used where a Frame construct may legitimately span lines —
+/// e.g. a transition written `->` <newline> `$State` — so parsing stays
+/// whitespace-invariant. It still only consumes contiguous whitespace, so
+/// a `->` with no `$` target on the following line is left un-matched
+/// (and falls through to native text) exactly as a same-line `-> foo`
+/// would. FRAMEC_BUGS #43.
+#[inline]
+pub fn skip_ws_nl(bytes: &[u8], mut pos: usize, end: usize) -> usize {
+    while pos < end
+        && (bytes[pos] == b' ' || bytes[pos] == b'\t' || bytes[pos] == b'\n' || bytes[pos] == b'\r')
+    {
         pos += 1;
     }
     pos

--- a/framec/tests/whitespace_invariance.rs
+++ b/framec/tests/whitespace_invariance.rs
@@ -2,12 +2,16 @@
 //!
 //! **Horizontal** whitespace between the tokens of a Frame statement is
 //! insignificant: any permutation of spaces/tabs must produce
-//! byte-identical generated code. Verified scope, learned the hard way
-//! (see below): Frame statements are **line-oriented** — a newline ends a
-//! statement, so newlines are NOT free to inject mid-statement (`->\n$B`
-//! is not a transition; it lowers to native `->` / `$B` lines). Thus the
-//! Tier-A invariant covers space/tab variants only; newline behavior is a
-//! separate (Tier-B) property.
+//! byte-identical generated code. The Tier-A `FILLERS` below stay
+//! space/tab-only because not every gap is newline-tolerant (e.g. the gap
+//! between `push$` and `->`, or before `=> $^`).
+//!
+//! Tier-B (FRAMEC_BUGS #43): the gap between a transition's `->` and its
+//! `$State` target **is** newline-tolerant — `->` ⏎ `$State` lowers
+//! identically to the one-line form. (It previously emitted `->` / `$B`
+//! as native garbage with no diagnostic.) That property is pinned by
+//! `transition_across_newline_matches_single_line` below rather than by
+//! the blanket `FILLERS` sweep.
 //!
 //! This is adjacent to — but not the same as — FRAMEC_BUGS #42. #42 was
 //! two *different but equivalent* segmentations (`push$`⏎`-> $S`
@@ -129,6 +133,44 @@ fn default_forward_is_whitespace_invariant() {
 }
 "#,
     );
+}
+
+/// Tier-B (FRAMEC_BUGS #43): a transition written across a newline
+/// (`->` ⏎ `$State`) must lower **identically** to the one-line `-> $State`.
+/// Before the fix it silently emitted `->` / `$State` as native text — no
+/// transition, no diagnostic — so the target state looked unreachable
+/// (spurious W414) and the handler did nothing.
+#[test]
+fn transition_across_newline_matches_single_line() {
+    let one_line = r#"
+@@system R {
+    interface:
+        go()
+        ev()
+    machine:
+        $A { go() { -> $B } }
+        $B { ev() { -> $A } }
+}
+"#;
+    let multi_line = r#"
+@@system R {
+    interface:
+        go()
+        ev()
+    machine:
+        $A { go() {
+                ->
+                $B } }
+        $B { ev() { -> $A } }
+}
+"#;
+    for backend in BACKENDS {
+        assert_eq!(
+            compile_source(multi_line, backend),
+            compile_source(one_line, backend),
+            "[transition-newline / {backend}] `->` ⏎ `$B` must lower like `-> $B`",
+        );
+    }
 }
 
 /// Pop transition `-> pop$`. Gap: around `->`.


### PR DESCRIPTION
## Bug (all backends, silent)
`->` ⏎ `$State` lowered to native `->` / `$State` text — **no transition, no diagnostic** — and the target state showed a spurious **W414** ("not reachable"). Frame targets whitespace-invariance, so a transition spanning lines should parse like the one-line form.

```frame
$A { go() {
        ->
        $B
} }
```
Before: handler emits `->` / `$B` as garbage. After: a real transition to `$B`, byte-identical to `-> $B`.

## Root cause — two parse paths
- **Unified scanner (codegen):** `skip_ws` after `->` stopped at the newline; and the statement line-end was seeded from the `->` line, truncating the segment before the target. Fixed with `skip_ws_nl` + seeding line-end from the matched target position.
- **Lexer (AST → reachability/validator):** `peek_frame_transition_target` + `lex_sol_transition` used inline-whitespace-only skips. Added `skip_ws_and_newlines` + a newline-aware peek.

The trailing-`$` requirement is preserved, so native `-> T` (Rust/Erlang) still doesn't match.

## Verification
- Multiline transition → correct target, no trailing garbage, **no W414**; byte-identical to one-line across Python + Rust.
- New `whitespace_invariance::transition_across_newline_matches_single_line` (7 backends). Full suite + clippy + fmt green; existing whitespace-invariance + snapshot suites unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)