### PR TITLE
fix(validator): scope E609 to Rust only — list/dict are supported on C (#37 follow-up)

### DIFF
--- a/framec/src/frame_c/compiler/frame_validator/domain.rs
+++ b/framec/src/frame_c/compiler/frame_validator/domain.rs
@@ -306,24 +306,31 @@ impl FrameValidator {
                         .with_span(var.span.clone()),
                     );
                 }
-                Type::Custom(s) => {
+                // #37 is Rust-only: `list`/`dict` ARE supported domain types on
+                // C (and dynamic targets) via the runtime's list/dict helpers
+                // (e.g. C's `_persist_pack_field_list`); only Rust lacks the
+                // mapping and emits the verbatim `pub xs: list` (invalid). Scope
+                // the rejection to Rust so those legitimately-supported fixtures
+                // still compile.
+                Type::Custom(s) if matches!(target, Rust) => {
                     if let Some(hint) = static_target_pseudo_type(s) {
                         self.errors.push(
                             ValidationError::new(
                                 "E609",
                                 format!(
-                                    "domain field '{}' in system '{}' has type '{}', which is \
-                                     not a real type on the statically-typed target '{:?}'. \
-                                     Frame passes type names through verbatim (it has no type \
-                                     system), so write {} instead. \
+                                    "domain field '{}' in system '{}' has type '{}', which the \
+                                     Rust backend does not map to a real type (Frame passes type \
+                                     names through verbatim, so it would emit the invalid \
+                                     `pub {}: {}`). Write {} instead. \
                                      See docs/frame_language.md § Types and Expressions.",
-                                    var.name, system.name, s, target, hint
+                                    var.name, system.name, s, var.name, s, hint
                                 ),
                             )
                             .with_span(var.span.clone()),
                         );
                     }
                 }
+                Type::Custom(_) => {}
             }
         }
     }
@@ -374,23 +381,25 @@ impl FrameValidator {
                         .with_span(span.clone()),
                     );
                 }
-                Type::Custom(s) => {
+                // #37 Rust-only — see the domain-field branch above.
+                Type::Custom(s) if matches!(target, Rust) => {
                     if let Some(hint) = static_target_pseudo_type(s) {
                         errs.push(
                             ValidationError::new(
                                 "E609",
                                 format!(
-                                    "{} '{}' parameter '{}' has type '{}', which is not a real \
-                                     type on the statically-typed target '{:?}'. Frame passes \
-                                     type names through verbatim, so write {} instead. \
+                                    "{} '{}' parameter '{}' has type '{}', which the Rust backend \
+                                     does not map to a real type (it would emit the verbatim, \
+                                     invalid `{}`). Write {} instead. \
                                      See docs/frame_language.md § Types and Expressions.",
-                                    kind, owner, pname, s, target, hint
+                                    kind, owner, pname, s, s, hint
                                 ),
                             )
                             .with_span(span.clone()),
                         );
                     }
                 }
+                Type::Custom(_) => {}
             }
         };
         // Interface-declared methods.

--- a/framec/tests/static_pseudo_type_e609.rs
+++ b/framec/tests/static_pseudo_type_e609.rs
@@ -1,10 +1,13 @@
-//! FRAMEC_BUGS #37: bare Python-ish container type names (`list`, `dict`,
-//! `set`, `tuple`) have no meaning on a statically-typed target. Frame
-//! passes type strings through verbatim, so `domain: xs: list` used to emit
-//! `pub xs: list` (invalid Rust). They are now rejected with **E609** + a
-//! native-type hint (keeping the type-passthrough architecture intact —
-//! framec does not map types). Real native types and dynamic targets are
-//! unaffected.
+//! FRAMEC_BUGS #37 (Rust-only): the Rust backend does not map the bare
+//! container type names `list`/`dict`/`set`/`tuple` to a real type — Frame
+//! passes type strings through verbatim, so `domain: xs: list` emitted
+//! `pub xs: list` (invalid Rust). On Rust they are now rejected with
+//! **E609** + a native-type hint (keeping type-passthrough intact — framec
+//! does not map types).
+//!
+//! These names ARE supported on C (and dynamic targets) via the runtime's
+//! list/dict helpers, so the rejection is **Rust-scoped**: real native
+//! types, C's bare `list`/`dict`, and dynamic targets are all unaffected.
 
 mod common;
 use common::{compile_expect_error, compile_source};
@@ -38,9 +41,19 @@ fn rust_real_container_type_accepted() {
 
 #[test]
 fn dynamic_target_pseudo_type_allowed() {
-    // `list` is a real type on Python — the check is static-target only.
+    // `list` is a real type on Python — the check is Rust-only.
     let _ = compile_source(
         "@@[target(\"python_3\")]\n@@system R { interface: g() machine: $A { g() {} } domain: xs: list = [] }",
         "python_3",
+    );
+}
+
+#[test]
+fn c_target_list_dict_allowed() {
+    // C supports `list`/`dict` as domain types via the runtime's
+    // list/dict helpers — they must NOT be rejected (#37 is Rust-only).
+    let _ = compile_source(
+        "@@[target(\"c\")]\n@@system R { interface: g(m: dict) machine: $A { g(m: dict) {} } domain: xs: list = 0 }",
+        "c",
     );
 }


### PR DESCRIPTION
## Regression caught by the full matrix
The initial #37 fix (PR #51) rejected `list`/`dict`/`set`/`tuple` on **all** static targets. But the matrix showed these are **legitimately supported** domain/param types on **C** (and dynamic targets) via the runtime's list/dict helpers (e.g. C's `_persist_pack_field_list` / `_dict`). The 102/74/76/77 fixtures use bare `list`/`dict` on C *by design*. #37 is genuinely **Rust-only** — only Rust lacks the mapping and emits `pub xs: list` (invalid).

The broad gate broke those working C fixtures (matrix: 2 langs failing).

## Fix
Scope E609 to `target == Rust`. C's bare `list`/`dict` compile again; Rust `xs: list` still gets E609; every other static target returns to prior behavior (their fixtures use native types like `std::map`/`Dictionary<>`/`Vec`).

## Verification
- C 102/74/76/77 fixtures compile again; Rust `xs: list` → E609; Java/Python unaffected.
- `tests/static_pseudo_type_e609.rs` gains a C-allowed case (5 cases). Full suite + clippy + fmt green.

Note: if Java/C++/etc. also lack list/dict runtime support, that's a separate untracked item — not expanded here to avoid another over-reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)