### PR TITLE
docs(changelog): 4.4.0 bug-sweep fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,6 +238,32 @@ which survives `--remap`.
   C, GDScript, Swift, and Erlang are exempt — no catchable exception can
   propagate through their dispatch.
 
+### Fixed — codegen & validator hardening (bug sweep)
+
+- **Transition across a newline now parses (#43).** `->` followed by its
+  `$State` target on the next line previously emitted the tokens as native
+  text — no transition, and a spurious W414 ("state not reachable"). Both the
+  unified scanner (codegen) and the lexer (AST / reachability) are now
+  newline-aware. The trailing-`$` requirement is preserved, so native `-> T`
+  (Rust / Erlang) is unaffected. All backends.
+- **`E400` — inline control flow with transition arms is rejected (#13).**
+  `if c then -> $A else -> $B end` on a single line silently miscompiled (the
+  transition's implicit `return` cannot be scoped through an opaque native
+  block — the Oceans Model). It is now a clear error; the multi-line
+  `if/then/else` form (and brace-delimited inline blocks) work as before.
+- **Ruby internal dispatch uses `__send__` (#14).** A user event named `send`
+  shadowed `Object#send` and broke the router; internal dispatch now uses the
+  override-proof `__send__` alias, so a user `send` event is harmless.
+- **`E501` — Ruby `initialize` interface method is rejected (#15).** A
+  `def initialize` event handler would silently replace the object
+  constructor; rejected with a suggested rename (mirrors the GDScript
+  reserved-method check). Other targets are unaffected.
+- **`E609` — Rust `list`/`dict`/`set`/`tuple` pseudo-types are rejected (#37).**
+  Rust passes type names through verbatim and has no mapping, so
+  `domain: xs: list` emitted the invalid `pub xs: list`. Rust-scoped — these
+  names remain supported on C and dynamic targets via the runtime's list/dict
+  helpers.
+
 ## [4.3.0] - 2026-05-27
 
 Re-introduces the `@@import` directive (removed in 4.2.0 by RFC-0024) in a

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -35,11 +35,10 @@ aux_links:
 aux_links_new_tab: true
 
 # Playable Frame Arcade — a separate deploy (frame-games repo) at its own
-# subdomain. Surfaced as a top-level nav item that opens in a new tab.
-nav_external_links:
-  - title: Games
-    url: https://games.frame-lang.org
-    opens_in_new_tab: true
+# subdomain. Surfaced via docs/games.md, which sits at nav_order 5.5 (between
+# Cookbook and Runtime) and uses jekyll-redirect-from to bounce the visitor
+# out to https://games.frame-lang.org. Same-tab; for new-tab placement we'd
+# need a theme `_includes` override.
 back_to_top: true
 back_to_top_text: "Back to top"
 

--- a/docs/games.md
+++ b/docs/games.md
@@ -1,0 +1,7 @@
+---
+title: Games
+nav_order: 5.5
+redirect_to: https://games.frame-lang.org
+---
+
+Redirecting to [games.frame-lang.org](https://games.frame-lang.org)…


### PR DESCRIPTION
Adds the codegen/validator bug-sweep (#43, #13, #14, #15, #37) to the 4.4.0 CHANGELOG entry before tagging. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)