### PR TITLE
C: category-driven void* marshalling + pointer-typed embed calls + compile gate (closes #72, #73, #60)

### DIFF
--- a/framec/src/frame_c/compiler/codegen/c_marshal.rs
+++ b/framec/src/frame_c/compiler/codegen/c_marshal.rs
@@ -1,0 +1,163 @@
+//! C-target marshalling categories — the single source of truth for how a
+//! declared type travels through the C runtime's `void*` slots (interface
+//! params, the `_return` slot).
+//!
+//! Issue #72 root cause: three sites categorized types independently and
+//! disagreed — the return WRITE packed `float|double` via `pack_double`,
+//! the interface-wrapper READ unpacked only `double` (so a `float` return
+//! emitted an uncompilable `(float)void*` cast), and unknown types (structs)
+//! fell into `(void*)(intptr_t)` casts that don't compile at all. Every
+//! site now derives its pack/unpack form from `CMarshal`, so the write and
+//! read sides cannot drift apart again.
+//!
+//! ## The ABI per category
+//!
+//! | Category | write (pack)                          | read (unpack)              |
+//! |----------|---------------------------------------|----------------------------|
+//! | `Dbl`    | `Sys_pack_double(v)` (bit-pun)        | `Sys_unpack_double(p)`     |
+//! | `Int`    | `(void*)(intptr_t)(v)`                | `(T)(intptr_t)p`           |
+//! | `Str`    | `(void*)(intptr_t)(v)` (ptr fits)     | `(const char*)p`           |
+//! | `Ptr`    | `(void*)(intptr_t)(v)` (ptr fits)     | `(T)p`                     |
+//! | `Vec`    | direct                                | `(Sys_FrameVec*)p`         |
+//! | `Dict`   | direct                                | `(Sys_FrameDict*)p`        |
+//! | `Boxed`  | params: **stack box** (`&__box`);     | `*(T*)p` (deref-copy)      |
+//! |          | returns: **heap box** (`malloc`+copy) |                            |
+//!
+//! `Boxed` is the fallback for any type framec doesn't recognize — structs
+//! by value (`Vector2`), scalar typedefs, anything. Copy-through-a-box is
+//! type-correct for *every* C object type, so framec stays type-ignorant
+//! (no "is this a struct?" knowledge — see
+//! docs/contributing/type-ignorant-codegen.md).
+//!
+//! ## Boxed ownership contract
+//!
+//! - **Params**: the interface wrapper stack-allocates one local per boxed
+//!   param and pushes its address. The kernel dispatch is synchronous and
+//!   completes before the wrapper returns, so the locals outlive every
+//!   reader (including HSM forwards, which reuse the same `_parameters`
+//!   vec). Zero allocations; `FrameVec_destroy` never frees pointees.
+//! - **Returns**: each boxed `_return` write heap-allocates (freeing any
+//!   previous box first — only box-category writes can have written the
+//!   slot for a box-category method). The interface wrapper's read
+//!   deref-copies and frees: exactly one free, at the end of the call.
+//!   A mid-handler `@@:return` read deref-copies WITHOUT freeing (the
+//!   context is still live).
+//!
+//! State-args / enter-args / exit-args keep their historical `intptr_t`
+//! fallback: the transition push sites are a separate surface and struct
+//! state-args have never been supported on C (tracked as follow-up in #72).
+
+/// How a declared type travels through the C runtime's `void*` slots.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CMarshal {
+    /// `float` / `double` — bit-pun via `Sys_pack_double`/`Sys_unpack_double`.
+    Dbl,
+    /// `int` / `bool` — fits in `intptr_t`.
+    Int,
+    /// String types — already a pointer; reads cast to `const char*`.
+    Str,
+    /// Any explicit pointer type (`T*`) — travels as the pointer itself.
+    Ptr,
+    /// Frame's `list` family — `Sys_FrameVec*`.
+    Vec,
+    /// Frame's `dict` family — `Sys_FrameDict*`.
+    Dict,
+    /// Everything else (structs by value, typedefs) — box-by-copy.
+    Boxed,
+}
+
+/// Categorize a declared type string. The single place this decision is
+/// made — every C pack/unpack site routes through here.
+pub(crate) fn c_marshal_of(type_str: &str) -> CMarshal {
+    let t = type_str.trim();
+    match t {
+        "float" | "double" | "f32" | "f64" => CMarshal::Dbl,
+        "int" | "bool" => CMarshal::Int,
+        "str" | "string" | "String" | "char*" | "const char*" => CMarshal::Str,
+        "list" | "List" | "Array" | "Array<any>" => CMarshal::Vec,
+        "dict" | "Dict" | "Record<string, any>" => CMarshal::Dict,
+        _ if t.ends_with('*') => CMarshal::Ptr,
+        _ => CMarshal::Boxed,
+    }
+}
+
+/// The `_return`-slot WRITE for a value expression of the given declared
+/// type. `slot` is the lvalue (e.g. `Sys_CTX(self)->_return`). Boxed
+/// returns heap-box (freeing any previous box — see module docs).
+pub(crate) fn c_return_write(sys: &str, slot: &str, expr: &str, type_str: &str) -> String {
+    match c_marshal_of(type_str) {
+        CMarshal::Dbl => format!("{slot} = {sys}_pack_double({expr});"),
+        CMarshal::Boxed => format!(
+            "{{ {t}* __rbox = ({t}*)malloc(sizeof(*__rbox)); *__rbox = ({expr}); \
+             if ({slot}) free({slot}); {slot} = __rbox; }}",
+            t = type_str.trim(),
+        ),
+        _ => format!("{slot} = (void*)(intptr_t)({expr});"),
+    }
+}
+
+/// The `_return`-slot READ as an expression of the declared type.
+/// `slot` is the rvalue (e.g. `__result_ctx->_return`). Boxed reads
+/// deref-copy; freeing is the CALLER's decision (the interface wrapper
+/// frees after this read; mid-handler `@@:return` reads must not).
+pub(crate) fn c_return_read(sys: &str, slot: &str, type_str: &str) -> String {
+    let t = type_str.trim();
+    match c_marshal_of(type_str) {
+        CMarshal::Dbl => format!("{sys}_unpack_double({slot})"),
+        CMarshal::Int => format!("({t})(intptr_t){slot}"),
+        // Respect the declared pointer spelling (`char*` stays `char*` —
+        // a `(const char*)` read into a `char*` lvalue discards
+        // qualifiers); Frame's non-C string spellings get `const char*`.
+        CMarshal::Str if t.ends_with('*') => format!("({t}){slot}"),
+        CMarshal::Str => format!("(const char*){slot}"),
+        CMarshal::Vec => format!("({sys}_FrameVec*){slot}"),
+        CMarshal::Dict => format!("({sys}_FrameDict*){slot}"),
+        CMarshal::Ptr => format!("({t}){slot}"),
+        CMarshal::Boxed => format!("*({t}*){slot}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn float_and_double_are_dbl() {
+        // Issue #72: the read side categorized only "double"; float fell
+        // through to an uncompilable raw cast. Lock the symmetric set.
+        for t in ["float", "double", "f32", "f64"] {
+            assert_eq!(c_marshal_of(t), CMarshal::Dbl, "{t}");
+        }
+    }
+
+    #[test]
+    fn structs_and_typedefs_box() {
+        for t in ["Vector2", "MyStruct", "size_t", "uint32_t"] {
+            assert_eq!(c_marshal_of(t), CMarshal::Boxed, "{t}");
+        }
+    }
+
+    #[test]
+    fn pointers_pass_through() {
+        for t in ["Vector2*", "void*", "Demo*"] {
+            assert_eq!(c_marshal_of(t), CMarshal::Ptr, "{t}");
+        }
+    }
+
+    #[test]
+    fn write_read_symmetry_float() {
+        let w = c_return_write("Demo", "SLOT", "2.5", "float");
+        let r = c_return_read("Demo", "SLOT", "float");
+        assert!(w.contains("Demo_pack_double(2.5)"), "{w}");
+        assert!(r.contains("Demo_unpack_double(SLOT)"), "{r}");
+    }
+
+    #[test]
+    fn write_read_symmetry_struct() {
+        let w = c_return_write("Demo", "SLOT", "v", "Vector2");
+        let r = c_return_read("Demo", "SLOT", "Vector2");
+        assert!(w.contains("malloc(sizeof(*__rbox))"), "{w}");
+        assert!(w.contains("if (SLOT) free(SLOT);"), "{w}");
+        assert_eq!(r, "*(Vector2*)SLOT");
+    }
+}

--- a/framec/src/frame_c/compiler/codegen/frame_expansion/context_self.rs
+++ b/framec/src/frame_c/compiler/codegen/frame_expansion/context_self.rs
@@ -108,9 +108,14 @@ pub(super) fn expand_context_self_field_call(
         raw_args.to_string()
     };
 
-    // Embed = the field's declared type is itself a defined system.
+    // Embed = the field's declared type is itself a defined system. The
+    // declared spelling may be pointer-qualified — the C guide's idiomatic
+    // cross-system field is `inner: Inner*` (#73) — so strip trailing `*`s
+    // to get the base system name for the check (and for C's free-function
+    // family / Erlang's module name below).
     let field_type = ctx.domain_field_types.get(field);
-    let is_embed = field_type.is_some_and(|t| ctx.defined_systems.contains(t));
+    let embed_base: Option<&str> = field_type.map(|t| t.trim().trim_end_matches('*').trim_end());
+    let is_embed = embed_base.is_some_and(|base| ctx.defined_systems.contains(base));
 
     match lang {
         // C: a struct has no methods, so an embed call is a cross-system
@@ -120,7 +125,7 @@ pub(super) fn expand_context_self_field_call(
         // native (`self->field.method(args)`).
         TargetLanguage::C => {
             if is_embed {
-                let sys = field_type.map(|s| s.as_str()).unwrap_or("");
+                let sys = embed_base.unwrap_or("");
                 let inner = strip_outer_parens(&args);
                 if inner.trim().is_empty() {
                     format!("{sys}_{method}(self->{field})")
@@ -140,8 +145,8 @@ pub(super) fn expand_context_self_field_call(
         // is always a cross-system call; the module name is the field's system
         // type, snake-cased — matching the field's `@@System()` initializer.)
         TargetLanguage::Erlang => {
-            if let Some(sys_type) = field_type {
-                let module = to_snake_case(sys_type);
+            if let Some(base) = embed_base {
+                let module = to_snake_case(base);
                 let inner = strip_outer_parens(&args);
                 if inner.trim().is_empty() {
                     format!("{module}:{method}(self.{field})")

--- a/framec/src/frame_c/compiler/codegen/frame_expansion/handler_body.rs
+++ b/framec/src/frame_c/compiler/codegen/frame_expansion/handler_body.rs
@@ -76,22 +76,19 @@ pub(super) fn context_return_read_typed(
             "this._context_stack[this._context_stack.length - 1]._return".to_string()
         }
         TargetLanguage::C => {
-            // C's `_return` slot is a `void*` — a per-category cast back
-            // is forced by the ABI: `double` rides via the memcpy
-            // bit-pun, a string is already a pointer, everything else
-            // fits in the integer width. (See type-ignorant-codegen.md
-            // category 3.)
+            // C's `_return` slot is a `void*` — the per-category unpack
+            // comes from `c_marshal::c_return_read` (#72), the same
+            // categorization every write site uses, so pack and unpack
+            // cannot drift: `double` rides via the memcpy bit-pun, a
+            // string is already a pointer, ints fit the integer width,
+            // and a struct deref-copies its heap box (NOT freed here —
+            // the context is still live; the interface wrapper owns the
+            // single free at end-of-call).
             let raw = format!("{}_RETURN(self)", system_name);
-            match frame_type {
-                "float" | "double" | "f32" | "f64" => {
-                    format!("{}_unpack_double({})", system_name, raw)
-                }
-                "str" | "string" | "String" | "char*" | "const char*" => {
-                    format!("((const char*){})", raw)
-                }
-                "int" | "bool" => format!("((int)(intptr_t){})", raw),
-                _ => raw,
-            }
+            format!(
+                "({})",
+                super::super::c_marshal::c_return_read(system_name, &raw, frame_type)
+            )
         }
         TargetLanguage::Rust => super::super::rust_system::rust_context_return_read_typed(
             frame_type,

--- a/framec/src/frame_c/compiler/codegen/frame_expansion/utility.rs
+++ b/framec/src/frame_c/compiler/codegen/frame_expansion/utility.rs
@@ -22,37 +22,21 @@
 //!   whitespace from spliced handler text so generated code lines
 //!   up at column 0 before re-indentation downstream.
 
-/// C `_return` assignment with double-aware marshalling.
+/// C `_return` assignment with category-aware marshalling.
 ///
-/// The `_return` slot is `void*`. Ints/bools/pointers travel via
-/// `(void*)(intptr_t)(val)` cleanly. Doubles don't — `(intptr_t)(42.0)`
-/// truncates the fractional part. When the handler's declared return
-/// type is `float`/`double`, pack via a memcpy helper the runtime emits
-/// (`Sys_pack_double`).
+/// The `_return` slot is `void*`. Marshalling routes through
+/// `c_marshal::c_return_write` (#72) — the single categorization shared
+/// with every read site, so pack and unpack cannot drift: ints/bools/
+/// pointers via `(void*)(intptr_t)`, floats/doubles via the `pack_double`
+/// memcpy helper (`(intptr_t)(42.0)` truncates), structs via a heap box.
 pub(super) fn c_return_assign(
     system_name: &str,
     expanded_expr: &str,
     return_type: &Option<String>,
 ) -> String {
-    let is_dbl = return_type
-        .as_deref()
-        .map(|t| {
-            let t = t.trim();
-            t == "float" || t == "double"
-        })
-        .unwrap_or(false);
-    if is_dbl {
-        format!(
-            "{sys}_CTX(self)->_return = {sys}_pack_double({expr});",
-            sys = system_name,
-            expr = expanded_expr,
-        )
-    } else {
-        format!(
-            "{}_CTX(self)->_return = (void*)(intptr_t)({});",
-            system_name, expanded_expr
-        )
-    }
+    let ty = return_type.as_deref().unwrap_or("int");
+    let slot = format!("{}_CTX(self)->_return", system_name);
+    super::super::c_marshal::c_return_write(system_name, &slot, expanded_expr, ty)
 }
 
 /// Strip the outer parentheses from `(inner)` → `inner`.

--- a/framec/src/frame_c/compiler/codegen/interface_gen.rs
+++ b/framec/src/frame_c/compiler/codegen/interface_gen.rs
@@ -341,18 +341,30 @@ finally:
                 let sys = &system.name;
 
                 // Build parameters dict creation (with semicolon).
-                // Float/double params route through `Sys_pack_double`
-                // (memcpy bit-pun) — `(void*)(intptr_t)(0.5)` truncates
-                // to integer and breaks any float-typed interface arg.
+                // Marshalling per `c_marshal_of` (#72): float/double params
+                // route through `Sys_pack_double` (memcpy bit-pun —
+                // `(void*)(intptr_t)(0.5)` truncates); struct-by-value
+                // params travel as the address of a STACK box (the kernel
+                // dispatch is synchronous, so the wrapper's locals outlive
+                // every reader; see c_marshal.rs § Boxed ownership).
                 let params_code = if method.params.is_empty() {
                     format!("{}_FrameEvent* __e = {}_FrameEvent_new(\"{}\", NULL, 0);", sys, sys, method.name)
                 } else {
                     let mut code = format!("{}_FrameVec* __params = {}_FrameVec_new();\n", sys, sys);
                     for p in &method.params {
                         let p_type = type_to_string(&p.param_type);
-                        let push_arg = match p_type.trim() {
-                            "float" | "double" | "f32" | "f64" => {
+                        let push_arg = match super::c_marshal::c_marshal_of(&p_type) {
+                            super::c_marshal::CMarshal::Dbl => {
                                 format!("{}_pack_double({})", sys, p.name)
+                            }
+                            super::c_marshal::CMarshal::Boxed => {
+                                code.push_str(&format!(
+                                    "{} __box_{} = {};\n",
+                                    p_type.trim(),
+                                    p.name,
+                                    p.name
+                                ));
+                                format!("(void*)&__box_{}", p.name)
                             }
                             _ => format!("(void*)(intptr_t){}", p.name),
                         };
@@ -381,36 +393,47 @@ finally:
                     .map(|s| s != "void" && s != "None")
                     .unwrap_or(false);
 
-                // Set default return value after context creation. For
-                // float/double returns, pack via the memcpy helper since
-                // `(void*)(intptr_t)(3.14)` truncates to an integer.
-                let is_double_return = return_type_str
-                    .as_ref()
-                    .map(|s| s == "double")
-                    .unwrap_or(false);
+                // Set default return value after context creation —
+                // marshalled per `c_return_write` (#72): doubles pack via
+                // the memcpy helper (`(void*)(intptr_t)(3.14)` truncates),
+                // structs heap-box.
                 let default_init = if let Some(ref init_expr) = method.return_init {
-                    if is_double_return {
-                        format!("\n__ctx->_return = {}_pack_double({});", sys, init_expr)
-                    } else {
-                        format!("\n__ctx->_return = (void*)(intptr_t)({});", init_expr)
-                    }
+                    let ty = return_type_str.as_deref().unwrap_or("int");
+                    format!(
+                        "\n{}",
+                        super::c_marshal::c_return_write(sys, "__ctx->_return", init_expr, ty)
+                    )
                 } else {
                     String::new()
                 };
 
                 if let (true, Some(return_type_str)) = (has_return_value, return_type_str) {
-                    // Unpack based on declared return type:
-                    //   bool/int  → `(intptr_t)__ctx->_return`  (truncates to int size)
-                    //   double    → `Sys_unpack_double(...)`     (memcpy round-trip)
-                    //   str/ptr   → `(T)__ctx->_return`          (pointer already fits)
-                    let extract = if return_type_str == "double" {
-                        format!("{}_unpack_double(__result_ctx->_return)", sys)
+                    // Unpack via `c_return_read` (#72) — the categorization
+                    // is shared with the write side (c_return_assign /
+                    // c_marshal) so pack and unpack cannot drift apart:
+                    //   bool/int  → `(T)(intptr_t)…`
+                    //   float/dbl → `Sys_unpack_double(…)` (memcpy round-trip)
+                    //   str/ptr   → `(T)…` (pointer already fits)
+                    //   struct    → `*(T*)…` deref-copy, then free the box
+                    let extract = super::c_marshal::c_return_read(
+                        sys,
+                        "__result_ctx->_return",
+                        &return_type_str,
+                    );
+                    // Boxed returns: free the heap box after the deref-copy
+                    // (the single owner-free; see c_marshal.rs). Guard the
+                    // deref against a never-written NULL slot.
+                    let is_boxed = matches!(
+                        super::c_marshal::c_marshal_of(&return_type_str),
+                        super::c_marshal::CMarshal::Boxed
+                    );
+                    let result_decl = if is_boxed {
+                        format!(
+                            "{t} __result; memset(&__result, 0, sizeof(__result));\nif (__result_ctx->_return) {{ __result = {extract}; free(__result_ctx->_return); }}",
+                            t = return_type_str, extract = extract
+                        )
                     } else {
-                        let cast = match return_type_str.as_str() {
-                            "bool" | "int" => "(intptr_t)",
-                            _ => "",
-                        };
-                        format!("({}){}__result_ctx->_return", return_type_str, cast)
+                        format!("{} __result = {};", return_type_str, extract)
                     };
                     CodegenNode::NativeBlock {
                         code: format!(
@@ -419,12 +442,12 @@ finally:
 {}_FrameVec_push(self->_context_stack, __ctx);
 {}_kernel(self, __e);
 {}_FrameContext* __result_ctx = ({}_FrameContext*){}_FrameVec_pop(self->_context_stack);
-{} __result = {};
+{}
 {}_FrameContext_destroy(__result_ctx);
 {}_FrameEvent_destroy(__e);
 return __result;"#,
                             params_code, sys, sys, default_init, sys, sys, sys, sys, sys,
-                            return_type_str, extract, sys, sys
+                            result_decl, sys, sys
                         ),
                         span: None,
                     }

--- a/framec/src/frame_c/compiler/codegen/mod.rs
+++ b/framec/src/frame_c/compiler/codegen/mod.rs
@@ -166,6 +166,7 @@ pub mod ast;
 pub mod backend;
 pub mod backends;
 pub mod block_transform;
+pub(crate) mod c_marshal;
 pub mod codegen_utils;
 pub mod erlang_system;
 pub mod frame_expansion;

--- a/framec/src/frame_c/compiler/codegen/state_dispatch.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch.rs
@@ -411,28 +411,17 @@ pub(super) fn emit_handler_return_init(
             indent, init_expr
         ),
         TargetLanguage::C => {
-            // Doubles don't survive `(void*)(intptr_t)(val)` — the
-            // intptr_t cast truncates. Bit-pun through memcpy via the
-            // generated `Sys_pack_double` helper.
-            let is_dbl = handler
-                .return_type
-                .as_deref()
-                .map(|t| {
-                    let t = t.trim();
-                    t == "float" || t == "double"
-                })
-                .unwrap_or(false);
-            if is_dbl {
-                format!(
-                    "{}{}_CTX(self)->_return = {}_pack_double({});\n",
-                    indent, system_name, system_name, init_expr
-                )
-            } else {
-                format!(
-                    "{}{}_CTX(self)->_return = (void*)(intptr_t)({});\n",
-                    indent, system_name, init_expr
-                )
-            }
+            // Marshalled per `c_marshal::c_return_write` (#72): doubles
+            // bit-pun via `Sys_pack_double` (`(intptr_t)(42.0)` truncates),
+            // structs heap-box; the categorization is shared with every
+            // read site so pack and unpack cannot drift.
+            let ty = handler.return_type.as_deref().unwrap_or("int");
+            let slot = format!("{}_CTX(self)->_return", system_name);
+            format!(
+                "{}{}\n",
+                indent,
+                super::c_marshal::c_return_write(system_name, &slot, init_expr, ty)
+            )
         }
         TargetLanguage::Rust => {
             // RFC-0025 Track B.2: handler default-return inits the

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/c.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/c.rs
@@ -68,44 +68,57 @@ pub(crate) fn generate_c_handler_method(
 
     let mut body = String::new();
 
-    // State-param / handler-param binding from a void* slot. Maps Frame
-    // types to native C types so `str` → `const char*`, `bool` → `int`,
-    // `float`/`double` → `double` (via the runtime's `Sys_unpack_double`
-    // bit-pun helper, since `(intptr_t)(0.5)` truncates), etc. Falls
-    // back to `int` for unknown types — matches `DispatchSyntax::C`'s
-    // `c_param_type_and_cast` helper, extended for floats.
+    // State-param / handler-param binding from a void* slot. Categories
+    // come from `c_marshal::c_marshal_of` (#72) — the same source of truth
+    // the wrapper's pack side uses, so write and read cannot drift:
+    // `str` → `const char*`, `bool` → `int`, `float`/`double` → `double`
+    // (via the runtime's `Sys_unpack_double` bit-pun — `(intptr_t)(0.5)`
+    // truncates), `T*` → typed cast.
+    //
+    // The Boxed fallback (structs / unknown typedefs) differs by slot:
+    // EVENT params are pushed by the interface wrapper as stack-box
+    // addresses → deref-copy here (`T v = *(T*)val`). STATE/enter/exit
+    // args are pushed by the transition sites, which still use the
+    // historical `(void*)(intptr_t)` form → keep the int fallback there
+    // (struct state-args have never been supported on C; #72 follow-up).
     //
     // Returns (decl_type, full_extract_expr) where the extractor takes
     // the void* value placeholder `{val}`.
-    let c_extract = |type_str: &str, val_expr: &str| -> (String, String) {
+    let c_extract_mode = |type_str: &str, val_expr: &str, boxed_slot: bool| -> (String, String) {
+        use crate::frame_c::compiler::codegen::c_marshal::{c_marshal_of, CMarshal};
         let t = type_str.trim();
-        match t {
-            "str" | "string" | "String" | "char*" | "const char*" => (
+        match c_marshal_of(t) {
+            CMarshal::Str => (
                 "const char*".to_string(),
                 format!("(const char*){}", val_expr),
             ),
-            "float" | "f32" | "f64" | "double" => (
+            CMarshal::Dbl => (
                 "double".to_string(),
                 format!("{}_unpack_double({})", system_name, val_expr),
             ),
             // Frame's `: list` lands as <sys>_FrameVec* (see backends/c.rs
-            // convert_type_to_c). State-args/event-args of list type
-            // need the typed cast, not the int fallthrough.
-            "list" | "List" | "Array" | "Array<any>" => {
+            // convert_type_to_c); `: dict` → <sys>_FrameDict*.
+            CMarshal::Vec => {
                 let typ = format!("{}_FrameVec*", system_name);
                 let extract = format!("({}){}", typ, val_expr);
                 (typ, extract)
             }
-            // Same shape for `: dict` → <sys>_FrameDict*.
-            "dict" | "Dict" | "Record<string, any>" => {
+            CMarshal::Dict => {
                 let typ = format!("{}_FrameDict*", system_name);
                 let extract = format!("({}){}", typ, val_expr);
                 (typ, extract)
             }
-            _ if t.ends_with('*') => (t.to_string(), format!("({}){}", t, val_expr)),
-            _ => ("int".to_string(), format!("(int)(intptr_t){}", val_expr)),
+            CMarshal::Ptr => (t.to_string(), format!("({}){}", t, val_expr)),
+            CMarshal::Boxed if boxed_slot => (t.to_string(), format!("*({}*){}", t, val_expr)),
+            CMarshal::Int | CMarshal::Boxed => {
+                ("int".to_string(), format!("(int)(intptr_t){}", val_expr))
+            }
         }
     };
+    // Event-param slots carry boxed structs (wrapper stack-boxes them);
+    // state/enter/exit-arg slots keep the historical int fallback.
+    let c_extract = |type_str: &str, val_expr: &str| c_extract_mode(type_str, val_expr, false);
+    let c_extract_event = |type_str: &str, val_expr: &str| c_extract_mode(type_str, val_expr, true);
     if let Some(sp_names) = state_param_names.get(state_name) {
         let handler_param_names: std::collections::HashSet<&str> =
             handler.params.iter().map(|p| p.name.as_str()).collect();
@@ -131,9 +144,13 @@ pub(crate) fn generate_c_handler_method(
         }
     }
 
-    // Handler-param binding. Reuse the c_extract helper from above so
+    // Handler-param binding. Same category helper as state-args so
     // float/double params route through `Sys_unpack_double` (intptr_t
-    // cast truncates floats — same root issue as state-args).
+    // cast truncates floats). EVENT params (`__e->_parameters`) come from
+    // the interface wrapper, which stack-boxes struct-by-value params
+    // (#72) — use the boxed-slot extractor; enter/exit args come from the
+    // transition sites and keep the historical fallback.
+    let is_event_params = !handler.is_enter && !handler.is_exit;
     let param_source_pre = if handler.is_enter {
         "compartment->enter_args"
     } else if handler.is_exit {
@@ -144,7 +161,11 @@ pub(crate) fn generate_c_handler_method(
     for (i, param) in handler.params.iter().enumerate() {
         let type_str = param.symbol_type.as_deref().unwrap_or("int");
         let val_expr = format!("{}_FrameVec_get({}, {})", system_name, param_source_pre, i);
-        let (c_decl, extract) = c_extract(type_str, &val_expr);
+        let (c_decl, extract) = if is_event_params {
+            c_extract_event(type_str, &val_expr)
+        } else {
+            c_extract(type_str, &val_expr)
+        };
         body.push_str(&format!("{} {} = {};\n", c_decl, param.name, extract));
         body.push_str(&format!("(void){};\n", param.name));
     }

--- a/framec/tests/c_snapshots.rs
+++ b/framec/tests/c_snapshots.rs
@@ -72,3 +72,42 @@ fn no_persist() {
 fn lifecycle_args() {
     insta::assert_snapshot!(compile_fixture("13_lifecycle_args", "c"));
 }
+
+/// Compile gate for the C backend (#60) — the gap that let #72 (float/
+/// struct void* marshalling) and #73 (pointer-typed embed calls) ship as
+/// uncompilable text that snapshots happily blessed. Pipes the dedicated
+/// `16_marshal_embed` fixture (valid C apart from its Frame constructs)
+/// through `gcc -std=c11 -fsyntax-only`: the only thing that can make the
+/// compiler reject it is a marshalling or embed-lowering regression.
+///
+/// Skipped (not failed) when no C compiler is on PATH, matching the
+/// RFC-0034 convention in the other backends' compile checks.
+#[test]
+fn issue60_marshal_embed_compiles() {
+    use std::process::Command;
+    let cc = match common::find_tool("gcc")
+        .or_else(|| common::find_tool("clang"))
+        .or_else(|| common::find_tool("cc"))
+    {
+        Some(p) => p,
+        None => {
+            eprintln!("#60 c compile gate skipped: no C compiler on PATH");
+            return;
+        }
+    };
+    let code = compile_fixture("16_marshal_embed", "c");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("16_marshal_embed.c");
+    std::fs::write(&path, &code).expect("write tempfile");
+    let out = Command::new(&cc)
+        .args(["-std=c11", "-fsyntax-only"])
+        .arg(&path)
+        .output()
+        .expect("cc process");
+    assert!(
+        out.status.success(),
+        "#60/#72/#73: framec emits C the compiler rejects.\n--- stderr ---\n{}\n--- generated source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        code
+    );
+}

--- a/framec/tests/fixtures/c/16_marshal_embed.frm
+++ b/framec/tests/fixtures/c/16_marshal_embed.frm
@@ -1,0 +1,59 @@
+// Compile-gate fixture for the C target (#60) — covers the two C codegen
+// bug classes that text snapshots were blind to:
+//
+//   #72 — void*-slot marshalling: float return (symmetric pack/unpack),
+//         float param, struct-by-value param (wrapper stack-box), and
+//         struct-by-value return (heap box).
+//   #73 — embedded-system call `@@:self.sub.method()` with the C-idiomatic
+//         pointer-typed field (`sub: Sub*`) must lower to the free-function
+//         family `Sub_method(self->sub, …)`, not struct-member access.
+//
+// Everything here is valid C apart from the Frame constructs, so the only
+// thing that can make `gcc -fsyntax-only` reject the emitted .c is a
+// marshalling or embed-lowering regression.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct { float x; float y; } Vector2;
+
+@@system Inner {
+    interface:
+        ping(): int
+    machine:
+        $A { ping(): int { @@:(7) } }
+}
+
+@@[main]
+@@system Marshal {
+    interface:
+        set_court(size: Vector2)
+        set_margin(m: float)
+        court(): Vector2
+        radius(): float
+        relay(): int
+    machine:
+        $A {
+            set_court(size: Vector2) {
+                @@:self.w = size.x;
+                @@:self.h = size.y;
+            }
+            set_margin(m: float) {
+                @@:self.margin = m;
+            }
+            court(): Vector2 {
+                Vector2 v;
+                v.x = @@:self.w;
+                v.y = @@:self.h;
+                @@:(v)
+            }
+            radius(): float { @@:(@@:self.w / 2.0f + @@:self.margin) }
+            relay(): int { @@:(@@:self.inner.ping()) }
+        }
+    domain:
+        w: float = 0.0f
+        h: float = 0.0f
+        margin: float = 0.0f
+        inner: Inner* = @@Inner()
+}


### PR DESCRIPTION
Fixes the two C-target codegen bugs found porting Asteroids, and closes the compile-gate gap that let them ship.

## #72 — float/struct void*-slot marshalling (`c9f4978`)
Three sites categorized types independently and drifted (write packed `float|double`, wrapper read unpacked only `double`; structs hit illegal `(void*)(intptr_t)` casts). New **`c_marshal.rs`** is the single source of truth (Dbl/Int/Str/Ptr/Vec/Dict/Boxed) consumed by all 7 pack/unpack sites. Boxed = type-ignorant box-by-copy (`T` verbatim; params: zero-allocation stack box; returns: heap box freed exactly once by the wrapper read). Passthrough preserved: user type text verbatim everywhere; the categories govern only framec's own runtime plumbing and are C's native spellings.

## #73 — pointer-typed embed calls (`4b57ae8`)
`@@:self.sub.method()` with the C-idiomatic `sub: Sub*` field emitted struct-member access. Embed detection now normalizes the declared spelling (strips `*`s); C emits `Sub_method(self->sub, args)`.

## #60 — C compile gate (`4b57ae8`)
New `16_marshal_embed.frm` fixture (covers both bug classes) + `issue60_marshal_embed_compiles` (`gcc -std=c11 -fsyntax-only`). With this every typed target has a compile gate: rust/cpp/c in-repo, C++/C#/Go via matrix-smoke on PRs, all 17 in the test-env matrix. (#60's fixture asks were already met by `15_float_state_vars` + the comment-coverage work in 4.5.0.)

## Validation
- Both #72 repros + the #73 repro **compile and run** (incl. the Vector2/float Asteroids shape)
- Generated C **byte-identical** for the entire existing snapshot corpus (zero churn — purely additive)
- 30 test binaries 0 failures (incl. new c_marshal unit tests + the C gate); clippy `-D warnings`; fmt
- C matrix **332/0** (incl. new test-env regression fixture `marshal_float_struct_72.fc`); full matrix **17/17**; full nightly fuzz tier **21/21 phases PASS**

Companion test-env PR adds the runtime regression fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)