### PR TITLE
docs: revert Games nav to external link

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -35,10 +35,15 @@ aux_links:
 aux_links_new_tab: true
 
 # Playable Frame Arcade — a separate deploy (frame-games repo) at its own
-# subdomain. Surfaced via docs/games.md, which sits at nav_order 5.5 (between
-# Cookbook and Runtime) and uses jekyll-redirect-from to bounce the visitor
-# out to https://games.frame-lang.org. Same-tab; for new-tab placement we'd
-# need a theme `_includes` override.
+# subdomain. Surfaced as a top-level external nav link that opens in a new
+# tab. just-the-docs renders nav_external_links at the bottom of the
+# sidebar by theme convention. We tried a docs/games.md redirect page to
+# slot it mid-sidebar (between Cookbook and Runtime) but the docs chrome
+# wrapped the redirect instead of firing it instantly, so we reverted.
+nav_external_links:
+  - title: Games
+    url: https://games.frame-lang.org
+    opens_in_new_tab: true
 back_to_top: true
 back_to_top_text: "Back to top"
 

--- a/docs/games.md
+++ b/docs/games.md
@@ -1,7 +1,0 @@
----
-title: Games
-nav_order: 5.5
-redirect_to: https://games.frame-lang.org
----
-
-Redirecting to [games.frame-lang.org](https://games.frame-lang.org)…


### PR DESCRIPTION
## Summary
- The redirect-page approach (`docs/games.md` + jekyll-redirect-from from commit afd251d) wrapped in just-the-docs's layout instead of rendering jekyll-redirect-from's minimal meta-refresh, producing a visible "Redirecting to games.frame-lang.org…" interstitial.
- Reverts to `nav_external_links` for Games: opens https://games.frame-lang.org in a new tab immediately, but the link sits at the bottom of the sidebar (theme convention).

## Test plan
- [ ] Verify clicking Games in the sidebar opens games.frame-lang.org in a new tab.
- [ ] Verify no leftover `docs/games.md` redirect page is reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)