### PR TITLE
fix(ruby): __send__ dispatch (#14) + reject initialize event, E501 (#15)

### DIFF
--- a/framec/src/frame_c/compiler/codegen/interface_gen/persist/ruby.rs
+++ b/framec/src/frame_c/compiler/codegen/interface_gen/persist/ruby.rs
@@ -172,9 +172,9 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
         restore_body.push_str(&format!("instance = {}.allocate\n", sys));
         restore_body.push_str("instance.instance_variable_set(:@_context_stack, [])\n");
         restore_body.push_str("instance.instance_variable_set(:@__next_compartment, nil)\n");
-        restore_body.push_str("instance.instance_variable_set(:@__compartment, instance.send(:__deser_comp, _parsed[\"_compartment\"]))\n");
+        restore_body.push_str("instance.instance_variable_set(:@__compartment, instance.__send__(:__deser_comp, _parsed[\"_compartment\"]))\n");
         restore_body.push_str("if _parsed[\"_state_stack\"]\n");
-        restore_body.push_str("  instance.instance_variable_set(:@_state_stack, _parsed[\"_state_stack\"].map { |sc| instance.send(:__deser_comp, sc) })\n");
+        restore_body.push_str("  instance.instance_variable_set(:@_state_stack, _parsed[\"_state_stack\"].map { |sc| instance.__send__(:__deser_comp, sc) })\n");
         restore_body.push_str("else\n");
         restore_body.push_str("  instance.instance_variable_set(:@_state_stack, [])\n");
         restore_body.push_str("end\n");

--- a/framec/src/frame_c/compiler/codegen/machinery/ruby.rs
+++ b/framec/src/frame_c/compiler/codegen/machinery/ruby.rs
@@ -3,7 +3,9 @@
 //! Moved verbatim from `system_codegen::generate_ruby_machinery` (4.2
 //! plan §7.1.P3). Ruby uses `@`-sigil instance variables, blocks for
 //! iteration (`each do |name|`), `nil` for null, and method-name
-//! dispatch via `respond_to?` + `send`.
+//! dispatch via `respond_to?` + `__send__` (the override-proof alias —
+//! a user event named `send` would otherwise shadow `Object#send` and
+//! break internal dispatch; FRAMEC_BUGS #14).
 
 use crate::frame_c::compiler::codegen::ast::{CodegenNode, Param, Visibility};
 use crate::frame_c::compiler::codegen::machinery::MachineryGenerator;
@@ -168,7 +170,7 @@ end"#,
             body: vec![CodegenNode::NativeBlock {
                 code: r#"handler_name = "_state_#{@__compartment.state}"
 if respond_to?(handler_name, true)
-    send(handler_name, __e, @__compartment)
+    __send__(handler_name, __e, @__compartment)
 end"#
                     .to_string(),
                 span: None,

--- a/framec/src/frame_c/compiler/frame_validator.rs
+++ b/framec/src/frame_c/compiler/frame_validator.rs
@@ -92,7 +92,10 @@ mod system_checks;
 mod target_specific;
 mod transitions;
 
-pub use target_specific::{gdscript_reserved_method_rename, typescript_global_collision_rename};
+pub use target_specific::{
+    gdscript_reserved_method_rename, ruby_reserved_method_rename,
+    typescript_global_collision_rename,
+};
 
 use super::arcanum::Arcanum;
 use super::frame_ast::*;

--- a/framec/src/frame_c/compiler/frame_validator/target_specific.rs
+++ b/framec/src/frame_c/compiler/frame_validator/target_specific.rs
@@ -48,6 +48,9 @@ impl FrameValidator {
             crate::frame_c::visitors::TargetLanguage::GDScript => {
                 self.validate_gdscript_reserved_methods(system);
             }
+            crate::frame_c::visitors::TargetLanguage::Ruby => {
+                self.validate_ruby_reserved_methods(system);
+            }
             crate::frame_c::visitors::TargetLanguage::TypeScript
             | crate::frame_c::visitors::TargetLanguage::JavaScript => {
                 self.validate_typescript_global_collision(system);
@@ -118,6 +121,46 @@ impl FrameValidator {
                 );
             }
         }
+    }
+
+    /// E501 (Ruby): an interface method whose generated `def <name>` would
+    /// override a method Ruby's object model relies on, an unworkable
+    /// collision. `initialize` is the constructor — a `def initialize`
+    /// event handler silently replaces the system's constructor, breaking
+    /// construction. (Contrast `send`, which is *not* rejected: internal
+    /// dispatch uses the override-proof `__send__` alias, so a user `send`
+    /// event is fine — FRAMEC_BUGS #14.) FRAMEC_BUGS #15.
+    pub(super) fn validate_ruby_reserved_methods(&mut self, system: &SystemAst) {
+        for method in &system.interface {
+            if let Some(suggested) = ruby_reserved_method_rename(&method.name) {
+                self.errors.push(
+                    ValidationError::new(
+                        "E501",
+                        format!(
+                            "Interface method '{}' in system '{}' collides with Ruby's \
+                             `{}` (the object constructor). The generated `def {}` would \
+                             silently replace the system's constructor, breaking \
+                             construction. Rename it (suggested: '{}').",
+                            method.name, system.name, method.name, method.name, suggested
+                        ),
+                    )
+                    .with_span(method.span.clone()),
+                );
+            }
+        }
+    }
+}
+
+/// Ruby method names an interface method must not use because the
+/// generated `def <name>` would override a method Ruby's object model
+/// depends on and the collision can't be worked around by the caller.
+/// `initialize` is the constructor. (`send` is deliberately absent —
+/// internal dispatch uses `__send__`, so a user `send` event is safe.)
+/// Returns `None` for names that are safe to use as-is.
+pub fn ruby_reserved_method_rename(name: &str) -> Option<&'static str> {
+    match name {
+        "initialize" => Some("on_initialize"),
+        _ => None,
     }
 }
 

--- a/framec/tests/ruby_reserved_names.rs
+++ b/framec/tests/ruby_reserved_names.rs
@@ -1,0 +1,44 @@
+//! Ruby reserved-name handling.
+//!
+//! #14: a user event named `send` must not break internal dispatch — the
+//! router routes via the override-proof `__send__`, so the user's
+//! `def send` is harmless.
+//! #15: a user event named `initialize` collides with Ruby's constructor
+//! (a `def initialize` would replace it); rejected with E501.
+
+mod common;
+use common::{compile_expect_error, compile_source};
+
+#[test]
+fn ruby_router_dispatches_via_override_proof_send() {
+    let out = compile_source(
+        "@@system R { interface: send() machine: $A { send() { } } }",
+        "ruby",
+    );
+    assert!(
+        out.contains("__send__(handler_name"),
+        "router must dispatch via the override-proof __send__:\n{out}"
+    );
+    assert!(
+        out.contains("def send"),
+        "the user's `send` event handler must still be emitted:\n{out}"
+    );
+}
+
+#[test]
+fn ruby_initialize_event_is_rejected() {
+    let err = compile_expect_error(
+        "@@system R { interface: initialize() machine: $A { initialize() { } } }",
+        "ruby",
+    );
+    assert!(err.contains("E501"), "expected E501, got:\n{err}");
+}
+
+#[test]
+fn initialize_event_allowed_on_non_ruby_target() {
+    // The collision is Ruby-specific (Python's constructor is `__init__`).
+    let _ = compile_source(
+        "@@system R { interface: initialize() machine: $A { initialize() { } } }",
+        "python_3",
+    );
+}

--- a/framec/tests/snapshots/ruby_snapshots__actions.snap
+++ b/framec/tests/snapshots/ruby_snapshots__actions.snap
@@ -142,7 +142,7 @@ class Actions
     def __router(__e)
         handler_name = "_state_#{@__compartment.state}"
         if respond_to?(handler_name, true)
-            send(handler_name, __e, @__compartment)
+            __send__(handler_name, __e, @__compartment)
         end
     end
 

--- a/framec/tests/snapshots/ruby_snapshots__consts.snap
+++ b/framec/tests/snapshots/ruby_snapshots__consts.snap
@@ -148,7 +148,7 @@ class Consts
     def __router(__e)
         handler_name = "_state_#{@__compartment.state}"
         if respond_to?(handler_name, true)
-            send(handler_name, __e, @__compartment)
+            __send__(handler_name, __e, @__compartment)
         end
     end
 

--- a/framec/tests/snapshots/ruby_snapshots__forward.snap
+++ b/framec/tests/snapshots/ruby_snapshots__forward.snap
@@ -146,7 +146,7 @@ class Forward
     def __router(__e)
         handler_name = "_state_#{@__compartment.state}"
         if respond_to?(handler_name, true)
-            send(handler_name, __e, @__compartment)
+            __send__(handler_name, __e, @__compartment)
         end
     end
 

--- a/framec/tests/snapshots/ruby_snapshots__hsm.snap
+++ b/framec/tests/snapshots/ruby_snapshots__hsm.snap
@@ -148,7 +148,7 @@ class MiniHsm
     def __router(__e)
         handler_name = "_state_#{@__compartment.state}"
         if respond_to?(handler_name, true)
-            send(handler_name, __e, @__compartment)
+            __send__(handler_name, __e, @__compartment)
         end
     end
 

--- a/framec/tests/snapshots/ruby_snapshots__lifecycle.snap
+++ b/framec/tests/snapshots/ruby_snapshots__lifecycle.snap
@@ -147,7 +147,7 @@ class Lifecycle
     def __router(__e)
         handler_name = "_state_#{@__compartment.state}"
         if respond_to?(handler_name, true)
-            send(handler_name, __e, @__compartment)
+            __send__(handler_name, __e, @__compartment)
         end
     end
 

--- a/framec/tests/snapshots/ruby_snapshots__lifecycle_args.snap
+++ b/framec/tests/snapshots/ruby_snapshots__lifecycle_args.snap
@@ -145,7 +145,7 @@ class LifecycleArgs
     def __router(__e)
         handler_name = "_state_#{@__compartment.state}"
         if respond_to?(handler_name, true)
-            send(handler_name, __e, @__compartment)
+            __send__(handler_name, __e, @__compartment)
         end
     end
 

--- a/framec/tests/snapshots/ruby_snapshots__linear_fsm.snap
+++ b/framec/tests/snapshots/ruby_snapshots__linear_fsm.snap
@@ -144,7 +144,7 @@ class LinearFsm
     def __router(__e)
         handler_name = "_state_#{@__compartment.state}"
         if respond_to?(handler_name, true)
-            send(handler_name, __e, @__compartment)
+            __send__(handler_name, __e, @__compartment)
         end
     end
 

--- a/framec/tests/snapshots/ruby_snapshots__no_persist.snap
+++ b/framec/tests/snapshots/ruby_snapshots__no_persist.snap
@@ -144,7 +144,7 @@ class NoPersist
     def __router(__e)
         handler_name = "_state_#{@__compartment.state}"
         if respond_to?(handler_name, true)
-            send(handler_name, __e, @__compartment)
+            __send__(handler_name, __e, @__compartment)
         end
     end
 

--- a/framec/tests/snapshots/ruby_snapshots__persist.snap
+++ b/framec/tests/snapshots/ruby_snapshots__persist.snap
@@ -142,7 +142,7 @@ class Counter
     def __router(__e)
         handler_name = "_state_#{@__compartment.state}"
         if respond_to?(handler_name, true)
-            send(handler_name, __e, @__compartment)
+            __send__(handler_name, __e, @__compartment)
         end
     end
 

--- a/framec/tests/snapshots/ruby_snapshots__pushpop.snap
+++ b/framec/tests/snapshots/ruby_snapshots__pushpop.snap
@@ -145,7 +145,7 @@ class PushPop
     def __router(__e)
         handler_name = "_state_#{@__compartment.state}"
         if respond_to?(handler_name, true)
-            send(handler_name, __e, @__compartment)
+            __send__(handler_name, __e, @__compartment)
         end
     end
 

--- a/framec/tests/snapshots/ruby_snapshots__return_explicit.snap
+++ b/framec/tests/snapshots/ruby_snapshots__return_explicit.snap
@@ -140,7 +140,7 @@ class ReturnExplicit
     def __router(__e)
         handler_name = "_state_#{@__compartment.state}"
         if respond_to?(handler_name, true)
-            send(handler_name, __e, @__compartment)
+            __send__(handler_name, __e, @__compartment)
         end
     end
 

--- a/framec/tests/snapshots/ruby_snapshots__selfcall.snap
+++ b/framec/tests/snapshots/ruby_snapshots__selfcall.snap
@@ -142,7 +142,7 @@ class SelfCall
     def __router(__e)
         handler_name = "_state_#{@__compartment.state}"
         if respond_to?(handler_name, true)
-            send(handler_name, __e, @__compartment)
+            __send__(handler_name, __e, @__compartment)
         end
     end
 

--- a/framec/tests/snapshots/ruby_snapshots__state_args.snap
+++ b/framec/tests/snapshots/ruby_snapshots__state_args.snap
@@ -141,7 +141,7 @@ class StateArgs
     def __router(__e)
         handler_name = "_state_#{@__compartment.state}"
         if respond_to?(handler_name, true)
-            send(handler_name, __e, @__compartment)
+            __send__(handler_name, __e, @__compartment)
         end
     end
 


### PR DESCRIPTION
Two Ruby reserved-name collisions.

## #14 — `send` event broke internal dispatch
The machine dispatched handlers with `send(handler_name, ...)` (and persist used `instance.send(:__deser_comp, ...)`). A user event named `send` emits `def send`, **shadowing `Object#send`**, so internal dispatch invoked the user's handler with the wrong signature. **Fix:** use the override-proof `__send__` alias for internal dispatch — the user's `def send` is now harmless. Ruby snapshots re-blessed (only `send` → `__send__`).

## #15 — `initialize` event collided with the constructor
A user event named `initialize` emits `def initialize`, **silently replacing Ruby's constructor**. Unlike `send`, this can't be worked around (the name *is* the object constructor). **Fix:** reject it with **E501** + a suggested rename, mirroring the existing GDScript reserved-method check (`validate_ruby_reserved_methods`). Target-specific — `initialize` is fine on other targets (Python's constructor is `__init__`). `send` is deliberately **not** rejected (#14 makes it safe).

## Verification
- `__router` emits `__send__(handler_name, ...)`; user `def send` present; generated Ruby passes `ruby -c`.
- `initialize` event → E501 with rename suggestion; allowed on python_3.
- `tests/ruby_reserved_names.rs` (3 cases). Full suite + clippy + fmt green; 13 Ruby snapshots re-blessed (send → __send__ only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)