### PR TITLE
Comments pass through verbatim (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   and are emitted exactly like domain-field initializers; the per-target
   "portable init" value wrapping (`""` → `String::from("")`, …) was removed. Write
   the native init value for the declared type.
+- **Section comments now emit verbatim (#58).** framec no longer rewrites a `//`
+  comment leader to the target's native one (`#`/`--`/`%`). Comments pass through
+  unchanged like everything else — write your target's own comment syntax
+  everywhere. This was the last source transform framec performed.
 
 ### Fixed
 
@@ -26,6 +30,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   (#59).** `$.x: f64 = 0.0` previously parsed-and-reserialized through
   `f64::to_string()` and emitted `0` (uncompilable Rust; wrong on every typed
   target). State-var inits are now verbatim, so the literal is preserved.
+- **A `#` in a structural section no longer throws `E002` (#58).** `#` was
+  rejected as an unexpected byte in `interface:` while passing through verbatim
+  in `domain:`/handlers. The structural scanner now passes `#` through like any
+  non-Frame text, consistent across all sections (the Oceans Model).
 
 ### Docs
 

--- a/docs/releases/4.5.0-migration.md
+++ b/docs/releases/4.5.0-migration.md
@@ -75,6 +75,25 @@ $Idle { $.buffer: String = String::from("") }
   slot needs the suffix (`0.0f`); their `double` and Rust's `f32`/`f64` take `0.0`.
 - Dynamic targets (Python/JS/Ruby/Lua/PHP) are unchanged — `""`, `0`, `0.0` work.
 
+## 3. Comments → native leaders
+
+framec no longer rewrites a `//` comment leader to the target's native one.
+Section comments emit **verbatim**, like everything else. If you wrote `//`
+structural comments in a source targeting a `#`/`--`/`%` language, switch to that
+language's leader — the same one you already use inside handler bodies:
+
+```frame
+# before — relied on //→native translation (Python target)
+// reset the counter
+
+# after — write Python's own comment leader
+# reset the counter
+```
+
+Targets whose native leader is already `//` (Rust, C, C++, C#, Java, Kotlin,
+Swift, Go, Dart, JS, TS, PHP) are unaffected. A `#` in a structural section no
+longer throws `E002` — it passes through verbatim like any native text.
+
 ## Quick check
 
 Compile your tree to each target you ship and let the native compiler flag the

--- a/framec/src/frame_c/compiler/lexer/mod.rs
+++ b/framec/src/frame_c/compiler/lexer/mod.rs
@@ -835,18 +835,25 @@ impl Lexer {
                 self.cursor += 1;
                 continue;
             }
-            // Always handle // line comments in structural sections
-            // (Frame structural syntax uses // regardless of target language)
-            if b == b'/' && self.cursor + 1 < self.end && self.source[self.cursor + 1] == b'/' {
+            // Line comments in structural sections. Frame recognizes the
+            // construct grammar and passes everything else through as native
+            // text (Oceans Model) — so a comment here is captured and emitted
+            // verbatim, never rejected. We accept both `//` and `#` leaders
+            // universally (the two a user reaches for structurally) so an
+            // unrecognized leader never throws `E002`; whether the leader is
+            // valid for the target is the target compiler's concern, not
+            // framec's (same contract as type names and init values).
+            if (b == b'/' && self.cursor + 1 < self.end && self.source[self.cursor + 1] == b'/')
+                || b == b'#'
+            {
                 let start = self.cursor;
-                self.cursor += 2;
                 while self.cursor < self.end && self.source[self.cursor] != b'\n' {
                     self.cursor += 1;
                 }
                 self.capture_section_comment(start, self.cursor);
                 continue;
             }
-            // Try to skip comments via SyntaxSkipper (handles #, /* */, etc.)
+            // Try to skip comments via SyntaxSkipper (handles /* */, etc.)
             if let Some(new_pos) = self
                 .skipper
                 .skip_comment(&self.source, self.cursor, self.end)

--- a/framec/src/frame_c/compiler/lexer/mod.rs
+++ b/framec/src/frame_c/compiler/lexer/mod.rs
@@ -872,15 +872,14 @@ impl Lexer {
     /// newline the per-language skipper consumed. Trailing newlines
     /// are trimmed so codegen can emit one per line cleanly.
     ///
-    /// Frame source for a given target uses that target's comment
-    /// leader (Oceans Model). The `//` line-comment branch in
-    /// `skip_whitespace_and_comments` accepts `//` regardless of
-    /// target — that's a convenience for users who write Frame
-    /// structurally and reach for `//` even in Python/Ruby/Lua/
-    /// GDScript Frame source. To preserve the Oceans-Model invariant
-    /// at codegen, captured `//` comments are translated here to the
-    /// target's native leader so emission produces valid target
-    /// source.
+    /// The comment is captured and emitted **verbatim** — framec does
+    /// not rewrite the leader. Like type names, init values, and all
+    /// native code, comments pass through unchanged (Oceans Model):
+    /// write your target's own comment syntax (`//`, `#`, `--`, `%`).
+    /// (Earlier versions translated a `//` leader to each target's
+    /// native leader; that was the last place framec rewrote source and
+    /// it was removed to keep the model uniform — native comments
+    /// everywhere, structural and native alike.)
     fn capture_section_comment(&mut self, start: usize, end: usize) {
         let bytes = &self.source[start..end];
         let raw = String::from_utf8_lossy(bytes)
@@ -890,8 +889,7 @@ impl Lexer {
         if raw.is_empty() {
             return;
         }
-        let text = translate_section_comment(&raw, self.lang);
-        self.pending_comments.push(text);
+        self.pending_comments.push(raw);
     }
 
     /// Drain comments captured since the last call. The parser invokes
@@ -987,56 +985,6 @@ impl Lexer {
 // ============================================================================
 // Convenience Functions
 // ============================================================================
-
-/// Translate a captured section comment so its leader matches the
-/// target's native comment leader. The lexer's
-/// `skip_whitespace_and_comments` accepts `//` regardless of target
-/// (a convenience for users writing Frame structurally), but
-/// codegen emits captured leading comments verbatim as NativeBlock
-/// nodes — for non-`//` targets that produces invalid source. Maps
-/// a leading `//` to the target's native leader; comments that
-/// already use the target's leader pass through unchanged.
-fn translate_section_comment(raw: &str, lang: TargetLanguage) -> String {
-    let target_leader = native_comment_leader(lang);
-    if target_leader == "//" {
-        return raw.to_string();
-    }
-    // Preserve any leading whitespace before the `//` so codegen's
-    // line-level emit lands at the right indent.
-    let trimmed_left_len = raw.len() - raw.trim_start().len();
-    let indent = &raw[..trimmed_left_len];
-    let body = &raw[trimmed_left_len..];
-    if let Some(rest) = body.strip_prefix("//") {
-        format!("{}{}{}", indent, target_leader, rest)
-    } else {
-        raw.to_string()
-    }
-}
-
-/// Native single-line comment leader per target language. Used by
-/// `translate_section_comment` to rewrite `//` Frame structural
-/// comments into the target's native syntax for codegen emission.
-fn native_comment_leader(lang: TargetLanguage) -> &'static str {
-    match lang {
-        TargetLanguage::Python3 | TargetLanguage::Ruby | TargetLanguage::GDScript => "#",
-        TargetLanguage::Lua => "--",
-        TargetLanguage::Erlang => "%",
-        // C-family + scripting languages that natively use `//`.
-        TargetLanguage::JavaScript
-        | TargetLanguage::TypeScript
-        | TargetLanguage::Java
-        | TargetLanguage::Kotlin
-        | TargetLanguage::CSharp
-        | TargetLanguage::C
-        | TargetLanguage::Cpp
-        | TargetLanguage::Rust
-        | TargetLanguage::Swift
-        | TargetLanguage::Go
-        | TargetLanguage::Dart
-        | TargetLanguage::Php => "//",
-        TargetLanguage::Graphviz => "//",
-    }
-}
 
 /// Convenience function to lex an entire system body in structural mode.
 /// Useful for testing. For the full pipeline, use the `Lexer` struct directly.


### PR DESCRIPTION
Completes the verbatim-passthrough model: framec now touches **nothing** in your source — types, init values, native code, **and comments** all pass through unchanged. (Re-opened against `main`; supersedes #64, which auto-closed when #63's branch was deleted on merge.)

## Two changes

1. **`#` no longer throws `E002` in structural sections.** A `#` in `interface:` hit an unrecognized byte and threw `E002: Unexpected byte '#'`, while the same `#` in `domain:`/handlers passed through verbatim. `skip_whitespace_and_comments` now accepts `#` line comments universally alongside `//`, so all three sections behave the same — `#` flows through verbatim (valid native on Python/Ruby/GDScript; use `//` on `//`-targets).

2. **Removed the `//`→native comment translation** — the last place framec rewrote source. Section comments now emit verbatim; deletes the dead `translate_section_comment` / `native_comment_leader`.

## Validation
- 512 lib tests + all backend snapshot suites + 118 doc samples green; `clippy -D warnings` + `fmt` clean.
- **17-language matrix green** (17/17, 0 failures). No corpus migration needed.
- Rust-lexer change only — no scanner FSM regen.

Closes #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)