### PR TITLE
docs: harmonize terminology across the guides (tool name, dispatch path, "machine")

### DIFF
--- a/docs/frame_cookbook.md
+++ b/docs/frame_cookbook.md
@@ -1448,7 +1448,7 @@ if __name__ == '__main__':
 
 **How it works:** `@@:self.reading()` dispatches through the full kernel pipeline. The return value is available as a native expression.
 
-**Automatic transition guard:** In `attempt_post_shutdown()`, calling `@@:self.trigger_shutdown()` transitions to `$Shutdown`. The framepiler emits an early-return guard immediately after every `@@:self.method(...)` call site:
+**Automatic transition guard:** In `attempt_post_shutdown()`, calling `@@:self.trigger_shutdown()` transitions to `$Shutdown`. framec emits an early-return guard immediately after every `@@:self.method(...)` call site:
 
 ```python
 def _s_Active_hdl_user_attempt_post_shutdown(self, __e, compartment):
@@ -11590,7 +11590,7 @@ Most security protocols are already state machines in prose form. RFC 8446 (TLS 
 
 Implemented as imperative code with booleans and guards, these protocols produce scattered `if`-checks, invisible safety properties, and transitions that reviewers must trace by hand. Implemented as Frame systems, the security property *is* the shape of the graph: missing a gate is a visible missing node, adding a bypass is a visible new edge, and impossible states are impossible because they have no handler — not because a check rejects them.
 
-The authoritative statement of each protocol above is the Frame source, diffed in version control, diagrammed with `framec system.fpy -l graphviz | dot -Tsvg`, and compiled to the same class the production system runs.
+The authoritative statement of each protocol above is the Frame source, diffed in version control, diagrammed with `framec system.fpy -l graphviz | dot -Tsvg`, and transpiled to the same class the production system runs.
 
 -----
 

--- a/docs/frame_getting_started.md
+++ b/docs/frame_getting_started.md
@@ -110,13 +110,13 @@ Frame's unit of definition for a single machine is a *system*. Here's one:
 
 This defines a traffic light with three states. Calling `next()` transitions between them: Green to Yellow to Red to Green. The `->` operator means "transition to." That's the core of Frame — states, events, and transitions, expressed directly.
 
-The framepiler generates a full implementation of this system in your target language — Python, TypeScript, Rust, C, and many others. The generated code is a plain class with no runtime dependencies: readable, debuggable, and ready to use.
+framec generates a full implementation of this system in your target language — Python, TypeScript, Rust, C, and many others. The generated code is a plain class with no runtime dependencies: readable, debuggable, and ready to use.
 
 ### Frame Lives Inside Your Code
 
 Frame is not a standalone language. It's designed to live *inside* your native source files, side by side with regular code.
 
-Frame makes heavy use of a special token — `@@` — to mark Frame pragmas and constructs that should be preprocessed by the *framepiler* (Frame's compilation tool). Everything without `@@` passes through unchanged.
+Frame makes heavy use of a special token — `@@` — to mark Frame pragmas and constructs that should be preprocessed by the *framepiler* (Frame's transpiler, `framec`). Everything without `@@` passes through unchanged.
 
 ```frame
 @@[target("python_3")]
@@ -147,9 +147,9 @@ if __name__ == '__main__':
     light.next()  # Red -> Green
 ```
 
-The `@@[target("python_3")]` pragma tells the framepiler which language to generate. The `@@system` block is expanded into a Python class. The `@@TrafficLight()` construct instantiates the system — the framepiler expands it to the appropriate native constructor.
+The `@@[target("python_3")]` pragma tells framec which language to generate. The `@@system` block is expanded into a Python class. The `@@TrafficLight()` construct instantiates the system — framec expands it to the appropriate native constructor.
 
-The `import`, the `logger`, the `if __name__` block — all native Python — pass through exactly as written. This is Frame's core design: **native code is the ocean, Frame systems are islands.** The framepiler only touches the islands.
+The `import`, the `logger`, the `if __name__` block — all native Python — pass through exactly as written. This is Frame's core design: **native code is the ocean, Frame systems are islands.** framec only touches the islands.
 
 ### Why Machines?
 
@@ -179,9 +179,9 @@ The generated code is readable, debuggable, and uses no runtime library. It's ju
 
 ### Target Language
 
-The `@@[target(...)]` attribute inside the file is the authoritative declaration of which native language the file targets. The framepiler uses it to determine how to parse native code regions (string/comment syntax), which code generator to use, and what output to produce. (The bare `@@target` form is hard-cut to E804 per RFC-0013.)
+The `@@[target(...)]` attribute inside the file is the authoritative declaration of which native language the file targets. framec uses it to determine how to parse native code regions (string/comment syntax), which backend to use, and what output to produce. (The bare `@@target` form is hard-cut to E804 per RFC-0013.)
 
-The `@@[target(...)]` can be overridden by a CLI flag (`-l <language>`) or other configuration, but if neither is provided, the in-file declaration is what controls compilation.
+The `@@[target(...)]` can be overridden by a CLI flag (`-l <language>`) or other configuration, but if neither is provided, the in-file declaration is what controls transpilation.
 
 ### File Extensions
 
@@ -196,7 +196,7 @@ Frame source files conventionally use a target-specific extension:
 | Go | `.fgo` | `traffic_light.fgo` |
 | Java | `.fjava` | `traffic_light.fjava` |
 
-The file extension is a hint — nothing more. It helps editors and build tools recognize Frame files, but the framepiler does not use it to determine the target language. The `@@[target(...)]` attribute (or a CLI override) is what matters.
+The file extension is a hint — nothing more. It helps editors and build tools recognize Frame files, but framec does not use it to determine the target language. The `@@[target(...)]` attribute (or a CLI override) is what matters.
 
 ---
 
@@ -236,7 +236,7 @@ Create a file called `hello.fpy`:
 
 Let's break this down:
 
-- **`@@[target("python_3")]`** — tells the framepiler to generate Python
+- **`@@[target("python_3")]`** — tells framec to generate Python
 - **`@@system Hello`** — declares a state machine called `Hello`
 - **`interface:`** — the public API. `greet()` is a method callers can invoke
 - **`machine:`** — the states. There's one state, `$Start`
@@ -299,7 +299,7 @@ Output:
 Hello from Frame!
 ```
 
-The `if __name__` block is native Python — the framepiler passes it through unchanged.
+The `if __name__` block is native Python — framec passes it through unchanged.
 
 ### The Anatomy of a System
 
@@ -575,7 +575,7 @@ There are three forms for setting the return value on the context stack:
 
 If the current state doesn't handle the event, the caller gets the default value (`0` in this case). Note: bare `return` exits the dispatch method but does NOT set the return value — always use `@@:(expr)`, `@@:return = expr`, or `@@:return(expr)` to set return values.
 
-**String returns across languages**: When returning string literals with `@@:("value")`, the framepiler automatically wraps the literal for typed backends (Rust: `String::from("value")`, C++: `std::string("value")`). For computed strings, use the target language's string construction (e.g., `@@:(format!("hello {}", name))` for Rust, `@@:(std::string("hello ") + name)` for C++). All other languages accept bare string literals without wrapping.
+**String returns across languages**: When returning string literals with `@@:("value")`, framec automatically wraps the literal for typed backends (Rust: `String::from("value")`, C++: `std::string("value")`). For computed strings, use the target language's string construction (e.g., `@@:(format!("hello {}", name))` for Rust, `@@:(std::string("hello ") + name)` for C++). All other languages accept bare string literals without wrapping.
 
 ### Multiple Parameters and Returns
 
@@ -1569,7 +1569,7 @@ system itself with `@@[async]` on the line just above `@@system`:
 ```
 
 The `@@[async]` attribute is **required** whenever a system has any async member.
-Forget it and the compiler stops you with a clear error:
+Forget it and framec stops you with a clear error:
 
 ```
 E720: @@system 'Connection' declares async member(s) but lacks the
@@ -1583,7 +1583,7 @@ inserts the attribute for you across a whole tree.
 
 If *any* interface method is declared `async`, the **entire system** becomes async. All generated methods — including ones you declared as sync — will be async in the output.
 
-This means callers must `await` every method on an async system, even `get_state()` above. This is a consequence of how state machines dispatch events internally: the system can't know at compile time which handler will run, so it must assume any call might be async.
+This means callers must `await` every method on an async system, even `get_state()` above. This is a consequence of how state machines dispatch events internally: the system can't know at transpile time which handler will run, so it must assume any call might be async.
 
 Sync methods on an async system still work correctly — awaiting a synchronous function is a no-op in most languages.
 
@@ -1929,5 +1929,5 @@ You now know the full Frame language. Here are some directions to explore:
 
 - Browse the [Cookbook](frame_cookbook.md) for 110 complete, runnable examples
 - Browse the [supported languages](https://github.com/frame-lang/framec#supported-languages) and try a different target
-- Read the [CONTRIBUTING guide](https://github.com/frame-lang/framec/blob/main/CONTRIBUTING.md) if you want to help improve the framepiler
+- Read the [CONTRIBUTING guide](https://github.com/frame-lang/framec/blob/main/CONTRIBUTING.md) if you want to help improve framec
 - Check the [GitHub issues](https://github.com/frame-lang/framec/issues) for feature requests and discussions

--- a/docs/frame_getting_started.md
+++ b/docs/frame_getting_started.md
@@ -1590,7 +1590,7 @@ Sync methods on an async system still work correctly — awaiting a synchronous 
 ### One Driver at a Time
 
 An `@@[async]` system is generated as two classes: the **casing** (the public
-class with the name you declared) and a private **machine** (`_Connection­Machine`)
+class with the name you declared) and a private **machine class** (`_ConnectionMachine`)
 that holds the actual state-machine dispatch. You only ever touch the casing.
 
 The casing enforces a **single-driver** rule: only one interface call may be in

--- a/docs/frame_language.md
+++ b/docs/frame_language.md
@@ -199,7 +199,7 @@ Three parameter groups configure a system at construction time. Each is optional
 | Enter arg | `$>(name: type)` | Start state's `compartment.enter_args` |
 | Domain arg | `name: type` (bare) | Constructor argument, used in domain field initializers |
 
-Each param body has the same shape (`name: type` or `name: type = default`) regardless of group; only the sigil differs. The framepiler validates that state and enter args have matching declarations on the start state's `$Start(name: type)` and `$>(name: type)` handlers.
+Each param body has the same shape (`name: type` or `name: type = default`) regardless of group; only the sigil differs. framec validates that state and enter args have matching declarations on the start state's `$Start(name: type)` and `$>(name: type)` handlers.
 
 #### Param syntax
 
@@ -236,7 +236,7 @@ name : type = default
 r = @@Robot($(7), "R2D2")       // x = 7 (state arg), name = "R2D2" (domain)
 ```
 
-Note the call site: state args are tagged with `$(...)` so the assembler can route them into `compartment.state_args`. See [System Instantiation](#system-instantiation) for the full call site form.
+Note the call site: state args are tagged with `$(...)` so framec can route them into `compartment.state_args`. See [System Instantiation](#system-instantiation) for the full call site form.
 
 State args are also written by transitions (`-> $Start(42)`). The codegen stores transition-passed args under the same declared param name, so the dispatch reads the param identically whether the state was entered via the system constructor or a transition.
 
@@ -289,7 +289,7 @@ Bare identifiers in the header become **constructor arguments** that are in scop
 c = @@Counter(10)               // value is 10
 ```
 
-The codegen prepends the language-appropriate self-reference (`self.`, `this.`, `@`) to the LHS of the domain field assignment, so `value = value` (param and field with the same name) is unambiguous: it compiles to `self.value = value`.
+The codegen prepends the language-appropriate self-reference (`self.`, `this.`, `@`) to the LHS of the domain field assignment, so `value = value` (param and field with the same name) is unambiguous: it transpiles to `self.value = value`.
 
 ---
 
@@ -368,7 +368,7 @@ $.<varName> (: <type>)? = <initializer_expr>
 - No duplicates within a state
 - State variable names may shadow domain variables (no ambiguity due to `$.` prefix)
 
-**Portable init expressions:** Use Frame-portable literals for state variable initializers: `""` for strings, `0` for integers, `false` for booleans. The framepiler wraps these to match the target language's type system (e.g., `String::from("")` for Rust, `std::string("")` for C++). Target-language-specific constructors like `String::new()` are NOT portable — the Frame parser may not handle them correctly. If you need a target-specific value, write it as native code and the framepiler will pass it through unchanged.
+**Portable init expressions:** Use Frame-portable literals for state variable initializers: `""` for strings, `0` for integers, `false` for booleans. framec wraps these to match the target language's type system (e.g., `String::from("")` for Rust, `std::string("")` for C++). Target-language-specific constructors like `String::new()` are NOT portable — the Frame parser may not handle them correctly. If you need a target-specific value, write it as native code and framec will pass it through unchanged.
 
 ### Event Handlers
 
@@ -423,7 +423,7 @@ $Active {
 ### Argument-receiver contract
 
 A transition that supplies args must have a receiver that can take
-them. The framepiler enforces this at compile time:
+them. framec enforces this at transpile time:
 
 | Site             | Receiver                       | Code  |
 |------------------|--------------------------------|-------|
@@ -431,7 +431,7 @@ them. The framepiler enforces this at compile time:
 | `-> (args) $T`   | target state's `$>(...)`       | E417  |
 | `-> $T(args)`    | target state's state params    | E405  |
 
-If the receiver is missing or its arity doesn't fit, the compile
+If the receiver is missing or its arity doesn't fit, transpilation
 fails. EventParam-backed receivers (E417, E419) honor trailing
 defaults — `<$(a, b = "x")` accepts 1 or 2 supplied args. State
 params (E405) currently have no defaults, so the count must match
@@ -762,7 +762,7 @@ Each interface call pushes its own context. Nested calls are isolated — inner 
 
 ## Self Reference
 
-`@@:self` is a syntactic prefix used to dispatch through the system's own interface. It is **not** a first-class value — bare `@@:self` is a compile error (E603). The only valid form is `@@:self.method(args)`.
+`@@:self` is a syntactic prefix used to dispatch through the system's own interface. It is **not** a first-class value — bare `@@:self` is a transpile error (E603). The only valid form is `@@:self.method(args)`.
 
 ### Self Accessors
 
@@ -782,7 +782,7 @@ In OO target languages (Python, TypeScript, Rust, Java, Kotlin, Swift, C#, Ruby,
 `@@:self.method(args)` is preferred for two reasons:
 
 1. **Static validation.** The validator checks that `method` exists in the `interface:` block with the right arity (E601/E602). Native calls bypass this.
-2. **Cross-backend portability.** In C and Erlang the handler scope has no `self`/`this` keyword; dispatch goes through a different mechanism. `@@:self.` abstracts that difference so the same Frame source compiles everywhere.
+2. **Cross-backend portability.** In C and Erlang the handler scope has no `self`/`this` keyword; dispatch goes through a different mechanism. `@@:self.` abstracts that difference so the same Frame source transpiles everywhere.
 
 ```frame
 $Active {
@@ -858,7 +858,7 @@ $Processing {
 
 > **Bare `@@:system.state` is reserved** ([RFC-0045](rfcs/rfc-0045.md)). The
 > name accessor is `@@:system.state.name`; writing bare `@@:system.state` is a
-> compile error (**E608**). The `@@:system.state` path is held for a future
+> transpile error (**E608**). The `@@:system.state` path is held for a future
 > direct reference to the current *compartment*, of which the name is one field.
 
 **Available in:** event handlers, enter/exit handlers, actions, non-static operations.
@@ -1059,7 +1059,7 @@ const migrated = migrate_async_attr(originalSource);
 
 ## System Instantiation
 
-Use `@@SystemName()` in native code to instantiate a Frame system. The framepiler expands this to the appropriate native constructor and validates that the system name exists and arguments match.
+Use `@@SystemName()` in native code to instantiate a Frame system. framec expands this to the appropriate native constructor and validates that the system name exists and arguments match.
 
 ```frame
 calc = @@Calculator()
@@ -1109,7 +1109,7 @@ Named-form args may be supplied in any order. Defaults are filled in for any omi
 
 #### Defaults are substituted at the call site
 
-Parameters with default values may be omitted from either form. The Frame assembler substitutes the declared default expression at the tagged-instantiation expansion site, so the target language never sees it as a constructor-default — it's a literal arg in the generated call.
+Parameters with default values may be omitted from either form. framec substitutes the declared default expression at the tagged-instantiation expansion site, so the target language never sees it as a constructor-default — it's a literal arg in the generated call.
 
 ```frame
 @@system Counter(initial: int = 0) { ... }
@@ -1121,7 +1121,7 @@ This means default values can use any expression valid in the target language at
 
 #### Instantiation Validation
 
-The framepiler validates at the assembler stage:
+framec validates this when it expands the instantiation:
 
 - The system name exists in this file.
 - Sigils on the call site match the declared groups (`$(...)` for state args, `$>(...)` for enter args, bare for domain).
@@ -1139,17 +1139,17 @@ Frame has two version numbers that move on different schedules.
 
 | Number | What it tracks | Example |
 |---|---|---|
-| **framec semver** | The compiler release line. Bumps signal CLI/codegen changes. | `4.3.0` |
+| **framec semver** | The transpiler release line. Bumps signal CLI/codegen changes. | `4.3.0` |
 | **Grammar version** | The Frame language specification itself. Moves much more slowly. | `v0.30` |
 
-The compiler version on its own does not tell you the language version, and vice versa. A patch release of framec almost never changes the grammar; a grammar bump only happens when the language surface changes (new syntax, removed syntax, semantics change).
+The framec version on its own does not tell you the language version, and vice versa. A patch release of framec almost never changes the grammar; a grammar bump only happens when the language surface changes (new syntax, removed syntax, semantics change).
 
 ### Source compatibility (what `4.x` means for your `.fpy` files)
 
 `framec` follows semver for **source-level** compatibility of `.fpy` / `.frs` / `.fts` / etc. files:
 
 - **Major** (`4.x` → `5.x`) may require source changes — a grammar version bump usually rides with it. Migration notes ship in `docs/releases/<version>-migration.md`.
-- **Minor** (`4.2` → `4.3`) is additive. Existing valid sources continue to compile.
+- **Minor** (`4.2` → `4.3`) is additive. Existing valid sources continue to transpile.
 - **Patch** (`4.2.3` → `4.2.4`) is bug-fix only. No source changes required.
 
 ### Generated code stability (will codegen churn on upgrade?)
@@ -1387,8 +1387,8 @@ if __name__ == '__main__':
 Frame's surface syntax divides into a small, closed set of categories. This
 appendix names each with standard compiler terminology and is the source of the
 vocabulary used throughout this guide. Every classification here is verified
-against *emitted code* by `framec/tests/syntax_taxonomy.rs` — it states what the
-compiler does, not what the syntax looks like.
+against *emitted code* by `framec/tests/syntax_taxonomy.rs` — it states what framec
+does, not what the syntax looks like.
 
 The central fact: **Frame has almost no expression grammar of its own.** There
 are no operators, literals, precedence, or control-flow keywords (`if`/`while`/
@@ -1423,7 +1423,7 @@ Frame reference (`$.x` → `self.x`) spliced in.
      `@@Sys(args)` / `@@!Sys()` (system instantiation). Both are usable in value
      position (assignment RHS) and, standalone, as expression-statements.
 
-5. **Attributes / Pragmas** — compile-time metadata, never runtime:
+5. **Attributes / Pragmas** — transpile-time metadata, never runtime:
    `@@[target(...)]`, `@@[persist]`, `@@[main]`, `@@[create/save/load/no_persist]`,
    and the bare directives `@@import`, `@@codegen`, `@@run-expect`, `@@skip-if`,
    `@@timeout`.

--- a/docs/frame_quickstart.md
+++ b/docs/frame_quickstart.md
@@ -371,7 +371,7 @@ Assignment to a `const` field in a handler body is E615. Per-target rendering: `
 ## CLI quick reference
 
 ```bash
-framec source.fpy                     # compile to target declared via @@[target(...)]
+framec source.fpy                     # transpile to target declared via @@[target(...)]
 framec source.fpy -l rust             # override target
 framec source.fpy -l graphviz | dot -Tsvg -o diagram.svg
 framec source.fpy -o out.py           # write output to file

--- a/docs/frame_runtime.md
+++ b/docs/frame_runtime.md
@@ -689,7 +689,7 @@ returns `true`. The state-event pair determines which handler runs,
 which determines the answer.
 
 `@@:(expr)` sets the return value. It's shorthand for
-`@@:return = expr`. Both compile to the same generated code.
+`@@:return = expr`. Both transpile to the same generated code.
 
 The return value needs somewhere to live during the call, so
 FrameContext gains a slot for it:
@@ -750,7 +750,7 @@ def _s_On_hdl_user_is_on(self, __e, compartment):
     self._context_stack[-1]._return = True
 ```
 
-`@@:(false)` compiles to `self._context_stack[-1]._return = False`.
+`@@:(false)` transpiles to `self._context_stack[-1]._return = False`.
 The handler writes to the top-of-stack context's `_return` slot.
 The wrapper reads the same slot when the kernel returns.
 
@@ -773,7 +773,7 @@ state — the basic value of state machines.
 >
 > This means `@@:return` or `@@:(...)` inside a void-declared
 > method is meaningless — the wrapper has nowhere to read the
-> slot. The framepiler rejects this at compile time rather than
+> slot. framec rejects this at transpile time rather than
 > emitting code the target compiler would reject. (Returning a
 > value from a void method is a type error in Java, Rust, Go,
 > Swift, C#, Kotlin, Dart, TypeScript, C, and C++.)
@@ -783,8 +783,8 @@ state — the basic value of state machines.
 > Their wrappers always read and return the slot regardless of
 > whether the source declared a return type. A method declared
 > without `: type` in Python that uses `@@:(42)` will return 42 to
-> the caller; the same source compiled for Java would be rejected
-> by the framepiler.
+> the caller; the same source transpiled for Java would be rejected
+> by framec.
 >
 > The asymmetry is deliberate. Frame matches each target's native
 > conventions rather than imposing a single uniform rule across
@@ -860,7 +860,7 @@ the implicit default may not be what you want.
 ### Native `return` vs `@@:`
 
 Native `return` in a handler exits the dispatch method but does
-not set `_return`. The framepiler emits warning W415 when a
+not set `_return`. framec emits warning W415 when a
 handler uses `return expr` because the value is almost certainly
 meant to be the interface return value. To set the return value,
 use `@@:return = expr` or `@@:(expr)`. Bare `return` (with no
@@ -953,7 +953,7 @@ handler body uses the parameters as ordinary locals.
 > **In statically-typed targets** — `_parameters[0]` is typed
 > "any" (`Object` in Java, `Box<dyn Any>` in Rust, `Any` in
 > Swift), so binding requires a cast to the declared parameter
-> type. The framepiler emits the cast based on the source's type
+> type. framec emits the cast based on the source's type
 > annotation:
 >
 > ```java
@@ -965,7 +965,7 @@ handler body uses the parameters as ordinary locals.
 > ```
 >
 > Same positional access pattern, just with the cast appropriate
-> to the target. Authors don't write the casts; the framepiler
+> to the target. Authors don't write the casts; framec
 > generates them from the parameter's declared type. Because
 > Frame source declares all parameter types, every cast is known
 > at code-generation time — there's no dynamic type checking at
@@ -976,20 +976,20 @@ handler body uses the parameters as ordinary locals.
 `_parameters` is a positional list at the wire level. Frame source
 lets you access parameters by name (`brightness` in the handler
 body, or `@@:params.brightness` if you prefer the explicit form),
-but that named access is a compile-time rewrite. The framepiler
+but that named access is a transpile-time rewrite. framec
 binds each parameter to a typed local at the top of the handler
 and rewrites named references to use that local.
 
 This is the same mechanism every statically-typed language uses
 for function parameters: positional at the calling convention,
 named at the source. The wire format is positional; the source is
-named; the framepiler bridges them.
+named; framec bridges them.
 
 ### `@@:params.x`
 
 `@@:params.x` is the explicit form of named parameter access. In a
 handler body it's interchangeable with the bare parameter name —
-both compile to the same local. It's most useful in actions, which
+both transpile to the same local. It's most useful in actions, which
 don't have parameters of their own but can read the calling
 handler's parameters via the context stack. We'll see actions in
 Step 13.
@@ -1385,7 +1385,7 @@ combination.
 #### Argument-receiver contract
 
 Each of the three arg channels has a strict-match contract enforced
-by framec at compile time:
+by framec at transpile time:
 
 | Site             | Receiver                       | Code  |
 |------------------|--------------------------------|-------|
@@ -1496,7 +1496,7 @@ def _s_On_hdl_frame_enter(self, __e, compartment):
     self.log_event(f"on at {brightness}: {greeting}")  # new
 ```
 
-`log_event(...)` in Frame source compiles to `self.log_event(...)`
+`log_event(...)` in Frame source transpiles to `self.log_event(...)`
 in Python. Same as any method call.
 
 ### What actions can and can't do
@@ -1520,7 +1520,7 @@ specific compartment. Handlers receive their compartment as a
 parameter (we'll see why in later steps). Actions don't — they're
 called from handlers in any state, so there's no single
 compartment that's theirs to receive. `$.varName` has nothing to
-resolve against in an action, so the framepiler rejects it (E401).
+resolve against in an action, so framec rejects it (E401).
 
 If an action needs a value that only a handler has access to, the
 handler passes it as an argument. For state variables (which we
@@ -1597,7 +1597,7 @@ The lamp adds two operations:
 - `get_event_count()` — a non-static method that returns the
   current event count from the domain.
 
-The operations compile straight to methods on the system class:
+The operations transpile straight to methods on the system class:
 
 ```python
 # new in this step
@@ -1761,9 +1761,9 @@ def log_event(self, msg: str):
     self.event_count = self.event_count + 1
 ```
 
-`@@:data.timestamp = expr` compiles to
+`@@:data.timestamp = expr` transpiles to
 `self._context_stack[-1]._data["timestamp"] = expr`.
-`@@:data.timestamp` (read) compiles to the corresponding lookup.
+`@@:data.timestamp` (read) transpiles to the corresponding lookup.
 
 The handler and the action both reach the same `_data` dict
 because both run during the same interface call, with the same
@@ -1801,10 +1801,10 @@ store as what it actually is.
 
 > **In statically-typed targets** — Reads from `_data` return the
 > target's "any" type. When the value is assigned to a typed
-> local or compared against a typed expression, the framepiler
+> local or compared against a typed expression, framec
 > emits the cast automatically based on the use site's expected
 > type. Direct uses (`if @@:data.flag`) work without a cast in
-> targets that auto-coerce; otherwise the framepiler inserts the
+> targets that auto-coerce; otherwise framec inserts the
 > cast. Authors write the same `@@:data.x` syntax regardless of
 > target.
 
@@ -1913,7 +1913,7 @@ desk = @@Lamp()             # default: "Lamp"
 
 `name` is a **domain parameter** — a constructor argument that's
 in scope when domain field initializers run. The domain block
-declares `name: str = name`, which compiles to `self.name = name`
+declares `name: str = name`, which transpiles to `self.name = name`
 in the constructor. The same identifier means parameter on the
 right, field on the left. The constructor signature picks up the
 parameter:
@@ -1934,10 +1934,10 @@ def __init__(self, name: str = "Lamp"):
     self._context_stack.pop()
 ```
 
-The default value (`"Lamp"`) is filled in by the framepiler at the
+The default value (`"Lamp"`) is filled in by framec at the
 call site, so the constructor signature shows it as a default.
 This works even in target languages that don't support parameter
-defaults — the assembler substitutes the default into the call.
+defaults — framec substitutes the default into the call.
 
 ### Three groups of system parameters
 
@@ -1954,7 +1954,7 @@ total:
 | Enter arg | `$>(name: type)` | Start state's `compartment.enter_args` |
 | Domain arg | `name: type` | Constructor parameter, used in domain initializers |
 
-The sigils tell the framepiler where to route the value. State
+The sigils tell framec where to route the value. State
 args go into the start state's compartment so handlers can read
 them. Enter args go to the start state's `$>` handler.
 
@@ -2030,7 +2030,7 @@ Two additions:
 
 - `max_brightness` is a `const` domain field. It's set from a
   system parameter at construction and can never be reassigned.
-  Handlers that try will be rejected at compile time (E615).
+  Handlers that try will be rejected at transpile time (E615).
 - A new operation, `get_state()`, returns the current state name
   via `@@:system.state.name`.
 
@@ -2049,7 +2049,7 @@ def __init__(self, name: str = "Lamp", max_brightness: int = 100):
 ```
 
 In Python, `const` is a comment-only marker — Python doesn't have
-true field immutability. In other targets, the framepiler emits
+true field immutability. In other targets, framec emits
 the language's idiomatic keyword:
 
 | Target | Emitted as |
@@ -2063,11 +2063,11 @@ the language's idiomatic keyword:
 | Rust | (fields are immutable by default) |
 | Python, JS, PHP, Ruby, Lua, Erlang, GDScript, C, Go | comment-only |
 
-The framepiler enforces single-assignment at compile time
+framec enforces single-assignment at transpile time
 regardless of target — even in Python, assigning to a `const`
 field in a handler body is E615.
 
-`@@:system.state.name` compiles to a direct read off the current
+`@@:system.state.name` transpiles to a direct read off the current
 compartment:
 
 ```python
@@ -2205,7 +2205,7 @@ constructed and populated by the state's `$>` handler.
 > **In statically-typed targets** — `state_vars` is typed as a map
 > of "any": `Map<String, Object>` in Java, `HashMap<String, Box<dyn Any>>`
 > in Rust. Same access pattern, with casts at the read site
-> emitted by the framepiler from the declared variable type:
+> emitted by framec from the declared variable type:
 >
 > ```java
 > int failures = (Integer) compartment.state_vars.get("failures");
@@ -2241,8 +2241,8 @@ def _s_Open_hdl_frame_enter(self, __e, compartment):
 ```
 
 The `if "x" not in compartment.state_vars` guard is the
-initialization pattern. Every state variable gets one — the
-framepiler emits the guard at the top of every state's `$>`
+initialization pattern. Every state variable gets one — framec
+emits the guard at the top of every state's `$>`
 handler.
 
 The guard looks redundant: the compartment was just built with an
@@ -2255,7 +2255,7 @@ parent via `=> $^` — each layer's synthesized `$>` initializes
 its own `state_vars` independently, once.
 
 `$Closed` doesn't declare a `$>` handler in the source, but it has
-a state variable to initialize. The framepiler emits one anyway:
+a state variable to initialize. framec emits one anyway:
 
 ```python
 def _s_Closed_hdl_frame_enter(self, __e, compartment):
@@ -2289,15 +2289,15 @@ def _s_Open_hdl_user_tick(self, __e, compartment):
         return
 ```
 
-`$.failures` in Frame source compiles to
+`$.failures` in Frame source transpiles to
 `compartment.state_vars["failures"]` — direct lookup in the dict
 on the compartment parameter. `$.cooldown_remaining` works the
 same way against `$Open`'s compartment.
 
 This is why handlers receive a `compartment` parameter. State
 variables live on a specific compartment; handlers need a
-reference to that compartment to read or write them. The
-framepiler ensures every handler gets passed the right one — the
+reference to that compartment to read or write them. framec
+ensures every handler gets passed the right one — the
 router calls each state's dispatcher with the system's current
 compartment, which is the dispatcher's own state's compartment.
 
@@ -2343,8 +2343,8 @@ it.
 **Scope is hard to escape.** Frame source has `$.varName` syntax
 for state variables but no syntax for "the variable in some other
 state." Each handler can only reach its own state's variables
-through its own compartment parameter. The framepiler enforces
-this at compile time. There's no way to accidentally read or write
+through its own compartment parameter. framec enforces
+this at transpile time. There's no way to accidentally read or write
 another state's variables.
 
 Domain fields and context data exist for cases where data needs
@@ -2420,7 +2420,7 @@ for you — we'll work through the mechanics below.
 
 ### Self-call mechanics
 
-`@@:self.reading()` compiles to `self.reading()` — a normal Python
+`@@:self.reading()` transpiles to `self.reading()` — a normal Python
 method call:
 
 ```python
@@ -2430,7 +2430,7 @@ def _s_Active_hdl_user_calibrate(self, __e, compartment):
     self._context_stack[-1]._return = True
 ```
 
-The framepiler validates at compile time that the method exists
+framec validates at transpile time that the method exists
 in the system's interface (E601 otherwise) and that the argument
 count matches (E602 otherwise). After validation, the emission is
 straightforward — it really is just a method call.
@@ -2476,7 +2476,7 @@ def _s_Active_hdl_user_reading(self, __e, compartment):
     self._context_stack[-1]._return = self.sensor_value + self.offset
 ```
 
-`@@:(...)` compiles to `self._context_stack[-1]._return = ...`.
+`@@:(...)` transpiles to `self._context_stack[-1]._return = ...`.
 The `[-1]` access takes the top of the stack, which is whatever
 context was pushed most recently — `reading()`'s context.
 
@@ -2676,7 +2676,7 @@ one expression trades fineness of control for compactness.
 
 ### Validation
 
-Self-calls have compile-time checks:
+Self-calls have transpile-time checks:
 
 | Code | Check |
 |---|---|
@@ -2686,7 +2686,7 @@ Self-calls have compile-time checks:
 | E604 | Bare `@@:system` (must be `@@:system.state.name`) |
 
 The validation runs at the same stage as other interface
-references. By the time the framepiler emits code, all self-calls
+references. By the time framec emits code, all self-calls
 have been resolved against real interface declarations.
 
 ---
@@ -2885,7 +2885,7 @@ The two stacks operate independently.
 
 `-> pop$` on an empty `_state_stack` is undefined. Python raises
 `IndexError`; other targets fail with their language's equivalent.
-The framepiler doesn't check at compile time — keeping push/pop
+framec doesn't check at transpile time — keeping push/pop
 balanced is the author's responsibility, like keeping any other
 stack discipline.
 
@@ -3012,7 +3012,7 @@ class ThermostatCompartment:
 (`$Active`, `$Off`) and points at the parent's compartment for
 HSM children (`$Heating`, `$Cooling`).
 
-The framepiler emits a static topology table that knows which
+framec emits a static topology table that knows which
 states have parents:
 
 ```python
@@ -3028,7 +3028,7 @@ _HSM_CHAIN = {
 Each entry maps a leaf state name to the chain from root to leaf.
 `$Heating`'s chain is `["Active", "Heating"]` — the parent first,
 the leaf last. `$Active` has just itself. The table is generated
-once at compile time from the source's `=> $Parent` declarations.
+once at transpile time from the source's `=> $Parent` declarations.
 
 The transition into an HSM state needs to build the whole chain,
 not just the leaf compartment. A new helper does this:
@@ -3367,7 +3367,7 @@ For this to be type-safe, every state in the chain has to declare
 the same signature. Mismatched signatures would mean a parent
 expects different arguments than what the transition provides,
 or a child expects different arguments than what propagated to
-it. The framepiler rejects this at compile time.
+it. framec rejects this at transpile time.
 
 The rule applies to all three channels:
 
@@ -3737,7 +3737,7 @@ unhandled events are genuinely ignored.
 
 `=> $^` is only legal in states that declare an HSM parent. A
 state without a parent has nothing to forward to, so the
-declaration is meaningless. The framepiler rejects it at compile
+declaration is meaningless. framec rejects it at transpile
 time.
 
 ### Trace a forwarded event
@@ -4206,7 +4206,7 @@ CompartmentBlob {
 A Python backend produces this as JSON or MessagePack; a Java
 backend produces it via Jackson; a Rust backend uses serde. The
 output is interchangeable across backends — a Python system's
-saved blob can be restored by a Java system compiled from the
+saved blob can be restored by a Java system transpiled from the
 same Frame source.
 
 This is the cross-host migration property the runtime promises:
@@ -4463,14 +4463,14 @@ The canonical format is the same regardless of target backend.
 This means a system saved on one host can be loaded on another:
 
 - A Java service serializes its state and sends the blob to a
-  worker process compiled from the same Frame source but running
+  worker process transpiled from the same Frame source but running
   in Rust. The Rust process restores from the blob and continues.
 - A Python development environment saves a system's state mid-
   test. A Go production service (same Frame source, different
   backend) loads the blob to reproduce the failure conditions.
 - A Kubernetes pod running a Frame-generated state machine is
   drained. Its state is saved, the pod terminates, a new pod
-  spins up (possibly compiled for a different OS/arch), and
+  spins up (possibly transpiled for a different OS/arch), and
   resumes from the saved state.
 
 This works because the format is Frame's contract, not any
@@ -4478,7 +4478,7 @@ backend's. The state machine moves between hosts, preserving its
 logical state.
 
 The property depends on source agreement. Both endpoints must be
-compiled from the same Frame source — same states, same HSM
+transpiled from the same Frame source — same states, same HSM
 topology, same domain fields, same state variables. The
 `_HSM_CHAIN` validation on restore catches topology drift; the
 `schema_version` field in the blob is reserved for future
@@ -4504,5 +4504,5 @@ the data, not the dispatch.
 This is the property the doc has been building toward: a state
 machine's behavior is fully captured by its source. The runtime
 makes that data observable, restorable, and portable, but doesn't
-change the meaning of the source. Two compiled versions of the
+change the meaning of the source. Two transpiled versions of the
 same system on different hosts are the same machine.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -171,6 +171,22 @@ store. A stack of frame contexts (the *context stack*) exists so a
 event: its name and its positional parameters. See
 [runtime walkthrough § Step 1](frame_runtime.md#step-1--a-system-that-accepts-a-call).
 
+### framec
+
+The Frame [transpiler](#transpiler): the command-line tool that reads a Frame
+source file, expands its `@@system` blocks into an idiomatic state-machine
+implementation in the file's target language, and passes all native
+host code through unchanged. `framec` is the canonical name for the tool in both
+prose and CLI examples (`framec source.fpy -l rust`). Its formal project name is
+the [framepiler](#framepiler).
+
+### framepiler
+
+The formal project name for [framec](#framec) — the Frame
+[transpiler](#transpiler). The two names refer to the same tool: "framepiler" is
+the project/repository name, while `framec` is the binary and the name used
+throughout the guides. Architecture: [framepiler design](framepiler_design.md).
+
 ### hierarchical state machine (HSM)
 
 A [state machine](#machine) in which a [state](#state) may declare a parent
@@ -351,7 +367,7 @@ with `$.name`. See
 
 A Frame state machine as a unit: the `@@system` declaration with its
 `interface:`, `machine:`, `actions:`, `operations:`, and `domain:` blocks. The
-compilation target. See
+transpilation target. See
 [language reference § System Declaration](frame_language.md#system-declaration).
 
 ### system context
@@ -378,6 +394,15 @@ fresh [compartment](#compartment) for the target, and runs the target's `$>`
 [enter handler](#-enter-handler). See
 [language reference § Transition](frame_language.md#transition---state).
 
+### transpiler
+
+A source-to-source translator: a tool that reads source in one language and
+emits source in another, rather than producing machine code or bytecode.
+[framec](#framec) is a transpiler — it turns Frame `@@system` blocks into
+target-language source (Python, Rust, TypeScript, …) that a developer reads,
+edits, and compiles with that language's own toolchain. Frame uses *transpiler*
+(verb: *transpile*) throughout the documentation.
+
 ---
 
 ## Symbols
@@ -386,7 +411,7 @@ fresh [compartment](#compartment) for the target, and runs the target's `$>`
 
 The *system context* token. On its own it introduces a context accessor
 (`@@:return`, `@@:params.x`, `@@:event`, `@@:data.k`, `@@:system.state`,
-`@@:self.method(...)`); as a prefix it tags compiler-recognized constructs
+`@@:self.method(...)`); as a prefix it tags framec-recognized constructs
 (`@@system`, `@@[...]` attributes, `@@SystemName(...)` instantiation,
 `@@!Foo()`). See [language reference § System Context — `@@`](frame_language.md#system-context--).
 
@@ -403,7 +428,7 @@ and [RFC-0013](rfcs/rfc-0013.md).
 
 ### `@@[target(...)]`
 
-File-level attribute selecting the code-generation backend. See
+File-level attribute selecting the target backend. See
 [language reference § `@@[target(...)]`](frame_language.md#target).
 
 ### `@@[main]`
@@ -453,7 +478,7 @@ a resource handle, which the user reattaches explicitly). Applies only to
 
 Module-level **analysis directive** naming a Frame source file —
 `@@import "./other.frm"`. It tells framec where a referenced [system](#system)'s
-source lives so framec can read it *while compiling the current file*: to check
+source lives so framec can read it *while transpiling the current file*: to check
 this file's use of that system (argument arity/types, existence) and to resolve
 cross-file facts code generation needs (notably a [composed](#composed-system)
 child's [save](#save) / [load](#load) method names). It is **not** a

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -240,15 +240,22 @@ A [system](#system)'s state machine, declared in the `machine:` block: its
 [transitions](#transition) between them. See
 [language reference § Machine Section](frame_language.md#machine-section).
 
+Two other senses of the word appear in the docs: colloquially, *machine* is
+Frame's shorthand for the whole automaton (the systems it generates), and an
+[async system](#async-system) emits a distinct private class — see
+[machine (async system)](#machine-async-system).
+
 ### machine (async system)
 
 The private class (`_<Name>Machine`) framec emits for an
-[async system](#async-system), holding the actual dispatch core — kernel,
-router, state methods, transition loop, and lifecycle cascades. It is the
-previous-release single-class emission minus the public name; self-calls
-and kernel-internal dispatch run against it directly, bypassing the
-[casing](#casing)'s gate. It is internal: user code must not name
-`_<Name>Machine` directly. Introduced in [RFC-0043](rfcs/rfc-0043.md).
+[async system](#async-system), holding the actual dispatch core —
+[kernel](#kernel), [router](#router), state methods, transition loop, and
+lifecycle cascades. It is the previous-release single-class emission minus the
+public name; self-calls and kernel-internal dispatch run against it directly,
+bypassing the [casing](#casing)'s gate. It is internal: user code must not name
+`_<Name>Machine` directly. Distinct from [machine](#machine) (the `machine:`
+block of states) and from the colloquial use of *machine* for the whole
+automaton. Introduced in [RFC-0043](rfcs/rfc-0043.md).
 
 ### no-initialization
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -95,8 +95,20 @@ See [RFC-0015](rfcs/rfc-0015.md).
 The runtime act of routing an incoming [frame event](#frame-event) to the
 [event handler](#event-handler) for the current [state](#state) — walking up the
 [HSM](#hierarchical-state-machine-hsm) parent chain if the current state
-[forwards](#forward). Performed by the per-system *kernel* function. See
+[forwards](#forward). Performed by the per-system [kernel](#kernel) function,
+which calls the [router](#router) and the current state's
+[dispatcher](#dispatcher). See
 [runtime walkthrough § Step 1](frame_runtime.md#step-1--a-system-that-accepts-a-call).
+
+### dispatcher
+
+*(`_state_<State>` in generated code.)* A [state](#state)'s own event-handling
+function — one per state — that matches a [frame event](#frame-event)'s message
+to that state's [event handler](#event-handler) (or does nothing if the state
+has no handler for it). Selected and called by the [router](#router). Not to be
+confused with [dispatch](#dispatch), the runtime *act* of routing an event: the
+dispatcher is the per-state function that performs the final match. See
+[runtime walkthrough § Step 2](frame_runtime.md#step-2--adding-a-state).
 
 ### domain
 
@@ -200,6 +212,15 @@ A [system](#system)'s public API, declared in the `interface:` block: the named
 methods callers may invoke. Each interface call is [dispatched](#dispatch) to
 the current [state](#state). See
 [language reference § Interface Section](frame_language.md#interface-section).
+
+### kernel
+
+*(`__kernel`.)* The per-system runtime entry point for one [dispatch](#dispatch):
+an interface-method wrapper builds a [frame event](#frame-event) and hands it to
+the kernel, which calls the [router](#router) and then drains any pending
+[transitions](#transition). One kernel per system; it holds no state-selection
+logic itself. See
+[runtime walkthrough § Step 2](frame_runtime.md#step-2--adding-a-state).
 
 ### load
 
@@ -310,6 +331,14 @@ Reconstructing a [system](#system) instance from a serialized blob: allocate the
 instance with [no-initialization](#no-initialization), then call [`load`](#load).
 For a [composed system](#composed-system), the same pattern recurses into nested
 `@@system` domain fields. See [RFC-0015](rfcs/rfc-0015.md).
+
+### router
+
+*(`__router`.)* The single dispatch primitive: it reads the current
+[state](#state) name from the leaf [compartment](#compartment) and calls that
+state's [dispatcher](#dispatcher) — one `if/elif` branch per state. Invoked by
+the [kernel](#kernel). See
+[runtime walkthrough § Step 2](frame_runtime.md#step-2--adding-a-state).
 
 ### save
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ idiomatic state-machine implementations in that same language. Everything outsid
 the `@@system` blocks passes through unchanged — native code, no runtime
 dependency, drop-in ready.
 
-One specification compiles to **17 target languages** — Python, TypeScript,
+One specification transpiles to **17 target languages** — Python, TypeScript,
 JavaScript, Rust, C, C++, Java, C#, Go, PHP, Kotlin, Swift, Ruby, Erlang, Lua,
 Dart, GDScript — plus **Graphviz** for state-diagram visualization.
 
@@ -24,7 +24,7 @@ cargo install framec
 ## Start here
 
 - [Getting Started](frame_getting_started.md) — tutorial introduction
-- [QuickStart](frame_quickstart.md) — dense syntax reference
+- [QuickStart](frame_quickstart.md) — jump into Frame syntax
 - [Language Reference](frame_language.md) — full syntax and semantics
 - [Cookbook](frame_cookbook.md) — 111 recipes, from basic machines to enterprise patterns
 - [Runtime](frame_runtime.md) — how a generated machine behaves at runtime


### PR DESCRIPTION
Three terminology/harmonization passes over the user-facing guides, each addressing a docs-review finding. The through-line: doc terms stay aligned with the generated code and the canonical RFC vocabulary.

## Commits
- **`docs: standardize tool name on framec/transpiler across guides`** — the tool was called by seven names (framepiler, framec, transpiler, compiler/compilation tool, code generator, backend), alternating within single passages; worst case, `frame_runtime.md` Step 16 called the same actor "the framepiler" and "the assembler" two sentences apart with `assembler` never defined. Standardized on **`framec`** (proper noun) + **`transpiler`** (category), each defined once in the glossary; kept `framepiler` as the equated project name; removed `assembler` from prose (it stays a real Stage-7 name in internals docs). Preserved `backend`/`codegen` where they name real per-language targets, and target languages' own compilers.
- **`docs(glossary): define kernel/router/dispatcher runtime terms`** — the dispatch path (`__kernel` → `__router` → `_state_<State>`) is used heavily in the runtime walkthrough but only `dispatch` (the act) had a glossary entry, and that entry even leaned on an undefined "kernel". Added entries for kernel/router/dispatcher (naming the real emitted identifiers) and repaired the `dispatch` entry to link the chain.
- **`docs(glossary): disambiguate the three senses of "machine"`** — automaton (shorthand) vs the `machine:` block vs the async private class `_<Name>Machine`. Added bidirectional glossary cross-links and qualified the async intro as "a private machine class". Did **not** rename the async concept to "dispatch core"/"engine" (would diverge from the emitted `_<Name>Machine` and RFC-0043). Also stripped a stray soft hyphen from the `_ConnectionMachine` identifier.

## Notes
- Scope is the seven user-facing guides only; internals/design/RFC docs untouched.
- Each item deviated from the raw review where it would have hurt code↔doc alignment (kept framepiler/backend as real terms; added glossary entries rather than rewriting the runtime page; qualified "machine" instead of renaming it).
- No file overlap with current `main` (which touched `_config.yml`/`games.md`/framec source).

## Verification
- `assembler` = 0 in guides; all new glossary anchors resolve; cross-refs bidirectional.
- `jekyll build` clean; pre-commit validated all 118 runnable Frame samples on each commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)