### PR TITLE
fix(cpp): lower self.field handler-body access (closes #69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **C++: `self.field` is now lowered to `this->field` (#69).** It was emitted
   verbatim as `self.n` — uncompilable, since C++ has no `self`. The C++ handler
   body now lowers `self.<field>` to `this-><field>` (boundary-safe, respecting
-  strings/comments), matching what `cpp.md` documents. (Cross-system embed calls
-  `self.sub.method()` on a `shared_ptr` field — the `.`→`->` step — remain to do.)
+  strings/comments), matching what `cpp.md` documents. Cross-system embed calls
+  are handled too: a domain field whose type is itself a defined system is a
+  `std::shared_ptr<Sub>`, so `self.<embed>.method()` lowers to
+  `this-><embed>->method()` (the `.`→`->` deref) so the call compiles.
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   `Default::default()` in the parameterless `new()` — uncompilable for non-`Default`
   types. For systems with such fields, framec now skips `new()` and builds
   `__create(<params>)` directly with the params in scope (`inner: Inner::__create(p)`).
+- **C++: `self.field` is now lowered to `this->field` (#69).** It was emitted
+  verbatim as `self.n` — uncompilable, since C++ has no `self`. The C++ handler
+  body now lowers `self.<field>` to `this-><field>` (boundary-safe, respecting
+  strings/comments), matching what `cpp.md` documents. (Cross-system embed calls
+  `self.sub.method()` on a `shared_ptr` field — the `.`→`->` step — remain to do.)
 
 ### Docs
 

--- a/docs/per_language_guides/cpp.md
+++ b/docs/per_language_guides/cpp.md
@@ -86,9 +86,9 @@ private:
 };
 ```
 
-Frame's `self.field` lowers to bare `field` (implicit `this` in C++
-member methods) — no explicit `this->` is required, though the
-generated code uses `this->` for clarity in some contexts.
+Frame's `self.field` lowers to `this->field` in C++ member methods —
+`self` has no meaning in C++, and `this->` keeps the access unambiguous
+when a handler parameter shares a field's name.
 Instances can be stack-allocated:
 
 ```cpp

--- a/framec/src/frame_c/compiler/codegen/state_dispatch.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch.rs
@@ -842,6 +842,31 @@ pub(crate) fn generate_per_handler_methods(
 ) -> Vec<CodegenNode> {
     let mut methods = Vec::new();
 
+    // Cross-system embed fields: domain vars whose declared type is itself a
+    // defined system (`domain: ship: Ship = @@Ship(host)`). The C++ backend
+    // emits these as `std::shared_ptr<Ship>`, so a handler body's
+    // `self.ship.respawn()` must lower the deref to `self.ship->respawn()`
+    // (then the general `self.`→`this->` rule yields `this->ship->respawn()`).
+    // `domain_symbols.symbol_type` carries the Debug-formatted `Type`
+    // (`Custom("Ship")`); unwrap to the bare name before matching.
+    let embed_fields: Vec<String> = arcanum
+        .systems
+        .get(system_name)
+        .map(|entry| {
+            entry
+                .domain_symbols
+                .iter()
+                .filter(|(_, sym)| {
+                    sym.symbol_type
+                        .as_deref()
+                        .and_then(|t| t.strip_prefix("Custom(\"")?.strip_suffix("\")"))
+                        .is_some_and(|ty| defined_systems.contains(ty))
+                })
+                .map(|(name, _)| name.clone())
+                .collect()
+        })
+        .unwrap_or_default();
+
     // State → declared HSM parent map for use by transition codegen inside
     // handler bodies (so `-> $Child` where Child => Parent constructs the
     // full chain rather than patching parent_compartment = self.__compartment).
@@ -926,6 +951,7 @@ pub(crate) fn generate_per_handler_methods(
                 &handler_state_var_types,
                 &state_hsm_parents,
                 state_param_types,
+                &embed_fields,
             );
             methods.push(method);
         }
@@ -959,6 +985,7 @@ pub(crate) fn generate_per_handler_methods(
                 &handler_state_var_types,
                 &state_hsm_parents,
                 state_param_types,
+                &embed_fields,
             );
             // Per-handler leading comments (from `HandlerAst.leading_comments`
             // / `EnterHandler.leading_comments` / `ExitHandler.leading_comments`,
@@ -1005,6 +1032,7 @@ fn generate_per_handler_method_for_lang(
     handler_state_var_types: &std::collections::HashMap<String, String>,
     state_hsm_parents: &std::collections::HashMap<String, String>,
     state_param_types: &std::collections::HashMap<(String, String), String>,
+    embed_fields: &[String],
 ) -> CodegenNode {
     match lang {
         TargetLanguage::Python3 => generate_python_handler_method(
@@ -1232,6 +1260,7 @@ fn generate_per_handler_method_for_lang(
             handler_state_var_types,
             state_hsm_parents,
             state_param_types,
+            embed_fields,
         ),
         TargetLanguage::CSharp => generate_csharp_handler_method(
             system_name,

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/cpp.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/cpp.rs
@@ -5,8 +5,8 @@
 use super::super::super::ast::{CodegenNode, Param, Visibility};
 use super::super::super::codegen_utils::{
     cpp_map_type, csharp_map_type, expression_to_string, go_map_type, java_map_type,
-    kotlin_map_type, state_var_init_value, swift_map_type, to_snake_case, type_to_cpp_string,
-    HandlerContext,
+    kotlin_map_type, replace_outside_strings_and_comments, state_var_init_value, swift_map_type,
+    to_snake_case, type_to_cpp_string, HandlerContext,
 };
 use super::super::super::frame_expansion::{
     emit_handler_body_via_statements, normalize_indentation,
@@ -144,6 +144,15 @@ pub(crate) fn generate_cpp_handler_method(
     }
 
     let body_src = emit_handler_body_via_statements(&handler.body_span, source, lang, &ctx);
+    // Lower Frame's `self.<field>` receiver access to C++ member access.
+    // C++ has no `self`; domain fields are members of the system struct,
+    // so `self.n` → `this->n` (boundary-safe: respects `"..."` strings and
+    // `// /* */` comments via the shared helper). `this->` rather than bare
+    // `n` keeps it unambiguous when a handler param shares a field's name.
+    // (The `@@:self.method()` self-call path is lowered separately in
+    // `context_self.rs`.) Cross-system embed calls — `self.sub.method()` on
+    // a `shared_ptr<Sub>` field — still need a `.`→`->` step; tracked in #69.
+    let body_src = replace_outside_strings_and_comments(&body_src, lang, &[("self.", "this->")]);
     body.push_str(&body_src);
 
     let event_type = format!("{}FrameEvent&", system_name);

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/cpp.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/cpp.rs
@@ -39,6 +39,7 @@ pub(crate) fn generate_cpp_handler_method(
     handler_state_var_types: &std::collections::HashMap<String, String>,
     state_hsm_parents: &std::collections::HashMap<String, String>,
     state_param_types: &std::collections::HashMap<(String, String), String>,
+    embed_fields: &[String],
 ) -> CodegenNode {
     let method_name = handler_method_name(state_name, handler);
     let lang = TargetLanguage::Cpp;
@@ -150,9 +151,19 @@ pub(crate) fn generate_cpp_handler_method(
     // `// /* */` comments via the shared helper). `this->` rather than bare
     // `n` keeps it unambiguous when a handler param shares a field's name.
     // (The `@@:self.method()` self-call path is lowered separately in
-    // `context_self.rs`.) Cross-system embed calls — `self.sub.method()` on
-    // a `shared_ptr<Sub>` field — still need a `.`→`->` step; tracked in #69.
-    let body_src = replace_outside_strings_and_comments(&body_src, lang, &[("self.", "this->")]);
+    // `context_self.rs`.) Cross-system embed fields are `shared_ptr<Sub>`, so
+    // `self.<embed>.method()` lowers to `<embed>->method()` (the `.`→`->`
+    // deref) — these rules run first, then the general `self.`→`this->`.
+    let mut rules: Vec<(String, String)> = embed_fields
+        .iter()
+        .map(|e| (format!("self.{e}."), format!("this->{e}->")))
+        .collect();
+    rules.push(("self.".to_string(), "this->".to_string()));
+    let rule_refs: Vec<(&str, &str)> = rules
+        .iter()
+        .map(|(a, b)| (a.as_str(), b.as_str()))
+        .collect();
+    let body_src = replace_outside_strings_and_comments(&body_src, lang, &rule_refs);
     body.push_str(&body_src);
 
     let event_type = format!("{}FrameEvent&", system_name);

--- a/framec/tests/snapshots/cpp_snapshots__actions.snap
+++ b/framec/tests/snapshots/cpp_snapshots__actions.snap
@@ -134,13 +134,13 @@ private:
     }
 
     void _s_Counting_hdl_user_get_total(ActionsFrameEvent& __e, std::shared_ptr<ActionsCompartment> compartment) {
-        _context_stack.back()._return = std::any(self.total);
+        _context_stack.back()._return = std::any(this->total);
 
     }
 
     void _s_Counting_hdl_user_increment(ActionsFrameEvent& __e, std::shared_ptr<ActionsCompartment> compartment) {
         auto n = std::any_cast<int>(__e._parameters[0]);
-        self._scale(n)
+        this->_scale(n)
 
     }
 

--- a/framec/tests/snapshots/cpp_snapshots__consts.snap
+++ b/framec/tests/snapshots/cpp_snapshots__consts.snap
@@ -134,14 +134,14 @@ private:
     }
 
     void _s_Running_hdl_user_get_count(ConstsFrameEvent& __e, std::shared_ptr<ConstsCompartment> compartment) {
-        _context_stack.back()._return = std::any(self.count);
+        _context_stack.back()._return = std::any(this->count);
 
     }
 
     void _s_Running_hdl_user_tick(ConstsFrameEvent& __e, std::shared_ptr<ConstsCompartment> compartment) {
-        self.count = self.count + self.step;
-        if self.count >= self.limit {
-            self.count = 0;
+        this->count = this->count + this->step;
+        if this->count >= this->limit {
+            this->count = 0;
         }
 
     }

--- a/framec/tests/snapshots/cpp_snapshots__forward.snap
+++ b/framec/tests/snapshots/cpp_snapshots__forward.snap
@@ -154,7 +154,7 @@ private:
     }
 
     void _s_Start_hdl_user_run(ForwardFrameEvent& __e, std::shared_ptr<ForwardCompartment> compartment) {
-        self.starts = self.starts + 1;
+        this->starts = this->starts + 1;
         auto __compartment = __prepareEnter("Middle", std::vector<std::any>{}, std::vector<std::any>{});
         __compartment->forward_event = std::make_unique<ForwardFrameEvent>(__e);
         __transition(std::move(__compartment));
@@ -170,7 +170,7 @@ private:
     }
 
     void _s_Middle_hdl_user_run(ForwardFrameEvent& __e, std::shared_ptr<ForwardCompartment> compartment) {
-        self.middles = self.middles + 1
+        this->middles = this->middles + 1
 
     }
 

--- a/framec/tests/snapshots/cpp_snapshots__hsm.snap
+++ b/framec/tests/snapshots/cpp_snapshots__hsm.snap
@@ -185,23 +185,23 @@ private:
     }
 
     void _s_Awake_hdl_frame_enter(MiniHsmFrameEvent& __e, std::shared_ptr<MiniHsmCompartment> compartment) {
-        self.awakes = self.awakes + 1
+        this->awakes = this->awakes + 1
 
     }
 
     void _s_Awake_hdl_user_signal(MiniHsmFrameEvent& __e, std::shared_ptr<MiniHsmCompartment> compartment) {
-        self.last = 1;
+        this->last = 1;
         _state_Live(__e, compartment->parent_compartment);
 
     }
 
     void _s_Asleep_hdl_frame_enter(MiniHsmFrameEvent& __e, std::shared_ptr<MiniHsmCompartment> compartment) {
-        self.sleeps = self.sleeps + 1
+        this->sleeps = this->sleeps + 1
 
     }
 
     void _s_Asleep_hdl_user_signal(MiniHsmFrameEvent& __e, std::shared_ptr<MiniHsmCompartment> compartment) {
-        self.last = 2;
+        this->last = 2;
         _state_Live(__e, compartment->parent_compartment);
 
     }

--- a/framec/tests/snapshots/cpp_snapshots__lifecycle.snap
+++ b/framec/tests/snapshots/cpp_snapshots__lifecycle.snap
@@ -157,14 +157,14 @@ private:
     }
 
     void _s_Running_hdl_frame_exit(LifecycleFrameEvent& __e, std::shared_ptr<LifecycleCompartment> compartment) {
-        self.exited = self.exited + 1
+        this->exited = this->exited + 1
 
     }
 
     void _s_Running_hdl_frame_enter(LifecycleFrameEvent& __e, std::shared_ptr<LifecycleCompartment> compartment) {
         auto label = std::any_cast<std::string>(compartment->enter_args[0]);
-        self.entered = self.entered + 1;
-        self.tag = label;
+        this->entered = this->entered + 1;
+        this->tag = label;
 
     }
 

--- a/framec/tests/snapshots/cpp_snapshots__lifecycle_args.snap
+++ b/framec/tests/snapshots/cpp_snapshots__lifecycle_args.snap
@@ -159,19 +159,19 @@ private:
     void _s_Active_hdl_frame_enter(LifecycleArgsFrameEvent& __e, std::shared_ptr<LifecycleArgsCompartment> compartment) {
         auto count = std::any_cast<int>(compartment->enter_args[0]);
         auto name = std::any_cast<std::string>(compartment->enter_args[1]);
-        self.sum = count + 1;
-        self.label = name;
+        this->sum = count + 1;
+        this->label = name;
 
     }
 
     void _s_Active_hdl_user_tag(LifecycleArgsFrameEvent& __e, std::shared_ptr<LifecycleArgsCompartment> compartment) {
-        _context_stack.back()._return = std::any(self.label);
+        _context_stack.back()._return = std::any(this->label);
                         return
 
     }
 
     void _s_Active_hdl_user_total(LifecycleArgsFrameEvent& __e, std::shared_ptr<LifecycleArgsCompartment> compartment) {
-        _context_stack.back()._return = std::any(self.sum);
+        _context_stack.back()._return = std::any(this->sum);
                         return
 
     }

--- a/framec/tests/snapshots/cpp_snapshots__linear_fsm.snap
+++ b/framec/tests/snapshots/cpp_snapshots__linear_fsm.snap
@@ -166,7 +166,7 @@ private:
 
     void _s_Active_hdl_user_progress(LinearFsmFrameEvent& __e, std::shared_ptr<LinearFsmCompartment> compartment) {
         auto amount = std::any_cast<int>(__e._parameters[0]);
-        self.total = self.total + amount
+        this->total = this->total + amount
 
     }
 

--- a/framec/tests/snapshots/cpp_snapshots__no_persist.snap
+++ b/framec/tests/snapshots/cpp_snapshots__no_persist.snap
@@ -142,23 +142,23 @@ private:
     }
 
     void _s_Active_hdl_user_bump(NoPersistFrameEvent& __e, std::shared_ptr<NoPersistCompartment> compartment) {
-        self.count = self.count + 1
+        this->count = this->count + 1
 
     }
 
     void _s_Active_hdl_user_get_cache(NoPersistFrameEvent& __e, std::shared_ptr<NoPersistCompartment> compartment) {
-        _context_stack.back()._return = std::any(self.cache);
+        _context_stack.back()._return = std::any(this->cache);
 
     }
 
     void _s_Active_hdl_user_get_count(NoPersistFrameEvent& __e, std::shared_ptr<NoPersistCompartment> compartment) {
-        _context_stack.back()._return = std::any(self.count);
+        _context_stack.back()._return = std::any(this->count);
 
     }
 
     void _s_Active_hdl_user_set_cache(NoPersistFrameEvent& __e, std::shared_ptr<NoPersistCompartment> compartment) {
         auto v = std::any_cast<int>(__e._parameters[0]);
-        self.cache = v
+        this->cache = v
 
     }
 

--- a/framec/tests/snapshots/cpp_snapshots__persist.snap
+++ b/framec/tests/snapshots/cpp_snapshots__persist.snap
@@ -135,12 +135,12 @@ private:
 
     void _s_Counting_hdl_user_increment(CounterFrameEvent& __e, std::shared_ptr<CounterCompartment> compartment) {
         auto by = std::any_cast<int>(__e._parameters[0]);
-        self.count = self.count + by
+        this->count = this->count + by
 
     }
 
     void _s_Counting_hdl_user_value(CounterFrameEvent& __e, std::shared_ptr<CounterCompartment> compartment) {
-        _context_stack.back()._return = std::any(self.count);
+        _context_stack.back()._return = std::any(this->count);
 
     }
 

--- a/framec/tests/snapshots/cpp_snapshots__pushpop.snap
+++ b/framec/tests/snapshots/cpp_snapshots__pushpop.snap
@@ -156,12 +156,12 @@ private:
     }
 
     void _s_Idle_hdl_user_ping(PushPopFrameEvent& __e, std::shared_ptr<PushPopCompartment> compartment) {
-        self.pings = self.pings + 1
+        this->pings = this->pings + 1
 
     }
 
     void _s_Nested_hdl_user_leaf(PushPopFrameEvent& __e, std::shared_ptr<PushPopCompartment> compartment) {
-        self.leaves = self.leaves + 1
+        this->leaves = this->leaves + 1
 
     }
 

--- a/framec/tests/snapshots/cpp_snapshots__selfcall.snap
+++ b/framec/tests/snapshots/cpp_snapshots__selfcall.snap
@@ -134,14 +134,14 @@ private:
     }
 
     void _s_Active_hdl_user_kick(SelfCallFrameEvent& __e, std::shared_ptr<SelfCallCompartment> compartment) {
-        self.count = self.count + 1;
+        this->count = this->count + 1;
         this->report();
         if (!_context_stack.empty() && _context_stack.back()._transitioned) return;
 
     }
 
     void _s_Active_hdl_user_report(SelfCallFrameEvent& __e, std::shared_ptr<SelfCallCompartment> compartment) {
-        _context_stack.back()._return = std::any(self.count);
+        _context_stack.back()._return = std::any(this->count);
 
     }
 


### PR DESCRIPTION
## Summary

Closes #69. The C++ backend emitted Frame's `self.<field>` handler-body access verbatim — uncompilable, since C++ has no `self`. Two cases are now lowered, boundary-safe (respecting strings and `// /* */` comments):

1. **Plain domain field** — `self.score` → `this->score`.
2. **Cross-system embed** — a domain field whose type is itself a defined system (`domain: ship: Ship = @@Ship()`) is emitted as `std::shared_ptr<Ship>`, so `self.ship.respawn()` → `this->ship->respawn()` (the `.`→`->` deref through the pointer).

The embed rules run first, then the general `self.`→`this->`.

## Implementation

- `generate_per_handler_methods` computes the embed-field set (domain symbols whose declared type matches a defined system) from arcanum and threads it through `generate_per_handler_method_for_lang` to `generate_cpp_handler_method`.
- The C++ emitter builds the rewrite rules and applies them via `replace_outside_strings_and_comments`.

## Verification

- Cross-system repro compiles clean under `clang++ -std=c++17`.
- Emits `this->ship->respawn();` (embed) and `this->score = this->score + 1;` (plain field).
- Full 17-language matrix: **17 clean, 0 failures** (cpp 328/328).
- 512 lib tests pass; `clippy -D warnings` and `fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)