### PR TITLE
Rust: param-referencing domain initializers no longer require Default (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   rejected as an unexpected byte in `interface:` while passing through verbatim
   in `domain:`/handlers. The structural scanner now passes `#` through like any
   non-Frame text, consistent across all sections (the Oceans Model).
+- **Rust: param-referencing domain initializers no longer require `Default` (#67).**
+  A domain field whose initializer references a ctor param (a parameterized embed
+  `inner: Inner = @@Inner(p)`, or a non-`Default` handle like `Gd<Node>`) emitted
+  `Default::default()` in the parameterless `new()` — uncompilable for non-`Default`
+  types. For systems with such fields, framec now skips `new()` and builds
+  `__create(<params>)` directly with the params in scope (`inner: Inner::__create(p)`).
 
 ### Docs
 

--- a/framec/src/frame_c/compiler/codegen/backends/rust.rs
+++ b/framec/src/frame_c/compiler/codegen/backends/rust.rs
@@ -282,27 +282,41 @@ impl LanguageBackend for RustBackend {
                     cascade_stmts.push(stmt);
                 }
 
-                // Emit `pub fn new() -> Self` — bare framework
-                let mut result = format!("{}pub fn new() -> Self {{\n", ctx.get_indent());
-                ctx.push_indent();
-                result.push_str(&format!("{}Self {{\n", ctx.get_indent()));
-                ctx.push_indent();
-                for (field, value) in &framework_fields {
-                    result.push_str(&format!("{}{}: {},\n", ctx.get_indent(), field, value));
-                }
-                for (field, _value, default) in &param_bound_fields {
-                    result.push_str(&format!("{}{}: {},\n", ctx.get_indent(), field, default));
-                }
-                ctx.pop_indent();
-                result.push_str(&format!("{}}}\n", ctx.get_indent()));
-                ctx.pop_indent();
-                result.push_str(&format!("{}}}\n", ctx.get_indent()));
+                // RFC-0020 construction: `new()` is the bare framework
+                // constructor (`@@!Foo()`); `__create(<params>)` is the
+                // factory (`@@Foo(args)`) that also runs the start `$>`.
+                //
+                // A domain field whose initializer references a ctor param
+                // can't be built in the parameterless `new()` — there is no
+                // param in scope, and no generic value (Frame has no type
+                // system, so framec can't know whether the field type is
+                // `Default`). Emitting `Default::default()` there produced
+                // uncompilable Rust for non-`Default` types like a
+                // parameterized embed `@@Inner(p)` or a `Gd<Node>` handle
+                // (FRAMEC #67). So when any field is param-bound we do NOT
+                // emit `new()` — `__create` builds the struct literal
+                // directly with the params in scope. (`new()` is only ever
+                // called by `__create`; `restore` takes `&mut self`.)
+                let has_param_bound = !param_bound_fields.is_empty();
+                let mut result = String::new();
 
-                // Emit `pub fn __create(<params>) -> Self` — factory +
-                // start-$>. Per RFC-0020 the body that used to live in
-                // `__frame_init` is absorbed inline here, with `self.`
-                // → `c.` rewrite to retarget the local instance.
-                result.push('\n');
+                if !has_param_bound {
+                    result.push_str(&format!("{}pub fn new() -> Self {{\n", ctx.get_indent()));
+                    ctx.push_indent();
+                    result.push_str(&format!("{}Self {{\n", ctx.get_indent()));
+                    ctx.push_indent();
+                    for (field, value) in &framework_fields {
+                        result.push_str(&format!("{}{}: {},\n", ctx.get_indent(), field, value));
+                    }
+                    ctx.pop_indent();
+                    result.push_str(&format!("{}}}\n", ctx.get_indent()));
+                    ctx.pop_indent();
+                    result.push_str(&format!("{}}}\n\n", ctx.get_indent()));
+                }
+
+                // Emit `pub fn __create(<params>) -> Self`. The `__frame_init`
+                // body is absorbed inline, with `self.` → `c.` rewrite to
+                // retarget the local instance.
                 let create_params = self.emit_params(params, false);
                 result.push_str(&format!(
                     "{}pub fn __create({}) -> Self {{\n",
@@ -310,9 +324,22 @@ impl LanguageBackend for RustBackend {
                     create_params
                 ));
                 ctx.push_indent();
-                result.push_str(&format!("{}let mut c = Self::new();\n", ctx.get_indent()));
-                for (field, value, _default) in &param_bound_fields {
-                    result.push_str(&format!("{}c.{} = {};\n", ctx.get_indent(), field, value));
+                if has_param_bound {
+                    // Build directly — params are in scope, so the param-bound
+                    // fields use their real initializer (no parameterless
+                    // `new()` to fall back on).
+                    result.push_str(&format!("{}let mut c = Self {{\n", ctx.get_indent()));
+                    ctx.push_indent();
+                    for (field, value) in &framework_fields {
+                        result.push_str(&format!("{}{}: {},\n", ctx.get_indent(), field, value));
+                    }
+                    for (field, value, _default) in &param_bound_fields {
+                        result.push_str(&format!("{}{}: {},\n", ctx.get_indent(), field, value));
+                    }
+                    ctx.pop_indent();
+                    result.push_str(&format!("{}}};\n", ctx.get_indent()));
+                } else {
+                    result.push_str(&format!("{}let mut c = Self::new();\n", ctx.get_indent()));
                 }
                 for stmt in &cascade_stmts {
                     let stmt_str = self.emit(stmt, ctx);

--- a/framec/tests/snapshots/rust_snapshots__consts.snap
+++ b/framec/tests/snapshots/rust_snapshots__consts.snap
@@ -127,22 +127,16 @@ mod _consts_framec {
 
     #[allow(non_snake_case)]
     impl Consts {
-        pub fn new() -> Self {
-            Self {
+        pub fn __create(step: i32, limit: i32) -> Self {
+            let mut c = Self {
                 _state_stack: Vec::new(),
                 _context_stack: Vec::new(),
                 count: 0,
                 __compartment: ConstsCompartment::new("Running"),
                 __next_compartment: None,
-                step: <i32 as Default>::default(),
-                limit: <i32 as Default>::default(),
-            }
-        }
-
-        pub fn __create(step: i32, limit: i32) -> Self {
-            let mut c = Self::new();
-            c.step = step;
-            c.limit = limit;
+                step: step,
+                limit: limit,
+            };
             c.__compartment = c.__prepareEnter("Running");
             let __e = alloc::rc::Rc::new(ConstsFrameEvent::FrameEnter {});
             let __ctx = ConstsFrameContext::new(alloc::rc::Rc::clone(&__e), None);


### PR DESCRIPTION
## Bug
A domain field whose initializer references a constructor param emitted `Default::default()` in the generated parameterless `new()`, producing **uncompilable Rust** for non-`Default` types — a parameterized cross-system embed (`inner: Inner = @@Inner(p)`) or a non-`Default` host handle initialized from a param (gdext `Gd<Node> = host`). framec can't fall back to `Default` here: it has no type system, so it can't know whether the field type is `Default`, and it emits no `impl Default`. The tell was the literal-vs-param asymmetry — `@@Inner(5)` already worked (`Inner::__create(5)`), only `@@Inner(p)` broke.

## Root cause
`backends/rust.rs` splits ctor field assignments into `framework_fields` (real value in `new()`) and `param_bound_fields` (value mentions a param → `Default::default()` in `new()`, real value re-assigned in `__create`). The dead `Default::default()` in `new()` still has to typecheck, requiring `Default`.

## Fix
When any field is param-bound, **skip `new()`** and have `__create(<params>)` build the struct literal **directly** with the params in scope, so the field uses its real initializer:

```rust
pub fn __create(p: i32) -> Self {
    let mut c = Self { /* framework */, inner: Inner::__create(p) };
    // start-$> cascade ...
    c
}
```

`new()` is only ever called by `__create` (verified); `restore` takes `&mut self`, so dropping `new()` for these systems is safe. Systems with no param-bound field are unchanged.

## Validation
- The issue's repro compiles clean via `rustc`.
- Full in-repo suite green (incl. the RFC-0034 Rust compile gate); `clippy -D warnings` + `fmt` clean.
- **17-language matrix green** (rust 339/0; the param-bound construction fixtures — `sysparam_*`, multi-system, persist — all pass). Blesses the `consts` snapshot (a param-bound system now builds `__create` directly).

Rust-only change.

Closes #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)