### PR TITLE
Compile-gate C++/C#/Go on PRs (#60)

### DIFF
--- a/.github/workflows/matrix-smoke.yml
+++ b/.github/workflows/matrix-smoke.yml
@@ -1,25 +1,29 @@
 name: matrix-smoke
 
-# 4-backend parallel smoke tier of the 17-backend differential matrix.
-# Rationale: the Arc-A "ALL 17 BACKENDS COMPLETE" failure shipped 16
-# commits with 12/17 backends broken because nobody ran the gate. This
-# workflow exists so that gate runs automatically on every framec
-# change. Covers 4 of the 5 architectural buckets:
+# Parallel smoke tier of the 17-backend differential matrix — each
+# backend is an independent job that compiles AND runs the matrix
+# fixtures through that language's real toolchain. Rationale: the Arc-A
+# "ALL 17 BACKENDS COMPLETE" failure shipped 16 commits with 12/17
+# backends broken because nobody ran the gate. This workflow runs it on
+# every framec change. Backends:
 #
-#   - Python:  dynamic-baseline (catches cross-target codegen drift
-#              that most often surfaces first in dynamic-typed targets)
-#   - Rust:    typed-by-value, serde, ownership (catches type-system
-#              bugs)
-#   - Java:    JVM, Jackson, reference semantics (catches JVM-specific
-#              lowering bugs and Kotlin-shape regressions)
-#   - Erlang:  gen_statem actor model (the structurally-distinct backend
-#              with the most idiomatic divergence)
+#   - Python:  dynamic-baseline (cross-target codegen drift surfaces
+#              first in dynamic-typed targets)
+#   - Rust:    typed-by-value, serde, ownership (type-system bugs)
+#   - Java:    JVM, Jackson, reference semantics
+#   - Erlang:  gen_statem actor model (most idiomatic divergence)
+#   - C++ / C# / Go:  the other typed targets with distinct codegen
+#              paths (std::any storage, typed compartments, pointer
+#              receivers). Added per FRAMEC #60 — text snapshots are
+#              blind to "looks plausible but doesn't compile/run" bugs
+#              on the typed targets, and those don't always share a
+#              failure mode with Rust/Java. Compile-gating them here
+#              catches such bugs on the PR instead of only nightly.
 #
-# Out of scope: full 17-backend matrix runs as a nightly via a separate
-# workflow, not here. PR-time wants minutes, not the full ~10 min cold
-# Docker build. GDScript needs Godot; C/C++/Go/Dart/Swift/C#/Kotlin/
-# Lua/Ruby/PHP/JS/TS round-trip through the same dynamic-or-typed
-# lowering categories Python/Rust/Java/Erlang cover.
+# Out of scope: the full 17-backend matrix runs as a nightly (separate
+# workflow). The remaining backends (Kotlin/Swift/Dart/C/GDScript/Lua/
+# Ruby/PHP/JS/TS) stay nightly-only — GDScript needs Godot, and the rest
+# are lower-risk relative to CI minutes per PR.
 
 "on":
   push:
@@ -40,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        backend: [python, rust, java, erlang]
+        backend: [python, rust, java, erlang, cpp, csharp, go]
     steps:
       - name: Checkout framec
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   sections, and the portable-float guidance (#62) updated to the verbatim-native
   contract. See [4.5.0 migration](docs/releases/4.5.0-migration.md).
 
+### CI
+
+- **PR matrix-smoke now compile-gates the typed targets C++, C#, and Go (#60).**
+  Text snapshots are blind to "looks plausible but doesn't compile/run" codegen
+  bugs on typed targets (cf. #58/#59), and those don't always share a failure
+  mode with the existing Rust/Java representatives. They were previously gated
+  only by the nightly full matrix; now they run on every PR alongside
+  Python/Rust/Java/Erlang.
+
 ## [4.4.0] - 2026-06-06
 
 Ships RFC-0043: the `@@[async]` system-header attribute and a layered


### PR DESCRIPTION
Addresses #60: text snapshots capture emitted target code but never compile it, so a typed-target codegen bug that "looks plausible but doesn't compile/run" (cf. #58/#59) passes the in-repo snapshot suite.

## Change
Add **C++, C#, Go** to the `matrix-smoke` PR tier. They join Python/Rust/Java/Erlang, so all the typed targets the issue cites (Rust/C++/Java/C#/Go) are now **compile + run gated on every PR** through each language's real toolchain — previously they were only caught by the nightly full matrix. Each is an independent parallel job; the matrix's per-target fixtures already pass (full 17-lang matrix green).

## Why this and not an in-repo snapshot compile gate
The issue's literal suggestion (compile the emitted snapshot text in-repo) is blocked by a corpus limitation I hit and verified: the in-repo `_canonical` fixtures are Python/Rust-flavored — they use `self.x` and portable comment leaders, which substitute cleanly for *types* (via `gen_snapshot_fixtures.py`) but are **not valid native code** for C/C++/Dart/Java (which need `self->`/`this.`/receiver-name and native comment leaders). Compile-gating those in-repo would fail on the *fixtures*, not real bugs, unless the corpus is rewritten per-target — which duplicates what the matrix's hand-written per-target fixtures already provide. So the matrix is the right home for per-target compile validation; this just moves the cited typed targets from nightly-only into the PR gate.

## What remains for #60 (if you want it)
- The other typed/dynamic backends (Kotlin/Swift/Dart/C/GDScript/Lua/Ruby/PHP/JS/TS) stay nightly-only — a cost/coverage call per PR.
- The float-state-var surface (#59) is already covered: `_canonical/15_float_state_vars` is in the in-repo RFC-0034 compile gate (shipped in #63).

Refs #60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)