### PR TITLE
docs: Games nav redirect page

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -35,11 +35,10 @@ aux_links:
 aux_links_new_tab: true
 
 # Playable Frame Arcade — a separate deploy (frame-games repo) at its own
-# subdomain. Surfaced as a top-level nav item that opens in a new tab.
-nav_external_links:
-  - title: Games
-    url: https://games.frame-lang.org
-    opens_in_new_tab: true
+# subdomain. Surfaced via docs/games.md, which sits at nav_order 5.5 (between
+# Cookbook and Runtime) and uses jekyll-redirect-from to bounce the visitor
+# out to https://games.frame-lang.org. Same-tab; for new-tab placement we'd
+# need a theme `_includes` override.
 back_to_top: true
 back_to_top_text: "Back to top"
 

--- a/docs/games.md
+++ b/docs/games.md
@@ -1,0 +1,7 @@
+---
+title: Games
+nav_order: 5.5
+redirect_to: https://games.frame-lang.org
+---
+
+Redirecting to [games.frame-lang.org](https://games.frame-lang.org)…


### PR DESCRIPTION
Re-adds the games-nav refactor (`docs/games.md` + `docs/_config.yml`) as its own commit, separated from the v4.4.0 release line. Same content that was inadvertently bundled into the CHANGELOG commit; now standalone with a proper message. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)