### PR TITLE
Declared-type coercion at every type-erasure write site + runtime gates (closes #77, #78)

### DIFF
--- a/framec/src/frame_c/compiler/codegen/codegen_utils.rs
+++ b/framec/src/frame_c/compiler/codegen/codegen_utils.rs
@@ -78,6 +78,40 @@ pub(crate) struct HandlerContext {
     pub actions: std::collections::HashSet<String>,
 }
 
+/// Coerce a value expression to its DECLARED float-family type at the point
+/// it enters a target's type-erasure layer (#77).
+///
+/// The type-erased backends store state-vars / the return slot in an erased
+/// container (`std::any`, `object`, `Object`, `Any`, `interface{}`) and read
+/// back with an EXACT-match cast of the declared type. A bare literal,
+/// however, deduces/boxes to the target's default float width (`0.0` →
+/// C++ `double`, Java `Double`, Go `float64`, …), so a `float`-declared slot
+/// stores a double and every read crashes at runtime (`std::bad_any_cast` /
+/// `InvalidCastException` / `ClassCastException` / `as!` trap / interface
+/// panic) — while compiling cleanly. Third sighting of the typed-erasure
+/// round-trip class (#59 Rust literals, #72 C `void*`, #77 this).
+///
+/// The discipline: every WRITE into an erased slot coerces to the declared
+/// type; reads stay exact. Coercion is a no-op when the expression already
+/// has the declared type, so it is safe to apply unconditionally at the
+/// write chokepoints. Only the float family needs it (the only case where a
+/// valid literal's deduced type differs from a declared native type);
+/// everything else returns the expression unchanged. C is handled separately
+/// via `c_marshal` (bit-pun pack/unpack — there is no typed box to match).
+pub(crate) fn erased_write_coercion(lang: TargetLanguage, declared: &str, expr: &str) -> String {
+    let t = declared.trim();
+    match lang {
+        TargetLanguage::Cpp if t == "float" || t == "double" => format!("({t})({expr})"),
+        TargetLanguage::CSharp if t == "float" || t == "double" => format!("({t})({expr})"),
+        TargetLanguage::Java if t == "float" || t == "double" => format!("({t})({expr})"),
+        TargetLanguage::Kotlin if t == "Float" => format!("({expr}).toFloat()"),
+        TargetLanguage::Kotlin if t == "Double" => format!("({expr}).toDouble()"),
+        TargetLanguage::Swift if t == "Float" || t == "Double" => format!("{t}({expr})"),
+        TargetLanguage::Go if t == "float32" || t == "float64" => format!("{t}({expr})"),
+        _ => expr.to_string(),
+    }
+}
+
 /// Get default initialization value for a type
 pub(crate) fn state_var_init_value(var_type: &Type, lang: TargetLanguage) -> String {
     match var_type {

--- a/framec/src/frame_c/compiler/codegen/frame_expansion/context_return.rs
+++ b/framec/src/frame_c/compiler/codegen/frame_expansion/context_return.rs
@@ -62,6 +62,16 @@ pub(super) fn expand_context_return(
         // form there produces `Variant((expr))` (clippy::double_parens).
         // So the Rust arm uses `raw_expr` (unwrapped).
         let expanded_expr = paren_wrap_if_multiline(&raw_expr);
+        // #77: coerce to the DECLARED return type before the value enters
+        // the erased `_return` slot (bare literals deduce/box to the default
+        // float width; the wrapper's declared-type exact-match read then
+        // crashes at runtime). No-op for non-float-family declarations and
+        // non-erased targets; C marshals via c_return_assign below.
+        let expanded_expr = super::super::codegen_utils::erased_write_coercion(
+            lang,
+            ctx.current_return_type.as_deref().unwrap_or(""),
+            &expanded_expr,
+        );
         match lang {
             TargetLanguage::Python3 | TargetLanguage::GDScript => format!(
                 "{}self._context_stack[-1]._return = {}",
@@ -242,6 +252,14 @@ pub(super) fn expand_context_return_expr(
     // it, so it takes the unwrapped `raw_expr` to avoid `Variant((expr))`
     // (clippy::double_parens). Other backends need the multiline paren wrap.
     let expanded_expr = paren_wrap_if_multiline(&raw_expr);
+    // #77: coerce to the DECLARED return type before the value enters the
+    // erased `_return` slot (see expand_context_return above). No-op for
+    // non-float-family declarations and non-erased targets.
+    let expanded_expr = super::super::codegen_utils::erased_write_coercion(
+        lang,
+        ctx.current_return_type.as_deref().unwrap_or(""),
+        &expanded_expr,
+    );
     // Standalone @@ constructs include indent_str on all lines.
     // The scanner trims trailing whitespace from preceding native
     // text for standalone constructs (computed_indent > 0), so

--- a/framec/src/frame_c/compiler/codegen/frame_expansion/expression.rs
+++ b/framec/src/frame_c/compiler/codegen/frame_expansion/expression.rs
@@ -181,31 +181,35 @@ fn expand_state_vars_in_expr(expr: &str, lang: TargetLanguage, ctx: &HandlerCont
                     ));
                 }
                 TargetLanguage::C => {
+                    // Category-aware unpack via c_marshal (#77), mirroring
+                    // `expand_state_var`'s C arm: float/double state-vars
+                    // bit-pun through the void* slot — `(int)(intptr_t)`
+                    // truncates them.
                     let c_type = ctx
                         .state_var_types
                         .get(&var_name)
                         .map(|s| s.as_str())
                         .unwrap_or("int");
-                    let cast = match c_type {
-                        "char*" | "const char*" | "str" | "string" | "String" => "(const char*)",
-                        _ => "(int)(intptr_t)",
-                    };
-                    if ctx.per_handler {
-                        result.push_str(&format!(
-                            "{}{}_FrameDict_get(compartment->state_vars, \"{}\")",
-                            cast, ctx.system_name, var_name
-                        ))
+                    let comp = if ctx.per_handler {
+                        "compartment"
                     } else if ctx.use_sv_comp {
-                        result.push_str(&format!(
-                            "{}{}_FrameDict_get(__sv_comp->state_vars, \"{}\")",
-                            cast, ctx.system_name, var_name
-                        ))
+                        "__sv_comp"
                     } else {
-                        result.push_str(&format!(
-                            "{}{}_FrameDict_get(self->__compartment->state_vars, \"{}\")",
-                            cast, ctx.system_name, var_name
-                        ))
-                    }
+                        "self->__compartment"
+                    };
+                    let slot = format!(
+                        "{}_FrameDict_get({}->state_vars, \"{}\")",
+                        ctx.system_name, comp, var_name
+                    );
+                    use super::super::c_marshal::{c_marshal_of, CMarshal};
+                    let read = match c_marshal_of(c_type) {
+                        CMarshal::Str => format!("(const char*){}", slot),
+                        CMarshal::Dbl => {
+                            format!("{}_unpack_double({})", ctx.system_name, slot)
+                        }
+                        _ => format!("(int)(intptr_t){}", slot),
+                    };
+                    result.push_str(&read);
                 }
                 TargetLanguage::Cpp => {
                     let cpp_type = ctx

--- a/framec/src/frame_c/compiler/codegen/frame_expansion/state_var.rs
+++ b/framec/src/frame_c/compiler/codegen/frame_expansion/state_var.rs
@@ -103,21 +103,19 @@ pub(super) fn expand_state_var(
             super::super::rust_system::rust_expand_state_var_read(ctx, &var_name)
         }
         TargetLanguage::C => {
-            // For C, access via FrameDict_get with type-aware cast.
-            // Per-handler takes precedence — read from the handler's
-            // named `compartment` param. When use_sv_comp is set in
-            // the legacy path, read from `__sv_comp` pointer (walked
-            // up to owning state at dispatch entry); otherwise
-            // default to `self->__compartment`.
+            // For C, access via FrameDict_get with category-aware unpack
+            // (c_marshal, #77): float/double state-vars travel through the
+            // void* slot via the bit-pun pack/unpack pair —
+            // `(int)(intptr_t)` truncates them. Per-handler takes
+            // precedence — read from the handler's named `compartment`
+            // param. When use_sv_comp is set in the legacy path, read from
+            // `__sv_comp` pointer (walked up to owning state at dispatch
+            // entry); otherwise default to `self->__compartment`.
             let c_type = ctx
                 .state_var_types
                 .get(var_name.as_str())
                 .map(|s| s.as_str())
                 .unwrap_or("int");
-            let cast = match c_type {
-                "char*" | "const char*" | "str" | "string" | "String" => "(const char*)",
-                _ => "(int)(intptr_t)",
-            };
             let comp = if ctx.per_handler {
                 "compartment"
             } else if ctx.use_sv_comp {
@@ -125,10 +123,16 @@ pub(super) fn expand_state_var(
             } else {
                 "self->__compartment"
             };
-            format!(
-                "{}{}_FrameDict_get({}->state_vars, \"{}\")",
-                cast, ctx.system_name, comp, var_name
-            )
+            let slot = format!(
+                "{}_FrameDict_get({}->state_vars, \"{}\")",
+                ctx.system_name, comp, var_name
+            );
+            use super::super::c_marshal::{c_marshal_of, CMarshal};
+            match c_marshal_of(c_type) {
+                CMarshal::Str => format!("(const char*){}", slot),
+                CMarshal::Dbl => format!("{}_unpack_double({})", ctx.system_name, slot),
+                _ => format!("(int)(intptr_t){}", slot),
+            }
         }
         TargetLanguage::Cpp => {
             let cpp_type = ctx
@@ -369,6 +373,19 @@ pub(super) fn expand_state_var_assign(
     };
     // Expand state vars in the expression
     let expanded_expr = expand_expression(expr, lang, ctx);
+    // #77: coerce the value to the DECLARED float-family type before it
+    // enters the erased container — a bare literal deduces/boxes to the
+    // default float width (double/Double/float64) and the declared-type
+    // exact-match read then crashes at runtime. No-op for non-float
+    // declarations and for non-erased targets. (C is handled in its own
+    // arm below — it bit-puns via pack_double, there is no typed box.)
+    let declared = ctx
+        .state_var_types
+        .get(var_name)
+        .map(|s| s.as_str())
+        .unwrap_or("");
+    let expanded_expr =
+        super::super::codegen_utils::erased_write_coercion(lang, declared, &expanded_expr);
 
     match lang {
         TargetLanguage::Python3 | TargetLanguage::GDScript => {
@@ -475,19 +492,34 @@ pub(super) fn expand_state_var_assign(
             &expanded_expr,
         ),
         TargetLanguage::C => {
+            // Category-aware pack via c_marshal (#77): float/double
+            // state-vars bit-pun through the void* slot via pack_double —
+            // `(void*)(intptr_t)` truncates them. The matching read-side
+            // unpack lives in `expand_state_var` above.
+            let packed = {
+                use super::super::c_marshal::{c_marshal_of, CMarshal};
+                match c_marshal_of(declared) {
+                    CMarshal::Dbl => {
+                        format!("{}_pack_double({})", ctx.system_name, expanded_expr)
+                    }
+                    _ => format!("(void*)(intptr_t)({})", expanded_expr),
+                }
+            };
             if ctx.per_handler {
                 format!(
-                    "{}{}_FrameDict_set(compartment->state_vars, \"{}\", (void*)(intptr_t)({}));",
-                    indent_str, ctx.system_name, var_name, expanded_expr
+                    "{}{}_FrameDict_set(compartment->state_vars, \"{}\", {});",
+                    indent_str, ctx.system_name, var_name, packed
                 )
             } else if ctx.use_sv_comp {
                 format!(
-                    "{}{}_FrameDict_set(__sv_comp->state_vars, \"{}\", (void*)(intptr_t)({}));",
-                    indent_str, ctx.system_name, var_name, expanded_expr
+                    "{}{}_FrameDict_set(__sv_comp->state_vars, \"{}\", {});",
+                    indent_str, ctx.system_name, var_name, packed
                 )
             } else {
-                format!("{}{}_FrameDict_set(self->__compartment->state_vars, \"{}\", (void*)(intptr_t)({}));",
-                            indent_str, ctx.system_name, var_name, expanded_expr)
+                format!(
+                    "{}{}_FrameDict_set(self->__compartment->state_vars, \"{}\", {});",
+                    indent_str, ctx.system_name, var_name, packed
+                )
             }
         }
         TargetLanguage::Cpp => {

--- a/framec/src/frame_c/compiler/codegen/state_dispatch.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch.rs
@@ -401,6 +401,15 @@ pub(super) fn emit_handler_return_init(
     let Some(ref init_expr) = handler.return_init else {
         return String::new();
     };
+    // #77: coerce to the DECLARED return type before the init value enters
+    // the erased `_return` slot (bare literals deduce/box to the default
+    // float width; the declared-type exact-match read then crashes at
+    // runtime). No-op elsewhere; C marshals via c_return_write below.
+    let init_expr = &super::codegen_utils::erased_write_coercion(
+        lang,
+        handler.return_type.as_deref().unwrap_or(""),
+        init_expr,
+    );
     let assign = match lang {
         TargetLanguage::Python3 => format!(
             "{}self._context_stack[-1]._return = {}\n",

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/c.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/c.rs
@@ -171,6 +171,9 @@ pub(crate) fn generate_c_handler_method(
     }
 
     // State-var init (lifecycle enter only). Uses FrameDict_has + FrameDict_set.
+    // Packing per c_marshal (#77): float/double state-vars bit-pun via
+    // pack_double — `(void*)(intptr_t)(0.0)` truncates. The matching read-side
+    // unpack lives in `expand_state_var`'s C arm.
     if handler.is_enter {
         for var in state_vars_for_init {
             let init_val = if let Some(ref init) = var.initializer_text {
@@ -178,9 +181,20 @@ pub(crate) fn generate_c_handler_method(
             } else {
                 state_var_init_value(&var.var_type, lang)
             };
+            let packed = {
+                use crate::frame_c::compiler::codegen::c_marshal::{c_marshal_of, CMarshal};
+                let declared = match &var.var_type {
+                    crate::frame_c::compiler::frame_ast::Type::Custom(t) => t.as_str(),
+                    _ => "",
+                };
+                match c_marshal_of(declared) {
+                    CMarshal::Dbl => format!("{}_pack_double({})", system_name, init_val),
+                    _ => format!("(void*)(intptr_t)({})", init_val),
+                }
+            };
             body.push_str(&format!(
-                "if (!{}_FrameDict_has(compartment->state_vars, \"{}\")) {{\n    {}_FrameDict_set(compartment->state_vars, \"{}\", (void*)(intptr_t)({}));\n}}\n",
-                system_name, var.name, system_name, var.name, init_val
+                "if (!{}_FrameDict_has(compartment->state_vars, \"{}\")) {{\n    {}_FrameDict_set(compartment->state_vars, \"{}\", {});\n}}\n",
+                system_name, var.name, system_name, var.name, packed
             ));
         }
     }

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/cpp.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/cpp.rs
@@ -130,6 +130,17 @@ pub(crate) fn generate_cpp_handler_method(
             } else {
                 state_var_init_value(&var.var_type, lang)
             };
+            // #77: coerce the initializer to the DECLARED float-family type
+            // before it enters the erased container (a bare literal deduces
+            // to the default float width; the declared-type exact-match read
+            // then crashes at runtime). No-op for other types.
+            let init_val = {
+                let declared = match &var.var_type {
+                    crate::frame_c::compiler::frame_ast::Type::Custom(t) => t.as_str(),
+                    _ => "",
+                };
+                super::super::super::codegen_utils::erased_write_coercion(lang, declared, &init_val)
+            };
             let wrapped = if init_val.trim().starts_with('"') && init_val.trim().ends_with('"') {
                 format!("std::string({})", init_val)
             } else {

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/csharp.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/csharp.rs
@@ -137,6 +137,17 @@ pub(crate) fn generate_csharp_handler_method(
             } else {
                 state_var_init_value(&var.var_type, lang)
             };
+            // #77: coerce the initializer to the DECLARED float-family type
+            // before it enters the erased container (a bare literal deduces
+            // to the default float width; the declared-type exact-match read
+            // then crashes at runtime). No-op for other types.
+            let init_val = {
+                let declared = match &var.var_type {
+                    crate::frame_c::compiler::frame_ast::Type::Custom(t) => t.as_str(),
+                    _ => "",
+                };
+                super::super::super::codegen_utils::erased_write_coercion(lang, declared, &init_val)
+            };
             body.push_str(&format!(
                 "if (!compartment.state_vars.ContainsKey(\"{}\")) {{\n    compartment.state_vars[\"{}\"] = {};\n}}\n",
                 var.name, var.name, init_val

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/go.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/go.rs
@@ -115,6 +115,17 @@ pub(crate) fn generate_go_handler_method(
             } else {
                 state_var_init_value(&var.var_type, lang)
             };
+            // #77: coerce the initializer to the DECLARED float-family type
+            // before it enters the erased container (a bare literal deduces
+            // to the default float width; the declared-type exact-match read
+            // then crashes at runtime). No-op for other types.
+            let init_val = {
+                let declared = match &var.var_type {
+                    crate::frame_c::compiler::frame_ast::Type::Custom(t) => t.as_str(),
+                    _ => "",
+                };
+                super::super::super::codegen_utils::erased_write_coercion(lang, declared, &init_val)
+            };
             body.push_str(&format!(
                 "if _, ok := compartment.stateVars[\"{}\"]; !ok {{\n    compartment.stateVars[\"{}\"] = {}\n}}\n",
                 var.name, var.name, init_val

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/java.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/java.rs
@@ -135,6 +135,17 @@ pub(crate) fn generate_java_handler_method(
             } else {
                 state_var_init_value(&var.var_type, lang)
             };
+            // #77: coerce the initializer to the DECLARED float-family type
+            // before it enters the erased container (a bare literal deduces
+            // to the default float width; the declared-type exact-match read
+            // then crashes at runtime). No-op for other types.
+            let init_val = {
+                let declared = match &var.var_type {
+                    crate::frame_c::compiler::frame_ast::Type::Custom(t) => t.as_str(),
+                    _ => "",
+                };
+                super::super::super::codegen_utils::erased_write_coercion(lang, declared, &init_val)
+            };
             body.push_str(&format!(
                 "if (!compartment.state_vars.containsKey(\"{}\")) {{\n    compartment.state_vars.put(\"{}\", {});\n}}\n",
                 var.name, var.name, init_val

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/kotlin.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/kotlin.rs
@@ -118,6 +118,17 @@ pub(crate) fn generate_kotlin_handler_method(
             } else {
                 state_var_init_value(&var.var_type, lang)
             };
+            // #77: coerce the initializer to the DECLARED float-family type
+            // before it enters the erased container (a bare literal deduces
+            // to the default float width; the declared-type exact-match read
+            // then crashes at runtime). No-op for other types.
+            let init_val = {
+                let declared = match &var.var_type {
+                    crate::frame_c::compiler::frame_ast::Type::Custom(t) => t.as_str(),
+                    _ => "",
+                };
+                super::super::super::codegen_utils::erased_write_coercion(lang, declared, &init_val)
+            };
             body.push_str(&format!(
                 "if (!compartment.state_vars.containsKey(\"{}\")) {{\n    compartment.state_vars[\"{}\"] = {}\n}}\n",
                 var.name, var.name, init_val

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/swift.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/swift.rs
@@ -118,6 +118,17 @@ pub(crate) fn generate_swift_handler_method(
             } else {
                 state_var_init_value(&var.var_type, lang)
             };
+            // #77: coerce the initializer to the DECLARED float-family type
+            // before it enters the erased container (a bare literal deduces
+            // to the default float width; the declared-type exact-match read
+            // then crashes at runtime). No-op for other types.
+            let init_val = {
+                let declared = match &var.var_type {
+                    crate::frame_c::compiler::frame_ast::Type::Custom(t) => t.as_str(),
+                    _ => "",
+                };
+                super::super::super::codegen_utils::erased_write_coercion(lang, declared, &init_val)
+            };
             body.push_str(&format!(
                 "if compartment.state_vars[\"{}\"] == nil {{\n    compartment.state_vars[\"{}\"] = {}\n}}\n",
                 var.name, var.name, init_val

--- a/framec/tests/c_snapshots.rs
+++ b/framec/tests/c_snapshots.rs
@@ -111,3 +111,49 @@ fn issue60_marshal_embed_compiles() {
         code
     );
 }
+
+/// RUNTIME gate for the C backend (#78) — compiles AND EXECUTES the
+/// `17_float_roundtrip` fixture. The C float state-var path truncated
+/// values through `(void*)(intptr_t)` while compiling cleanly (#77's C
+/// sibling); only execution catches the round-trip class. The fixture's
+/// main asserts the values and exits non-zero on any mismatch.
+///
+/// Skipped (not failed) when no C compiler is on PATH.
+#[test]
+fn issue78_float_roundtrip_runs() {
+    use std::process::Command;
+    let cc = match common::find_tool("gcc")
+        .or_else(|| common::find_tool("clang"))
+        .or_else(|| common::find_tool("cc"))
+    {
+        Some(p) => p,
+        None => {
+            eprintln!("#78 c runtime gate skipped: no C compiler on PATH");
+            return;
+        }
+    };
+    let code = compile_fixture("17_float_roundtrip", "c");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("17_float_roundtrip.c");
+    let bin = dir.path().join("rt");
+    std::fs::write(&src, &code).expect("write tempfile");
+    let build = Command::new(&cc)
+        .args(["-std=c11", "-o"])
+        .arg(&bin)
+        .arg(&src)
+        .output()
+        .expect("cc process");
+    assert!(
+        build.status.success(),
+        "#78: float fixture failed to compile.\n--- stderr ---\n{}\n--- generated source ---\n{}",
+        String::from_utf8_lossy(&build.stderr),
+        code
+    );
+    let run = Command::new(&bin).output().expect("run process");
+    assert!(
+        run.status.success(),
+        "#77/#78: float fixture FAILED AT RUNTIME (values truncated through the void* slot).\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+}

--- a/framec/tests/cpp_snapshots.rs
+++ b/framec/tests/cpp_snapshots.rs
@@ -117,3 +117,50 @@ fn issue69_self_member_lowering_compiles() {
         code
     );
 }
+
+/// RUNTIME gate for the C++ backend (#78) — compiles AND EXECUTES the
+/// `17_float_any_roundtrip` fixture. #77 (float literals stored as double
+/// in std::any; declared-type any_cast<float> reads throw bad_any_cast)
+/// compiled cleanly, so the -fsyntax-only gate (#60) blessed it; only
+/// execution catches the erased-type round-trip class. The fixture's main
+/// asserts the values and exits non-zero on any mismatch or uncaught cast.
+///
+/// Skipped (not failed) when no C++ compiler is on PATH.
+#[test]
+fn issue78_float_any_roundtrip_runs() {
+    use std::process::Command;
+    let cxx = match common::find_tool("g++")
+        .or_else(|| common::find_tool("clang++"))
+        .or_else(|| common::find_tool("c++"))
+    {
+        Some(p) => p,
+        None => {
+            eprintln!("#78 cpp runtime gate skipped: no C++ compiler on PATH");
+            return;
+        }
+    };
+    let code = compile_fixture("17_float_any_roundtrip", "cpp");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("17_float_any_roundtrip.cpp");
+    let bin = dir.path().join("rt");
+    std::fs::write(&src, &code).expect("write tempfile");
+    let build = Command::new(&cxx)
+        .args(["-std=c++17", "-o"])
+        .arg(&bin)
+        .arg(&src)
+        .output()
+        .expect("c++ process");
+    assert!(
+        build.status.success(),
+        "#78: float-any fixture failed to compile.\n--- stderr ---\n{}\n--- generated source ---\n{}",
+        String::from_utf8_lossy(&build.stderr),
+        code
+    );
+    let run = Command::new(&bin).output().expect("run process");
+    assert!(
+        run.status.success(),
+        "#77/#78: float-any fixture FAILED AT RUNTIME (the class -fsyntax-only cannot catch).\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+}

--- a/framec/tests/fixtures/c/17_float_roundtrip.frm
+++ b/framec/tests/fixtures/c/17_float_roundtrip.frm
@@ -1,0 +1,43 @@
+// Runtime gate fixture for the C target (#77/#78) — float state-vars through
+// the void* slot, executed (not just compiled).
+//
+// The C state-var path stored floats via `(void*)(intptr_t)` (truncating)
+// and read them back as `(int)(intptr_t)` — values silently corrupted at
+// RUNTIME while compiling cleanly. Now packed/unpacked via the c_marshal
+// bit-pun pair, symmetric with interface returns (#72). This fixture
+// asserts the round-tripped values, covering the state-var initializer
+// (whole-number trap `0.0`), read-modify-write, and a float literal return.
+
+#include <stdio.h>
+#include <stdlib.h>
+
+@@[main]
+@@system Roundtrip {
+    interface:
+        bump()
+        peek(): float
+        radius(): float
+    machine:
+        $S {
+            $.cool: float = 0.0
+
+            bump() { $.cool = $.cool + 1.5 }
+            peek(): float { @@:($.cool) }
+            radius(): float { @@:(32.0) }
+        }
+    domain:
+        r: float = 1.0
+}
+
+int main() {
+    Roundtrip* p = @@Roundtrip();
+    Roundtrip_bump(p);
+    Roundtrip_bump(p);
+    double got = Roundtrip_peek(p);
+    if (got != 3.0) { printf("FAIL peek: %f\n", got); return 1; }
+    double rad = Roundtrip_radius(p);
+    if (rad != 32.0) { printf("FAIL radius: %f\n", rad); return 1; }
+    printf("PASS: 17_float_roundtrip\n");
+    Roundtrip_destroy(p);
+    return 0;
+}

--- a/framec/tests/fixtures/cpp/17_float_any_roundtrip.frm
+++ b/framec/tests/fixtures/cpp/17_float_any_roundtrip.frm
@@ -1,0 +1,42 @@
+// Runtime gate fixture for the C++ target (#77/#78) — float values through
+// the std::any erasure layer, executed (not just compiled).
+//
+// #77's class: a bare literal deduces to double, the declared-type
+// `std::any_cast<float>` read then throws std::bad_any_cast at RUNTIME while
+// compiling cleanly — which is why the -fsyntax-only gate (#60) missed it.
+// This fixture exercises both filed manifestations: a float state-var
+// initializer (whole-number trap `0.0`) with read-modify-write, and a
+// float-returning handler with a literal return (`32.0`).
+
+#include <iostream>
+#include <cstdlib>
+
+@@[main]
+@@system Roundtrip {
+    interface:
+        bump()
+        peek(): float
+        radius(): float
+    machine:
+        $S {
+            $.cool: float = 0.0
+
+            bump() { $.cool = $.cool + 1.5 }
+            peek(): float { @@:($.cool) }
+            radius(): float { @@:(32.0) }
+        }
+    domain:
+        r: float = 1.0
+}
+
+int main() {
+    auto p = @@Roundtrip();
+    p.bump();
+    p.bump();
+    float got = p.peek();
+    if (got != 3.0f) { std::cout << "FAIL peek: " << got << "\n"; return 1; }
+    float rad = p.radius();
+    if (rad != 32.0f) { std::cout << "FAIL radius: " << rad << "\n"; return 1; }
+    std::cout << "PASS: 17_float_any_roundtrip\n";
+    return 0;
+}


### PR DESCRIPTION
The systematic treatment #77 asked for ("rather than another one-off fix") — third sighting of the typed-erasure round-trip class (#59 Rust literals, #72 C void*, #77 C++ std::any).

## The audit
Confirmed the class on **all six** OO-erased targets: with a `float`-declared slot, a bare literal stores at the default float width (double/Double/float64) and the declared-type exact-match read crashes at runtime (`bad_any_cast` / `InvalidCastException` / `ClassCastException` / `as!` trap / interface panic) — while compiling cleanly. Plus the C state-var path silently truncating through `(void*)(intptr_t)`.

## The discipline (one source of truth)
**Every write into an erased slot coerces to the declared type; reads stay exact.** New `erased_write_coercion` helper applied at all chokepoints (SV init ×6 emitters, SV assign, `@@:return =` / `@@:(expr)`, return-init); C's SV path routed through `c_marshal` pack/unpack (both read sites — including the duplicate in expression.rs).

## #78 — runtime gates
The class compiles cleanly, so `-fsyntax-only` (#60) blessed it. New gates **execute** the generated binaries: in-repo `17_float_any_roundtrip` (cpp) + `17_float_roundtrip` (c) fixtures with asserting drivers; companion test-env PR #15 adds executing matrix fixtures for csharp/java/kotlin/swift/go.

## Validation
cpp/c/java probes run clean locally · 30 test binaries 0 failures (incl. both runtime gates) · clippy `-D warnings` · fmt · per-target matrices each +1 green (csharp 326, java 325, kotlin 330, swift 320, go 314) · **full matrix 17/17**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)