### PR TITLE
Coerce the @@:return(expr) early-return path (#77 reopen)

### DIFF
--- a/framec/src/frame_c/compiler/codegen/frame_expansion/return_stmt.rs
+++ b/framec/src/frame_c/compiler/codegen/frame_expansion/return_stmt.rs
@@ -91,6 +91,18 @@ pub(super) fn expand_return_call(
         &expr_owned
     };
     let expanded_expr = paren_wrap_if_multiline(&expand_expression(expr, lang, ctx));
+    // #77 (reopen): coerce to the DECLARED return type before the value
+    // enters the erased `_return` slot — this early-return form was the one
+    // write path missed by the original sweep (`@@:return = expr` and
+    // `@@:(expr)` were covered; `@@:return(expr)` was not, so a float
+    // literal here still stored a double and the wrapper's exact-match read
+    // crashed). No-op for non-float-family declarations and non-erased
+    // targets; C marshals via c_return_assign below.
+    let expanded_expr = super::super::codegen_utils::erased_write_coercion(
+        lang,
+        ctx.current_return_type.as_deref().unwrap_or(""),
+        &expanded_expr,
+    );
 
     // Standalone @@ constructs include indent_str on all lines.
     let set_code = match lang {

--- a/framec/tests/fixtures/c/17_float_roundtrip.frm
+++ b/framec/tests/fixtures/c/17_float_roundtrip.frm
@@ -17,6 +17,7 @@
         bump()
         peek(): float
         radius(): float
+        early(): float
     machine:
         $S {
             $.cool: float = 0.0
@@ -24,6 +25,7 @@
             bump() { $.cool = $.cool + 1.5 }
             peek(): float { @@:($.cool) }
             radius(): float { @@:(32.0) }
+            early(): float { @@:return(18.0) }
         }
     domain:
         r: float = 1.0
@@ -37,6 +39,8 @@ int main() {
     if (got != 3.0) { printf("FAIL peek: %f\n", got); return 1; }
     double rad = Roundtrip_radius(p);
     if (rad != 32.0) { printf("FAIL radius: %f\n", rad); return 1; }
+    double er = Roundtrip_early(p);
+    if (er != 18.0) { printf("FAIL early: %f\n", er); return 1; }
     printf("PASS: 17_float_roundtrip\n");
     Roundtrip_destroy(p);
     return 0;

--- a/framec/tests/fixtures/cpp/17_float_any_roundtrip.frm
+++ b/framec/tests/fixtures/cpp/17_float_any_roundtrip.frm
@@ -17,6 +17,7 @@
         bump()
         peek(): float
         radius(): float
+        early(): float
     machine:
         $S {
             $.cool: float = 0.0
@@ -24,6 +25,7 @@
             bump() { $.cool = $.cool + 1.5 }
             peek(): float { @@:($.cool) }
             radius(): float { @@:(32.0) }
+            early(): float { @@:return(18.0) }
         }
     domain:
         r: float = 1.0
@@ -37,6 +39,8 @@ int main() {
     if (got != 3.0f) { std::cout << "FAIL peek: " << got << "\n"; return 1; }
     float rad = p.radius();
     if (rad != 32.0f) { std::cout << "FAIL radius: " << rad << "\n"; return 1; }
+    float er = p.early();
+    if (er != 18.0f) { std::cout << "FAIL early: " << er << "\n"; return 1; }
     std::cout << "PASS: 17_float_any_roundtrip\n";
     return 0;
 }


### PR DESCRIPTION
The one write path the #77 sweep missed: `@@:return(expr)` (expand_return_call). Same `erased_write_coercion` applied; runtime gates extended so all three return forms are executed per target. Reopen's minimal repro runs PASS; all 6 erased matrices + full matrix 17/17 green. Closes #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)