### PR TITLE
fix(validator): reject pseudo-types on static targets, E609 (FRAMEC_BUGS #37)

### DIFF
--- a/framec/src/frame_c/compiler/frame_validator/domain.rs
+++ b/framec/src/frame_c/compiler/frame_validator/domain.rs
@@ -12,6 +12,26 @@ use crate::frame_c::compiler::codegen::system_codegen::init_references_param;
 use crate::frame_c::compiler::frame_ast::*;
 use std::collections::HashSet;
 
+/// E609 helper (FRAMEC_BUGS #37): bare Python-ish container type names have
+/// no meaning as a type on any statically-typed target — Frame passes type
+/// strings through verbatim, so `domain: xs: list` emits `pub xs: list`
+/// (invalid Rust). Returns a per-language hint for the few unambiguous
+/// pseudo-types; `None` for everything else.
+///
+/// Only the exact bare lowercase names are matched — a real static-target
+/// type (`List`/`Map` in Java/Kotlin, `std::vector`/`std::map` in C++,
+/// `Vec`/`HashMap` in Rust) is capitalized or namespaced and won't match,
+/// so this never flags legitimate native types.
+fn static_target_pseudo_type(t: &str) -> Option<&'static str> {
+    match t.trim() {
+        "list" => Some("your target's list/array type (e.g. `Vec<T>`, `std::vector<T>`, `List<T>`, `[]T`)"),
+        "dict" => Some("your target's map type (e.g. `HashMap<K, V>`, `std::map<K, V>`, `Map<K, V>`, `map[K]V`)"),
+        "set" => Some("your target's set type (e.g. `HashSet<T>`, `std::set<T>`, `Set<T>`)"),
+        "tuple" => Some("your target's tuple or a named struct type"),
+        _ => None,
+    }
+}
+
 impl FrameValidator {
     /// E615: Direct assignment to a `const` domain field inside a handler
     /// body. Catches the obvious per-target self-access patterns; the target
@@ -268,22 +288,42 @@ impl FrameValidator {
             return;
         }
         for var in &system.domain {
-            if matches!(var.var_type, Type::Unknown) {
-                self.errors.push(
-                    ValidationError::new(
-                        "E605",
-                        format!(
-                            "domain field '{}' in system '{}' missing type annotation. \
-                             Frame's canonical domain form is `name: type = init`. \
-                             For target '{:?}', framec cannot infer struct-field types \
-                             from initializers — the explicit annotation is required. \
-                             Add `: <type>` between the field name and `=`. \
-                             See docs/frame_language.md § Domain Section.",
-                            var.name, system.name, target
-                        ),
-                    )
-                    .with_span(var.span.clone()),
-                );
+            match &var.var_type {
+                Type::Unknown => {
+                    self.errors.push(
+                        ValidationError::new(
+                            "E605",
+                            format!(
+                                "domain field '{}' in system '{}' missing type annotation. \
+                                 Frame's canonical domain form is `name: type = init`. \
+                                 For target '{:?}', framec cannot infer struct-field types \
+                                 from initializers — the explicit annotation is required. \
+                                 Add `: <type>` between the field name and `=`. \
+                                 See docs/frame_language.md § Domain Section.",
+                                var.name, system.name, target
+                            ),
+                        )
+                        .with_span(var.span.clone()),
+                    );
+                }
+                Type::Custom(s) => {
+                    if let Some(hint) = static_target_pseudo_type(s) {
+                        self.errors.push(
+                            ValidationError::new(
+                                "E609",
+                                format!(
+                                    "domain field '{}' in system '{}' has type '{}', which is \
+                                     not a real type on the statically-typed target '{:?}'. \
+                                     Frame passes type names through verbatim (it has no type \
+                                     system), so write {} instead. \
+                                     See docs/frame_language.md § Types and Expressions.",
+                                    var.name, system.name, s, target, hint
+                                ),
+                            )
+                            .with_span(var.span.clone()),
+                        );
+                    }
+                }
             }
         }
     }
@@ -315,23 +355,42 @@ impl FrameValidator {
                         ptype: &Type,
                         span: &Span,
                         errs: &mut Vec<ValidationError>| {
-            if matches!(ptype, Type::Unknown) {
-                errs.push(
-                    ValidationError::new(
-                        "E606",
-                        format!(
-                            "{} '{}' parameter '{}' is missing a type annotation. \
-                             Frame has no type system — type names pass through \
-                             verbatim — and for the statically-typed target '{:?}' \
-                             framec cannot synthesize a parameter type. Write \
-                             `{}: <your target's type>` (e.g. `int`, `i64`, \
-                             `std::string`). See docs/frame_language.md \
-                             § Types and Expressions.",
-                            kind, owner, pname, target, pname
-                        ),
-                    )
-                    .with_span(span.clone()),
-                );
+            match ptype {
+                Type::Unknown => {
+                    errs.push(
+                        ValidationError::new(
+                            "E606",
+                            format!(
+                                "{} '{}' parameter '{}' is missing a type annotation. \
+                                 Frame has no type system — type names pass through \
+                                 verbatim — and for the statically-typed target '{:?}' \
+                                 framec cannot synthesize a parameter type. Write \
+                                 `{}: <your target's type>` (e.g. `int`, `i64`, \
+                                 `std::string`). See docs/frame_language.md \
+                                 § Types and Expressions.",
+                                kind, owner, pname, target, pname
+                            ),
+                        )
+                        .with_span(span.clone()),
+                    );
+                }
+                Type::Custom(s) => {
+                    if let Some(hint) = static_target_pseudo_type(s) {
+                        errs.push(
+                            ValidationError::new(
+                                "E609",
+                                format!(
+                                    "{} '{}' parameter '{}' has type '{}', which is not a real \
+                                     type on the statically-typed target '{:?}'. Frame passes \
+                                     type names through verbatim, so write {} instead. \
+                                     See docs/frame_language.md § Types and Expressions.",
+                                    kind, owner, pname, s, target, hint
+                                ),
+                            )
+                            .with_span(span.clone()),
+                        );
+                    }
+                }
             }
         };
         // Interface-declared methods.

--- a/framec/tests/static_pseudo_type_e609.rs
+++ b/framec/tests/static_pseudo_type_e609.rs
@@ -1,0 +1,46 @@
+//! FRAMEC_BUGS #37: bare Python-ish container type names (`list`, `dict`,
+//! `set`, `tuple`) have no meaning on a statically-typed target. Frame
+//! passes type strings through verbatim, so `domain: xs: list` used to emit
+//! `pub xs: list` (invalid Rust). They are now rejected with **E609** + a
+//! native-type hint (keeping the type-passthrough architecture intact —
+//! framec does not map types). Real native types and dynamic targets are
+//! unaffected.
+
+mod common;
+use common::{compile_expect_error, compile_source};
+
+#[test]
+fn rust_domain_pseudo_type_list_rejected() {
+    let err = compile_expect_error(
+        "@@system R { interface: g() machine: $A { g() {} } domain: xs: list = [] }",
+        "rust",
+    );
+    assert!(err.contains("E609"), "expected E609, got:\n{err}");
+}
+
+#[test]
+fn rust_param_pseudo_type_dict_rejected() {
+    let err = compile_expect_error(
+        "@@system R { interface: g(m: dict) machine: $A { g(m: dict) {} } }",
+        "rust",
+    );
+    assert!(err.contains("E609"), "expected E609, got:\n{err}");
+}
+
+#[test]
+fn rust_real_container_type_accepted() {
+    // A real native type (capitalized / generic) must NOT be flagged.
+    let _ = compile_source(
+        r#"@@system R { interface: g() machine: $A { g() {} } domain: xs: "Vec<i64>" = vec![] }"#,
+        "rust",
+    );
+}
+
+#[test]
+fn dynamic_target_pseudo_type_allowed() {
+    // `list` is a real type on Python — the check is static-target only.
+    let _ = compile_source(
+        "@@[target(\"python_3\")]\n@@system R { interface: g() machine: $A { g() {} } domain: xs: list = [] }",
+        "python_3",
+    );
+}


### PR DESCRIPTION
## Bug
`domain: xs: list` emitted `pub xs: list` — invalid Rust. Frame has no type system (type strings pass through verbatim), so a bare Python-ish container type name has no meaning on a statically-typed target.

## Fix (per the chosen approach — keep type-passthrough, add a diagnostic)
Reject the bare pseudo-types `list` / `dict` / `set` / `tuple` on static targets with **E609** + a native-type hint. framec does **not** reintroduce type mapping — it just refuses to emit garbage and tells the user to write the native type.

- Fires for domain fields and interface/handler/state params on the static targets (same set as E605/E606).
- Only the exact bare lowercase names match — real native types (`Vec<T>`, `List<String>`, `std::vector<T>`, `map[K]V`) are capitalized/namespaced and are **not** flagged.
- Dynamic targets (Python, etc.) where `list` is a real type are unaffected.

## Verification
- rust `xs: list` / param `dict` → E609; rust `Vec<i64>`, java `List<String>`, python `list` → compile clean.
- `tests/static_pseudo_type_e609.rs` (4 cases). Full suite + clippy + fmt green; **no existing fixture trips E609**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)