### PR TITLE
chore(release): separate games-nav from the release line

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -35,10 +35,11 @@ aux_links:
 aux_links_new_tab: true
 
 # Playable Frame Arcade — a separate deploy (frame-games repo) at its own
-# subdomain. Surfaced via docs/games.md, which sits at nav_order 5.5 (between
-# Cookbook and Runtime) and uses jekyll-redirect-from to bounce the visitor
-# out to https://games.frame-lang.org. Same-tab; for new-tab placement we'd
-# need a theme `_includes` override.
+# subdomain. Surfaced as a top-level nav item that opens in a new tab.
+nav_external_links:
+  - title: Games
+    url: https://games.frame-lang.org
+    opens_in_new_tab: true
 back_to_top: true
 back_to_top_text: "Back to top"
 

--- a/docs/games.md
+++ b/docs/games.md
@@ -1,7 +1,0 @@
----
-title: Games
-nav_order: 5.5
-redirect_to: https://games.frame-lang.org
----
-
-Redirecting to [games.frame-lang.org](https://games.frame-lang.org)…


### PR DESCRIPTION
Pulls the staged games-nav refactor (`docs/games.md` + `docs/_config.yml`) back out of the CHANGELOG commit so the v4.4.0 tag points at a clean release commit. The games-nav redirect page is re-added as its own commit right after tagging. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)