### PR TITLE
Craftsmanship audit remediation: no Debug-format parsing; boundary-safe Erlang normalize

### DIFF
--- a/framec/src/frame_c/compiler/arcanum.rs
+++ b/framec/src/frame_c/compiler/arcanum.rs
@@ -412,7 +412,11 @@ fn build_system_entry_from_frame_ast(system: &FrameSystemAst) -> SystemEntry {
         entry.domain_vars.insert(var.name.clone(), VarType::Native);
     }
 
-    // Phase 7: Extract domain variables with full symbol info
+    // Phase 7: Extract domain variables with full symbol info.
+    // `symbol_type` carries the user's verbatim type text (None when the
+    // declaration is untyped) — the same clean convention the param symbols
+    // below use via `type_to_string`. Consumers read it directly; nothing
+    // should ever have to parse a Debug-formatted `Type` out of it.
     for var in &system.domain {
         let symbol = FrameSymbol {
             name: var.name.clone(),
@@ -421,7 +425,10 @@ fn build_system_entry_from_frame_ast(system: &FrameSystemAst) -> SystemEntry {
                 start: var.span.start,
                 end: var.span.end,
             },
-            symbol_type: Some(format!("{:?}", var.var_type)),
+            symbol_type: match &var.var_type {
+                Type::Custom(t) => Some(t.clone()),
+                Type::Unknown => None,
+            },
             default_value: None,
         };
         entry.domain_symbols.insert(var.name.clone(), symbol);

--- a/framec/src/frame_c/compiler/codegen/erlang_system/body_processor.rs
+++ b/framec/src/frame_c/compiler/codegen/erlang_system/body_processor.rs
@@ -221,24 +221,66 @@ struct CaseFrame {
 /// body processor's existing `self.`-based handling (record access + Data
 /// threading) applies. A `@@:self.<method>(...)` **call** is left intact — its
 /// transition-guard wrapping downstream keys on the `@@:self` marker.
+///
+/// Boundary-safe: the walk delegates string-literal and comment skipping to
+/// the Erlang `SyntaxSkipper` (the same primitive
+/// `replace_outside_strings_and_comments` uses), so a `"@@:self.x"` inside a
+/// string or `%` comment passes through untouched. A plain substring scan
+/// can't be used here because the rewrite is conditional (field vs call).
 fn erlang_strip_at_self_field(line: &str) -> String {
-    let mut result = line.to_string();
-    let mut from = 0;
-    while let Some(rel) = result[from..].find("@@:self.") {
-        let pos = from + rel;
-        let after = pos + "@@:self.".len();
-        let id_end = result[after..]
-            .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
-            .map(|k| after + k)
-            .unwrap_or(result.len());
-        if result[id_end..].starts_with('(') {
-            from = after; // a call — keep `@@:self.`
-        } else {
-            result.replace_range(pos..after, "self.");
-            from = pos + "self.".len();
+    const MARKER: &[u8] = b"@@:self.";
+    let skipper = crate::frame_c::compiler::native_region_scanner::create_skipper(
+        crate::frame_c::visitors::TargetLanguage::Erlang,
+    );
+    let bytes = line.as_bytes();
+    let end = bytes.len();
+    let mut out = String::with_capacity(line.len());
+    let mut i = 0;
+    while i < end {
+        if let Some(next) = skipper.skip_string(bytes, i, end) {
+            out.push_str(&line[i..next]);
+            i = next;
+            continue;
         }
+        if let Some(next) = skipper.skip_comment(bytes, i, end) {
+            out.push_str(&line[i..next]);
+            i = next;
+            continue;
+        }
+        if i + MARKER.len() <= end && &bytes[i..i + MARKER.len()] == MARKER {
+            // Scan the member identifier after `@@:self.`.
+            let mut id_end = i + MARKER.len();
+            while id_end < end && (bytes[id_end].is_ascii_alphanumeric() || bytes[id_end] == b'_') {
+                id_end += 1;
+            }
+            if id_end < end && bytes[id_end] == b'(' {
+                // A call — keep the `@@:self.` marker for the guard wrapping.
+                out.push_str(&line[i..id_end]);
+            } else {
+                // A field access — drop the `@@:` prefix.
+                out.push_str("self.");
+                out.push_str(&line[i + MARKER.len()..id_end]);
+            }
+            i = id_end;
+            continue;
+        }
+        // Plain character — copy through at full UTF-8 width so multibyte
+        // sequences aren't split (same convention as
+        // `replace_outside_strings_and_comments`).
+        let width = if bytes[i] < 0x80 {
+            1
+        } else if bytes[i] >= 0xF0 {
+            4
+        } else if bytes[i] >= 0xE0 {
+            3
+        } else {
+            2
+        };
+        let next = (i + width).min(end);
+        out.push_str(&line[i..next]);
+        i = next;
     }
-    result
+    out
 }
 
 pub(super) fn erlang_process_body_lines_full(

--- a/framec/src/frame_c/compiler/codegen/interface_gen.rs
+++ b/framec/src/frame_c/compiler/codegen/interface_gen.rs
@@ -1011,11 +1011,7 @@ fn self_expansion_ctx(
                 .domain_symbols
                 .iter()
                 .filter_map(|(name, sym)| {
-                    let ty = sym
-                        .symbol_type
-                        .as_deref()
-                        .and_then(|t| t.strip_prefix("Custom(\"")?.strip_suffix("\")"))?;
-                    Some((name.clone(), ty.to_string()))
+                    Some((name.clone(), sym.symbol_type.as_deref()?.to_string()))
                 })
                 .collect()
         })

--- a/framec/src/frame_c/compiler/codegen/state_dispatch.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch.rs
@@ -842,10 +842,10 @@ pub(crate) fn generate_per_handler_methods(
 ) -> Vec<CodegenNode> {
     let mut methods = Vec::new();
 
-    // Domain field name → declared type (clean, e.g. `Ship`). Used by the C++
-    // `@@:self.field.method()` lowering (RFC-0046) to tell an embedded system
-    // (deref with `->`) from a scalar field (`.`). arcanum stores the type as
-    // the Debug-formatted `Type` (`Custom("Ship")`); unwrap to the bare name.
+    // Domain field name → declared type (the user's verbatim type text,
+    // e.g. `Ship`). Used by the C++ `@@:self.field.method()` lowering
+    // (RFC-0046) to tell an embedded system (deref with `->`) from a scalar
+    // field (`.`). arcanum's domain symbols carry the clean type directly.
     let domain_field_types: std::collections::HashMap<String, String> = arcanum
         .systems
         .get(system_name)
@@ -854,11 +854,7 @@ pub(crate) fn generate_per_handler_methods(
                 .domain_symbols
                 .iter()
                 .filter_map(|(name, sym)| {
-                    let ty = sym
-                        .symbol_type
-                        .as_deref()
-                        .and_then(|t| t.strip_prefix("Custom(\"")?.strip_suffix("\")"))?;
-                    Some((name.clone(), ty.to_string()))
+                    Some((name.clone(), sym.symbol_type.as_deref()?.to_string()))
                 })
                 .collect()
         })


### PR DESCRIPTION
Remediation from the full post-4.4.0 craftsmanship audit (FSM-first, no string-matching hacks, verbatim passthrough). Two findings, both fixed at the root:

1. **Debug-format type parsing (violation).** arcanum stored domain symbols' `symbol_type` as `format!("{:?}")` (`Custom("Ship")`) while params stored clean text — forcing two RFC-0046 consumers to parse Debug output via `strip_prefix("Custom(\"")`. Fixed at the source: domain symbols store the user's verbatim type (`Custom(t)`→`t`, `Unknown`→`None`); consumers read directly. No other reader depended on the Debug form (verified).

2. **Boundary safety in `erlang_strip_at_self_field` (borderline).** The `@@:self.<field>` normalize was a plain substring scan — an Erlang string literal containing `"@@:self.x"` would be silently corrupted. Rewritten on the Erlang `SyntaxSkipper` (the same primitive `replace_outside_strings_and_comments` uses), UTF-8-width-safe. Probe-verified: `Msg = "literal @@:self.n stays"` survives intact while real `@@:self.n` lowers.

Everything else in the post-4.4.0 diff audited CLEAN (report in the PR conversation if wanted). Validated: 0 test failures, clippy `-D warnings`, fmt, full matrix 17/17, full fuzz tier 21/21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)