### PR TITLE
fix(scanner): reject inline control-flow transitions, E400 (FRAMEC_BUGS #13)

### DIFF
--- a/framec/src/frame_c/compiler/native_region_scanner/unified.rs
+++ b/framec/src/frame_c/compiler/native_region_scanner/unified.rs
@@ -240,6 +240,56 @@ pub fn scan_native_regions<S: SyntaxSkipper>(
                     }
                 }
 
+                // E400 (FRAMEC_BUGS #13): a transition must be the last
+                // statement on its line. Inline native control flow with
+                // transition arms — `if c then -> $A else -> $B end` — can't
+                // scope the transition's implicit `return` through an opaque
+                // native block (Oceans Model), so it silently miscompiles
+                // (wrong arm taken, dropped `else`, or a broken `end`). Reject
+                // it; the multi-line if/then/else form works correctly.
+                //
+                // Allowed to follow the transition on its line: whitespace, a
+                // comment, a block/terminator delimiter (`}` / `;`), or a
+                // Frame continuation (`@`). Anything else (`else`, `end`, a
+                // second `->`, …) means the transition isn't the last token.
+                if kind == FrameSegmentKind::Transition {
+                    let construct_end = if match_pos < end && bytes[match_pos] == b'$' {
+                        let mut k = match_pos + 1;
+                        if k < end && bytes[k] == b'^' {
+                            k += 1; // $^
+                        } else {
+                            while k < end && (bytes[k].is_ascii_alphanumeric() || bytes[k] == b'_')
+                            {
+                                k += 1;
+                            }
+                        }
+                        if k < end && bytes[k] == b'(' {
+                            if let Some(k2) = skipper.balanced_paren_end(bytes, k, end) {
+                                k = k2;
+                            }
+                        }
+                        k
+                    } else {
+                        match_pos // `-> pop$` etc — already past the construct
+                    };
+                    let after = skip_ws(bytes, construct_end, end);
+                    let trailing_code = after < end
+                        && !matches!(bytes[after], b'\n' | b'\r' | b'}' | b';' | b'@')
+                        && skipper.skip_comment(bytes, after, end).is_none();
+                    if trailing_code {
+                        return Err(ScanError {
+                            kind: ScanErrorKind::UnterminatedProtected,
+                            message: "E400: a transition must be the last statement on its line. \
+                                      Inline native control flow with transition arms (e.g. \
+                                      `if c then -> $A else -> $B end`) is not supported — the \
+                                      transition's implicit return cannot be scoped through an \
+                                      opaque native block. Put each transition on its own line \
+                                      using the multi-line form."
+                                .to_string(),
+                        });
+                    }
+                }
+
                 // Find end of Frame statement. Seed the line-end search from
                 // the matched construct position rather than `i`: when a
                 // transition spans a newline (`->` <newline> `$State`,

--- a/framec/tests/inline_transition_e400.rs
+++ b/framec/tests/inline_transition_e400.rs
@@ -1,0 +1,108 @@
+//! FRAMEC_BUGS #13: a transition must be the last statement on its line.
+//!
+//! Inline native control flow with transition arms — `if c then -> $A else
+//! -> $B end` — can't scope the transition's implicit return through an
+//! opaque native block (Oceans Model), so it used to silently miscompile
+//! (wrong arm, dropped `else`, or a broken `end`). It is now rejected with
+//! **E400**. The multi-line if/then/else form works, as does a brace-
+//! delimited inline block (the braces scope the return).
+
+mod common;
+use common::{compile_expect_error, compile_source};
+
+#[test]
+fn inline_if_then_else_with_transitions_is_rejected() {
+    let err = compile_expect_error(
+        r#"
+@@[target("lua")]
+@@system R {
+    interface: go(x: int)
+    machine:
+        $A { go(x: int) { if x > 10 then -> $B else -> $C end } }
+        $B { }
+        $C { }
+}
+"#,
+        "lua",
+    );
+    assert!(err.contains("E400"), "expected E400, got:\n{err}");
+}
+
+#[test]
+fn inline_if_single_arm_transition_is_rejected() {
+    let err = compile_expect_error(
+        r#"
+@@[target("lua")]
+@@system R {
+    interface: go()
+    machine:
+        $A { go() { if true then -> $B end } }
+        $B { }
+}
+"#,
+        "lua",
+    );
+    assert!(err.contains("E400"), "expected E400, got:\n{err}");
+}
+
+#[test]
+fn multiline_if_with_transitions_compiles() {
+    // The supported form: each transition on its own line.
+    let out = compile_source(
+        r#"
+@@[target("lua")]
+@@system R {
+    interface: go(x: int)
+    machine:
+        $A { go(x: int) {
+            if x > 10 then
+                -> $B
+            else
+                -> $C
+            end
+        } }
+        $B { }
+        $C { }
+}
+"#,
+        "lua",
+    );
+    assert!(
+        out.contains("__transition"),
+        "multi-line if must still transition:\n{out}"
+    );
+}
+
+#[test]
+fn braced_inline_block_transition_compiles() {
+    // A brace-delimited inline block scopes the implicit return correctly,
+    // so it must NOT be rejected (only the non-brace `}`-less forms are).
+    let _ = compile_source(
+        r#"
+@@[target("c")]
+@@system R {
+    interface: go(c: int)
+    machine:
+        $A { go(c: int) { if (c) { -> $B } } }
+        $B { }
+}
+"#,
+        "c",
+    );
+}
+
+#[test]
+fn transition_with_trailing_semicolon_compiles() {
+    let _ = compile_source(
+        r#"
+@@[target("typescript")]
+@@system R {
+    interface: go()
+    machine:
+        $A { go() { -> $B; } }
+        $B { }
+}
+"#,
+        "typescript",
+    );
+}


### PR DESCRIPTION
## Bug
Inline native control flow with transition arms silently miscompiled:
```frame
$A { go(x:int) { if x > 10 then -> $Big else -> $Small end } }
```
The transition's implicit `return` can't be scoped through an **opaque native block** (Oceans Model), so codegen took the wrong arm, dropped the `else`, or produced a broken `end` (parse failure). 

Full inline support would require teaching codegen to parse native control flow — directly against the Oceans Model (native code is opaque passthrough). So instead this **rejects** the unsupported form.

## Fix
**A transition must be the last statement on its line.** The scanner emits **E400** when real native content follows a transition on the same line. Allowed to follow: whitespace, a comment, `}` / `;` (block close / terminator), or `@` (Frame continuation). `else` / `end` / a second `->` are rejected.

This is purely syntactic (line-level), so it doesn't violate "Frame can't reason about native control flow."

## Not affected (verified compile)
- **Multi-line** `if/then/else` with transitions (the supported form).
- **Brace-delimited** inline blocks `if (c) { -> $B }` — the braces scope the return.
- Normal single-line handlers `go() { -> $B }`; trailing `;`.

## Verification
`tests/inline_transition_e400.rs` (5 cases: 2 reject, 3 compile). Full suite + clippy + fmt green; **no existing fixture trips the new check** (27 test binaries pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)