### PR TITLE
fix(c): heap-box doubles through void* slots — pointer-width safe (#81)

### DIFF
--- a/framec/src/frame_c/compiler/codegen/c_marshal.rs
+++ b/framec/src/frame_c/compiler/codegen/c_marshal.rs
@@ -14,7 +14,8 @@
 //!
 //! | Category | write (pack)                          | read (unpack)              |
 //! |----------|---------------------------------------|----------------------------|
-//! | `Dbl`    | `Sys_pack_double(v)` (bit-pun)        | `Sys_unpack_double(p)`     |
+//! | `Dbl`    | `Sys_pack_double(v)` (**heap box**)   | `Sys_unpack_double(p)`     |
+//! |          |                                       | (NULL-safe deref)          |
 //! | `Int`    | `(void*)(intptr_t)(v)`                | `(T)(intptr_t)p`           |
 //! | `Str`    | `(void*)(intptr_t)(v)` (ptr fits)     | `(const char*)p`           |
 //! | `Ptr`    | `(void*)(intptr_t)(v)` (ptr fits)     | `(T)p`                     |
@@ -43,9 +44,27 @@
 //!   A mid-handler `@@:return` read deref-copies WITHOUT freeing (the
 //!   context is still live).
 //!
+//! ## Dbl ownership contract (#81)
+//!
+//! `Dbl` used to bit-pun the double into the pointer itself, which silently
+//! corrupts on 32-bit pointer targets (wasm32). It now travels as a real
+//! heap box (`pack_double` mallocs an 8-byte cell; `unpack_double` is a
+//! NULL-safe deref), so it follows the same ownership shape as `Boxed`:
+//!
+//! - **Params**: the interface wrapper stack-boxes (`double __box_p = p;`
+//!   push `&__box_p`) — zero allocations, locals outlive the synchronous
+//!   dispatch.
+//! - **Returns**: each `_return` write frees any previous box, then
+//!   heap-boxes; the interface wrapper frees after its final read.
+//! - **Containers** (state-vars, state-args): stored via the runtime's
+//!   owned-entry APIs (`FrameDict_set_owned` / `FrameVec_push_owned`) —
+//!   the container frees on overwrite/destroy and deep-copies on
+//!   compartment copy.
+//!
 //! State-args / enter-args / exit-args keep their historical `intptr_t`
-//! fallback: the transition push sites are a separate surface and struct
-//! state-args have never been supported on C (tracked as follow-up in #72).
+//! fallback for NON-Dbl unknowns: the transition push sites are a separate
+//! surface and struct state-args have never been supported on C (tracked
+//! as follow-up in #72).
 
 /// How a declared type travels through the C runtime's `void*` slots.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -86,7 +105,12 @@ pub(crate) fn c_marshal_of(type_str: &str) -> CMarshal {
 /// returns heap-box (freeing any previous box — see module docs).
 pub(crate) fn c_return_write(sys: &str, slot: &str, expr: &str, type_str: &str) -> String {
     match c_marshal_of(type_str) {
-        CMarshal::Dbl => format!("{slot} = {sys}_pack_double({expr});"),
+        // pack_double heap-boxes (#81) — free any previous box first,
+        // mirroring the Boxed arm. Only Dbl writes can have written the
+        // slot for a Dbl-returning method, so the free is type-safe.
+        CMarshal::Dbl => {
+            format!("{{ if ({slot}) free({slot}); {slot} = {sys}_pack_double({expr}); }}")
+        }
         CMarshal::Boxed => format!(
             "{{ {t}* __rbox = ({t}*)malloc(sizeof(*__rbox)); *__rbox = ({expr}); \
              if ({slot}) free({slot}); {slot} = __rbox; }}",
@@ -149,6 +173,9 @@ mod tests {
         let w = c_return_write("Demo", "SLOT", "2.5", "float");
         let r = c_return_read("Demo", "SLOT", "float");
         assert!(w.contains("Demo_pack_double(2.5)"), "{w}");
+        // #81: pack_double heap-boxes, so the write must free any
+        // previous box (repeated @@:return writes in one dispatch).
+        assert!(w.contains("if (SLOT) free(SLOT);"), "{w}");
         assert!(r.contains("Demo_unpack_double(SLOT)"), "{r}");
     }
 

--- a/framec/src/frame_c/compiler/codegen/codegen_utils.rs
+++ b/framec/src/frame_c/compiler/codegen/codegen_utils.rs
@@ -61,6 +61,17 @@ pub(crate) struct HandlerContext {
     /// typed-language per-handler emit so the prefetch cast/declaration
     /// matches the declared type instead of defaulting to `int`.
     pub state_param_types: std::collections::HashMap<(String, String), String>,
+    /// (state_name, param_name) → declared type of the state's `$>` enter
+    /// handler params. Used by the C transition codegen (#81) to pack each
+    /// enter arg per its declared marshal category (float/double heap-box
+    /// via pack_double, pushed owned). Empty on backends that don't need
+    /// write-side categorization (erased containers carry the type).
+    pub state_enter_param_types: std::collections::HashMap<(String, String), String>,
+    /// (state_name, param_name) → declared type of the state's `<$` exit
+    /// handler params. C transition codegen write-side mirror of
+    /// `state_enter_param_types` (#81); keyed by the transition's SOURCE
+    /// state (the one being exited).
+    pub state_exit_param_types: std::collections::HashMap<(String, String), String>,
     /// Declared return type of the handler currently being expanded.
     /// Used by the C backend to branch on `float`/`double` when emitting
     /// `@@:(expr)` so doubles survive the `void*` return slot.

--- a/framec/src/frame_c/compiler/codegen/erlang_system.rs
+++ b/framec/src/frame_c/compiler/codegen/erlang_system.rs
@@ -649,6 +649,8 @@ pub(crate) fn generate_erlang_system(
                     state_hsm_parents: std::collections::HashMap::new(),
                     current_return_type: None,
                     state_param_types: std::collections::HashMap::new(),
+                    state_enter_param_types: std::collections::HashMap::new(),
+                    state_exit_param_types: std::collections::HashMap::new(),
                     domain_field_types: domain_field_types.clone(),
                     actions: std::collections::HashSet::new(),
                 };
@@ -942,6 +944,8 @@ pub(crate) fn generate_erlang_system(
                     state_hsm_parents: std::collections::HashMap::new(),
                     current_return_type: None,
                     state_param_types: std::collections::HashMap::new(),
+                    state_enter_param_types: std::collections::HashMap::new(),
+                    state_exit_param_types: std::collections::HashMap::new(),
                     domain_field_types: domain_field_types.clone(),
                     actions: std::collections::HashSet::new(),
                 };
@@ -1525,6 +1529,8 @@ pub(crate) fn generate_erlang_system(
                     state_hsm_parents: std::collections::HashMap::new(),
                     current_return_type: None,
                     state_param_types: std::collections::HashMap::new(),
+                    state_enter_param_types: std::collections::HashMap::new(),
+                    state_exit_param_types: std::collections::HashMap::new(),
                     domain_field_types: domain_field_types.clone(),
                     actions: std::collections::HashSet::new(),
                 };
@@ -1605,6 +1611,8 @@ pub(crate) fn generate_erlang_system(
                     state_hsm_parents: std::collections::HashMap::new(),
                     current_return_type: None,
                     state_param_types: std::collections::HashMap::new(),
+                    state_enter_param_types: std::collections::HashMap::new(),
+                    state_exit_param_types: std::collections::HashMap::new(),
                     domain_field_types: domain_field_types.clone(),
                     actions: std::collections::HashSet::new(),
                 };
@@ -1703,6 +1711,8 @@ pub(crate) fn generate_erlang_system(
                     state_hsm_parents: std::collections::HashMap::new(),
                     current_return_type: None,
                     state_param_types: std::collections::HashMap::new(),
+                    state_enter_param_types: std::collections::HashMap::new(),
+                    state_exit_param_types: std::collections::HashMap::new(),
                     domain_field_types: domain_field_types.clone(),
                     actions: std::collections::HashSet::new(),
                 };

--- a/framec/src/frame_c/compiler/codegen/frame_expansion.rs
+++ b/framec/src/frame_c/compiler/codegen/frame_expansion.rs
@@ -174,6 +174,8 @@ mod tests {
             state_hsm_parents: std::collections::HashMap::new(),
             current_return_type: None,
             state_param_types: std::collections::HashMap::new(),
+            state_enter_param_types: std::collections::HashMap::new(),
+            state_exit_param_types: std::collections::HashMap::new(),
             domain_field_types: std::collections::HashMap::new(),
             actions: std::collections::HashSet::new(),
         }

--- a/framec/src/frame_c/compiler/codegen/frame_expansion/pop_transition.rs
+++ b/framec/src/frame_c/compiler/codegen/frame_expansion/pop_transition.rs
@@ -232,6 +232,13 @@ pub(super) fn generate_pop_transition(
                 }
                 TargetLanguage::Rust => {}
                 TargetLanguage::C => {
+                    // The popped target state is runtime-determined, so the
+                    // declared enter-param type is statically unknowable —
+                    // this push keeps the historical intptr_t fallback.
+                    // Float/double pop-args are therefore UNSUPPORTED on C
+                    // (the typed read would deref a non-box, #81): tracked
+                    // as a follow-up; do not silently route through
+                    // pack_double here without a type to key on.
                     code.push_str(&format!(
                         "{}{}_FrameVec_push(__saved->enter_args, (void*)(intptr_t)({}));\n",
                         indent, ctx.system_name, value

--- a/framec/src/frame_c/compiler/codegen/frame_expansion/state_var.rs
+++ b/framec/src/frame_c/compiler/codegen/frame_expansion/state_var.rs
@@ -378,7 +378,7 @@ pub(super) fn expand_state_var_assign(
     // default float width (double/Double/float64) and the declared-type
     // exact-match read then crashes at runtime. No-op for non-float
     // declarations and for non-erased targets. (C is handled in its own
-    // arm below — it bit-puns via pack_double, there is no typed box.)
+    // arm below — it heap-boxes a double via pack_double, #81.)
     let declared = ctx
         .state_var_types
         .get(var_name)
@@ -492,33 +492,39 @@ pub(super) fn expand_state_var_assign(
             &expanded_expr,
         ),
         TargetLanguage::C => {
-            // Category-aware pack via c_marshal (#77): float/double
-            // state-vars bit-pun through the void* slot via pack_double —
-            // `(void*)(intptr_t)` truncates them. The matching read-side
-            // unpack lives in `expand_state_var` above.
-            let packed = {
+            // Category-aware pack via c_marshal (#77, #81): float/double
+            // state-vars heap-box via pack_double — `(void*)(intptr_t)`
+            // truncates them, and bit-punning corrupts on 32-bit pointers.
+            // The box is stored OWNED so the dict frees it on overwrite
+            // and destroy, and deep-copies it on compartment copy. The
+            // matching read-side unpack lives in `expand_state_var` above.
+            let (packed, setter) = {
                 use super::super::c_marshal::{c_marshal_of, CMarshal};
                 match c_marshal_of(declared) {
-                    CMarshal::Dbl => {
-                        format!("{}_pack_double({})", ctx.system_name, expanded_expr)
-                    }
-                    _ => format!("(void*)(intptr_t)({})", expanded_expr),
+                    CMarshal::Dbl => (
+                        format!("{}_pack_double({})", ctx.system_name, expanded_expr),
+                        "FrameDict_set_owned",
+                    ),
+                    _ => (
+                        format!("(void*)(intptr_t)({})", expanded_expr),
+                        "FrameDict_set",
+                    ),
                 }
             };
             if ctx.per_handler {
                 format!(
-                    "{}{}_FrameDict_set(compartment->state_vars, \"{}\", {});",
-                    indent_str, ctx.system_name, var_name, packed
+                    "{}{}_{}(compartment->state_vars, \"{}\", {});",
+                    indent_str, ctx.system_name, setter, var_name, packed
                 )
             } else if ctx.use_sv_comp {
                 format!(
-                    "{}{}_FrameDict_set(__sv_comp->state_vars, \"{}\", {});",
-                    indent_str, ctx.system_name, var_name, packed
+                    "{}{}_{}(__sv_comp->state_vars, \"{}\", {});",
+                    indent_str, ctx.system_name, setter, var_name, packed
                 )
             } else {
                 format!(
-                    "{}{}_FrameDict_set(self->__compartment->state_vars, \"{}\", {});",
-                    indent_str, ctx.system_name, var_name, packed
+                    "{}{}_{}(self->__compartment->state_vars, \"{}\", {});",
+                    indent_str, ctx.system_name, setter, var_name, packed
                 )
             }
         }

--- a/framec/src/frame_c/compiler/codegen/frame_expansion/transition.rs
+++ b/framec/src/frame_c/compiler/codegen/frame_expansion/transition.rs
@@ -690,7 +690,39 @@ pub(super) fn expand_transition(
                 let mut code = String::new();
                 let sys = &ctx.system_name;
 
-                // exit_args via __prepareExit if any provided.
+                // Positional push of a handler arg, packed per its declared
+                // marshal category (#81): float/double heap-box via
+                // pack_double and push OWNED (the vec frees/deep-copies the
+                // box — `(void*)(intptr_t)` truncates, and the handler-side
+                // read derefs); everything else keeps the historical
+                // intptr_t fallback (struct args unsupported on C, #72).
+                // `types` is the (state, param_name) → declared-type map for
+                // the slot family; `names` gives the positional param names.
+                let push_typed = |idx: usize,
+                                  value_expr: &str,
+                                  state: &str,
+                                  names: &[String],
+                                  types: &std::collections::HashMap<(String, String), String>|
+                 -> (String, &'static str) {
+                    use super::super::c_marshal::{c_marshal_of, CMarshal};
+                    let frame_type = names
+                        .get(idx)
+                        .and_then(|name| types.get(&(state.to_string(), name.clone())).cloned())
+                        .unwrap_or_default();
+                    match c_marshal_of(&frame_type) {
+                        CMarshal::Dbl => (
+                            format!("{}_pack_double({})", sys, value_expr),
+                            "FrameVec_push_owned",
+                        ),
+                        _ => (
+                            format!("(void*)(intptr_t)({})", value_expr),
+                            "FrameVec_push",
+                        ),
+                    }
+                };
+
+                // exit_args via __prepareExit if any provided. Declared
+                // types come from the SOURCE state's `<$` params.
                 if let Some(ref exit) = exit_str {
                     let vals: Vec<&str> = exit
                         .split(',')
@@ -698,14 +730,26 @@ pub(super) fn expand_transition(
                         .filter(|x| !x.is_empty())
                         .collect();
                     if !vals.is_empty() {
+                        let exit_names: Vec<String> = ctx
+                            .state_exit_param_names
+                            .get(&ctx.state_name)
+                            .cloned()
+                            .unwrap_or_default();
                         code.push_str(&format!(
                             "{}{{ {}_FrameVec* __ea = {}_FrameVec_new();\n",
                             indent_str, sys, sys
                         ));
-                        for v in &vals {
+                        for (i, v) in vals.iter().enumerate() {
+                            let (arg, push_fn) = push_typed(
+                                i,
+                                v,
+                                &ctx.state_name,
+                                &exit_names,
+                                &ctx.state_exit_param_types,
+                            );
                             code.push_str(&format!(
-                                "{}{}_FrameVec_push(__ea, (void*)(intptr_t)({}));\n",
-                                indent_str, sys, v
+                                "{}{}_{}(__ea, {});\n",
+                                indent_str, sys, push_fn, arg
                             ));
                         }
                         code.push_str(&format!("{}{}_prepareExit(self, __ea);\n", indent_str, sys));
@@ -749,29 +793,20 @@ pub(super) fn expand_transition(
                 // separate `if` branches).
                 // Look up target's state-arg names so each value
                 // can be packed using its declared type. Float /
-                // double survive only via the memcpy bit-pun
-                // helper `Sys_pack_double`; (intptr_t) truncates.
+                // double heap-box via `Sys_pack_double` (#81 —
+                // (intptr_t) truncates; bit-punning corrupts on
+                // 32-bit pointers) and push OWNED so the vec
+                // frees/deep-copies the box.
                 let target_param_names: Vec<String> = ctx
                     .state_param_names
                     .get(&target)
                     .cloned()
                     .unwrap_or_default();
-                let push_arg_for_target = |idx: usize, value_expr: &str| -> String {
-                    let frame_type = target_param_names
-                        .get(idx)
-                        .and_then(|name| {
-                            ctx.state_param_types
-                                .get(&(target.clone(), name.clone()))
-                                .cloned()
-                        })
-                        .unwrap_or_default();
-                    match frame_type.trim() {
-                        "float" | "double" | "f32" | "f64" => {
-                            format!("{}_pack_double({})", sys, value_expr)
-                        }
-                        _ => format!("(void*)(intptr_t)({})", value_expr),
-                    }
-                };
+                let target_enter_param_names: Vec<String> = ctx
+                    .state_enter_param_names
+                    .get(&target)
+                    .cloned()
+                    .unwrap_or_default();
                 code.push_str(&format!("{}{{\n", indent_str));
                 if state_vals.is_empty() {
                     code.push_str(&format!(
@@ -784,10 +819,11 @@ pub(super) fn expand_transition(
                         indent_str, sys, sys
                     ));
                     for (i, v) in state_vals.iter().enumerate() {
-                        let push_arg = push_arg_for_target(i, v);
+                        let (push_arg, push_fn) =
+                            push_typed(i, v, &target, &target_param_names, &ctx.state_param_types);
                         code.push_str(&format!(
-                            "{}    {}_FrameVec_push(__sa, {});\n",
-                            indent_str, sys, push_arg
+                            "{}    {}_{}(__sa, {});\n",
+                            indent_str, sys, push_fn, push_arg
                         ));
                     }
                 }
@@ -801,10 +837,19 @@ pub(super) fn expand_transition(
                         "{}    {}_FrameVec* __ea = {}_FrameVec_new();\n",
                         indent_str, sys, sys
                     ));
-                    for v in &enter_vals {
+                    // Enter args: declared types come from the TARGET
+                    // state's `$>` params.
+                    for (i, v) in enter_vals.iter().enumerate() {
+                        let (push_arg, push_fn) = push_typed(
+                            i,
+                            v,
+                            &target,
+                            &target_enter_param_names,
+                            &ctx.state_enter_param_types,
+                        );
                         code.push_str(&format!(
-                            "{}    {}_FrameVec_push(__ea, (void*)(intptr_t)({}));\n",
-                            indent_str, sys, v
+                            "{}    {}_{}(__ea, {});\n",
+                            indent_str, sys, push_fn, push_arg
                         ));
                     }
                 }

--- a/framec/src/frame_c/compiler/codegen/frame_expansion/utility.rs
+++ b/framec/src/frame_c/compiler/codegen/frame_expansion/utility.rs
@@ -25,10 +25,11 @@
 /// C `_return` assignment with category-aware marshalling.
 ///
 /// The `_return` slot is `void*`. Marshalling routes through
-/// `c_marshal::c_return_write` (#72) — the single categorization shared
-/// with every read site, so pack and unpack cannot drift: ints/bools/
-/// pointers via `(void*)(intptr_t)`, floats/doubles via the `pack_double`
-/// memcpy helper (`(intptr_t)(42.0)` truncates), structs via a heap box.
+/// `c_marshal::c_return_write` (#72, #81) — the single categorization
+/// shared with every read site, so pack and unpack cannot drift: ints/
+/// bools/pointers via `(void*)(intptr_t)`, floats/doubles AND structs via
+/// a heap box (`(intptr_t)(42.0)` truncates; the old double bit-pun
+/// overflowed 32-bit pointers).
 pub(super) fn c_return_assign(
     system_name: &str,
     expanded_expr: &str,

--- a/framec/src/frame_c/compiler/codegen/interface_gen.rs
+++ b/framec/src/frame_c/compiler/codegen/interface_gen.rs
@@ -341,12 +341,12 @@ finally:
                 let sys = &system.name;
 
                 // Build parameters dict creation (with semicolon).
-                // Marshalling per `c_marshal_of` (#72): float/double params
-                // route through `Sys_pack_double` (memcpy bit-pun —
-                // `(void*)(intptr_t)(0.5)` truncates); struct-by-value
-                // params travel as the address of a STACK box (the kernel
-                // dispatch is synchronous, so the wrapper's locals outlive
-                // every reader; see c_marshal.rs § Boxed ownership).
+                // Marshalling per `c_marshal_of` (#72, #81): float/double
+                // and struct-by-value params travel as the address of a
+                // STACK box (the kernel dispatch is synchronous, so the
+                // wrapper's locals outlive every reader; see c_marshal.rs
+                // § ownership). Doubles never heap-allocate on the param
+                // path and never bit-pun into the pointer (wasm32-unsafe).
                 let params_code = if method.params.is_empty() {
                     format!("{}_FrameEvent* __e = {}_FrameEvent_new(\"{}\", NULL, 0);", sys, sys, method.name)
                 } else {
@@ -355,7 +355,11 @@ finally:
                         let p_type = type_to_string(&p.param_type);
                         let push_arg = match super::c_marshal::c_marshal_of(&p_type) {
                             super::c_marshal::CMarshal::Dbl => {
-                                format!("{}_pack_double({})", sys, p.name)
+                                code.push_str(&format!(
+                                    "double __box_{} = {};\n",
+                                    p.name, p.name
+                                ));
+                                format!("(void*)&__box_{}", p.name)
                             }
                             super::c_marshal::CMarshal::Boxed => {
                                 code.push_str(&format!(
@@ -394,9 +398,9 @@ finally:
                     .unwrap_or(false);
 
                 // Set default return value after context creation —
-                // marshalled per `c_return_write` (#72): doubles pack via
-                // the memcpy helper (`(void*)(intptr_t)(3.14)` truncates),
-                // structs heap-box.
+                // marshalled per `c_return_write` (#72, #81): doubles and
+                // structs heap-box (`(void*)(intptr_t)(3.14)` truncates;
+                // bit-punning corrupts on 32-bit pointers).
                 let default_init = if let Some(ref init_expr) = method.return_init {
                     let ty = return_type_str.as_deref().unwrap_or("int");
                     format!(
@@ -412,7 +416,8 @@ finally:
                     // is shared with the write side (c_return_assign /
                     // c_marshal) so pack and unpack cannot drift apart:
                     //   bool/int  → `(T)(intptr_t)…`
-                    //   float/dbl → `Sys_unpack_double(…)` (memcpy round-trip)
+                    //   float/dbl → `Sys_unpack_double(…)` (NULL-safe heap-
+                    //               box deref, #81), then free the box
                     //   str/ptr   → `(T)…` (pointer already fits)
                     //   struct    → `*(T*)…` deref-copy, then free the box
                     let extract = super::c_marshal::c_return_read(
@@ -420,14 +425,15 @@ finally:
                         "__result_ctx->_return",
                         &return_type_str,
                     );
-                    // Boxed returns: free the heap box after the deref-copy
-                    // (the single owner-free; see c_marshal.rs). Guard the
-                    // deref against a never-written NULL slot.
-                    let is_boxed = matches!(
+                    // Boxed AND Dbl returns are heap boxes (#72, #81): free
+                    // after the final read (the single owner-free; see
+                    // c_marshal.rs). Guard against a never-written NULL slot
+                    // — memset-zero gives 0/+0.0 for the unwritten case.
+                    let owns_return = matches!(
                         super::c_marshal::c_marshal_of(&return_type_str),
-                        super::c_marshal::CMarshal::Boxed
+                        super::c_marshal::CMarshal::Boxed | super::c_marshal::CMarshal::Dbl
                     );
-                    let result_decl = if is_boxed {
+                    let result_decl = if owns_return {
                         format!(
                             "{t} __result; memset(&__result, 0, sizeof(__result));\nif (__result_ctx->_return) {{ __result = {extract}; free(__result_ctx->_return); }}",
                             t = return_type_str, extract = extract

--- a/framec/src/frame_c/compiler/codegen/interface_gen/persist/c.rs
+++ b/framec/src/frame_c/compiler/codegen/interface_gen/persist/c.rs
@@ -94,6 +94,28 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
                 .collect()
         })
         .unwrap_or_default();
+    // (state_name, [(var_name, declared_type)]) for `$.var` declarations —
+    // state_vars round-trip through the same typed persist_pack/_unpack
+    // dispatch as state_args (#81: the old generic dict walk int-punned
+    // every entry, which serialized a heap-box POINTER for doubles and a
+    // char* for strings; only ints ever round-tripped).
+    let state_var_types: Vec<(String, Vec<(String, String)>)> = system
+        .machine
+        .as_ref()
+        .map(|m| {
+            m.states
+                .iter()
+                .map(|s| {
+                    let vars: Vec<(String, String)> = s
+                        .state_vars
+                        .iter()
+                        .map(|v| (v.name.clone(), type_to_string(&v.var_type)))
+                        .collect();
+                    (s.name.clone(), vars)
+                })
+                .collect()
+        })
+        .unwrap_or_default();
     let c_mangle_type = |t: &str| -> String {
         let t = t.trim();
         let canonical = match t {
@@ -141,17 +163,30 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
         "    {}_FrameDict* sv = comp->state_vars;\n",
         system.name
     ));
+    // Typed per-state packing (#81): each declared `$.var` routes through
+    // persist_pack_<type> — the generic dict walk that int-punned every
+    // entry serialized a heap-box pointer for doubles. Only vars present
+    // in the dict are written, preserving restore-skips-init fidelity.
     serialize_helper.push_str("    if (sv) {\n");
-    serialize_helper.push_str("        for (int i = 0; i < sv->bucket_count; i++) {\n");
-    serialize_helper.push_str(&format!(
-        "            {}_FrameDictEntry* entry = sv->buckets[i];\n",
-        system.name
-    ));
-    serialize_helper.push_str("            while (entry) {\n");
-    serialize_helper.push_str("                cJSON_AddNumberToObject(vars, entry->key, (double)(intptr_t)entry->value);\n");
-    serialize_helper.push_str("                entry = entry->next;\n");
-    serialize_helper.push_str("            }\n");
-    serialize_helper.push_str("        }\n");
+    for (state_name, vars) in &state_var_types {
+        if vars.is_empty() {
+            continue;
+        }
+        serialize_helper.push_str(&format!(
+            "        if (strcmp(comp->state, \"{}\") == 0) {{\n",
+            state_name
+        ));
+        for (var_name, t) in vars {
+            let val_expr = format!("{}_FrameDict_get(sv, \"{}\")", system.name, var_name);
+            serialize_helper.push_str(&format!(
+                "            if ({sys}_FrameDict_has(sv, \"{name}\")) cJSON_AddItemToObject(vars, \"{name}\", {pack});\n",
+                sys = system.name,
+                name = var_name,
+                pack = c_pack_for(t, &val_expr, &system.name)
+            ));
+        }
+        serialize_helper.push_str("        }\n");
+    }
     serialize_helper.push_str("    }\n");
     serialize_helper.push_str("    cJSON_AddItemToObject(obj, \"state_vars\", vars);\n");
     serialize_helper.push_str("    cJSON* sa = cJSON_CreateArray();\n");
@@ -211,15 +246,42 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
     deserialize_helper.push_str("    if (!data || cJSON_IsNull(data)) return NULL;\n");
     deserialize_helper.push_str("    cJSON* state_item = cJSON_GetObjectItem(data, \"state\");\n");
     deserialize_helper.push_str(&format!(
-        "    {}_Compartment* comp = {}_Compartment_new(strdup(state_item->valuestring));\n",
-        system.name, system.name
+        "    {}_Compartment* comp = {}_Compartment_new({}_strdup_(state_item->valuestring));\n",
+        system.name, system.name, system.name
     ));
     deserialize_helper.push_str("    cJSON* vars = cJSON_GetObjectItem(data, \"state_vars\");\n");
+    // Typed per-state restore mirroring the serialize side (#81). Doubles
+    // come back as heap boxes from persist_unpack_double and are stored
+    // OWNED so the dict frees/deep-copies them.
     deserialize_helper.push_str("    if (vars) {\n");
-    deserialize_helper.push_str("        cJSON* var_item;\n");
-    deserialize_helper.push_str("        cJSON_ArrayForEach(var_item, vars) {\n");
-    deserialize_helper.push_str(&format!("            {}_FrameDict_set(comp->state_vars, var_item->string, (void*)(intptr_t)(int)var_item->valuedouble);\n", system.name));
-    deserialize_helper.push_str("        }\n");
+    for (state_name, vars) in &state_var_types {
+        if vars.is_empty() {
+            continue;
+        }
+        deserialize_helper.push_str(&format!(
+            "        if (strcmp(comp->state, \"{}\") == 0) {{\n",
+            state_name
+        ));
+        for (var_name, t) in vars {
+            let setter = if c_mangle_type(t) == "double" {
+                "FrameDict_set_owned"
+            } else {
+                "FrameDict_set"
+            };
+            deserialize_helper.push_str(&format!(
+                "            cJSON* var_{name} = cJSON_GetObjectItem(vars, \"{name}\");\n",
+                name = var_name
+            ));
+            deserialize_helper.push_str(&format!(
+                "            if (var_{name}) {sys}_{setter}(comp->state_vars, \"{name}\", {unpack});\n",
+                sys = system.name,
+                setter = setter,
+                name = var_name,
+                unpack = c_unpack_for(t, &format!("var_{var_name}"), &system.name)
+            ));
+        }
+        deserialize_helper.push_str("        }\n");
+    }
     deserialize_helper.push_str("    }\n");
     deserialize_helper.push_str("    cJSON* sa = cJSON_GetObjectItem(data, \"state_args\");\n");
     deserialize_helper.push_str("    if (sa) {\n");
@@ -232,13 +294,20 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
             state_name
         ));
         for (i, t) in types.iter().enumerate() {
+            // Doubles come back as heap boxes — push OWNED (#81).
+            let push_fn = if c_mangle_type(t) == "double" {
+                "FrameVec_push_owned"
+            } else {
+                "FrameVec_push"
+            };
             deserialize_helper.push_str(&format!(
                 "            cJSON* sa_item_{i} = cJSON_GetArrayItem(sa, {i});\n"
             ));
             deserialize_helper.push_str(&format!(
-                "            if (sa_item_{i}) {sys}_FrameVec_push(comp->state_args, {unpack});\n",
+                "            if (sa_item_{i}) {sys}_{push_fn}(comp->state_args, {unpack});\n",
                 i = i,
                 sys = system.name,
+                push_fn = push_fn,
                 unpack = c_unpack_for(t, &format!("sa_item_{i}"), &system.name)
             ));
         }
@@ -256,13 +325,20 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
             state_name
         ));
         for (i, t) in types.iter().enumerate() {
+            // Doubles come back as heap boxes — push OWNED (#81).
+            let push_fn = if c_mangle_type(t) == "double" {
+                "FrameVec_push_owned"
+            } else {
+                "FrameVec_push"
+            };
             deserialize_helper.push_str(&format!(
                 "            cJSON* ea_item_{i} = cJSON_GetArrayItem(ea, {i});\n"
             ));
             deserialize_helper.push_str(&format!(
-                "            if (ea_item_{i}) {sys}_FrameVec_push(comp->enter_args, {unpack});\n",
+                "            if (ea_item_{i}) {sys}_{push_fn}(comp->enter_args, {unpack});\n",
                 i = i,
                 sys = system.name,
+                push_fn = push_fn,
                 unpack = c_unpack_for(t, &format!("ea_item_{i}"), &system.name)
             ));
         }

--- a/framec/src/frame_c/compiler/codegen/machinery/c.rs
+++ b/framec/src/frame_c/compiler/codegen/machinery/c.rs
@@ -120,12 +120,10 @@ int n = {sys}_hsm_chain(self, leaf, &chain);
 {sys}_Compartment* comp = NULL;
 for (int i = 0; i < n; i++) {{
     {sys}_Compartment* nc = {sys}_Compartment_new(chain[i]);
-    if (state_args) {{
-        for (int j = 0; j < state_args->size; j++) {sys}_FrameVec_push(nc->state_args, state_args->items[j]);
-    }}
-    if (enter_args) {{
-        for (int j = 0; j < enter_args->size; j++) {sys}_FrameVec_push(nc->enter_args, enter_args->items[j]);
-    }}
+    // FrameVec_extend deep-copies vec-owned heap boxes (#81: doubles)
+    // so the caller can destroy its arg vecs after this returns.
+    {sys}_FrameVec_extend(nc->state_args, state_args);
+    {sys}_FrameVec_extend(nc->enter_args, enter_args);
     nc->parent_compartment = comp;  // adopts ref
     comp = nc;
 }}
@@ -151,11 +149,10 @@ return comp;"#,
                 code: format!(
                     r#"{sys}_Compartment* comp = self->__compartment;
 while (comp != NULL) {{
-    // Clear any prior exit_args before copying the new ones in.
-    while (comp->exit_args->size > 0) comp->exit_args->size--;
-    if (exit_args) {{
-        for (int j = 0; j < exit_args->size; j++) {sys}_FrameVec_push(comp->exit_args, exit_args->items[j]);
-    }}
+    // Clear any prior exit_args (freeing vec-owned boxes, #81) before
+    // copying the new ones in; extend deep-copies owned entries.
+    {sys}_FrameVec_clear(comp->exit_args);
+    {sys}_FrameVec_extend(comp->exit_args, exit_args);
     comp = comp->parent_compartment;
 }}"#,
                     sys = sys

--- a/framec/src/frame_c/compiler/codegen/runtime/c.rs
+++ b/framec/src/frame_c/compiler/codegen/runtime/c.rs
@@ -47,9 +47,22 @@ fn generate_c_runtime_types(system: &SystemAst) -> String {
         "// ============================================================================\n\n"
     ));
 
+    // strdup is POSIX, not ISO C — rejected under strict -std=c11 (e.g.
+    // emcc's default; #81). Emit a tiny static shim instead.
+    code.push_str(&format!("static char* {}_strdup_(const char* s) {{\n", sys));
+    code.push_str("    size_t n = strlen(s) + 1;\n");
+    code.push_str("    char* p = (char*)malloc(n);\n");
+    code.push_str("    memcpy(p, s, n);\n");
+    code.push_str("    return p;\n");
+    code.push_str("}\n\n");
+
     code.push_str(&format!("typedef struct {}_FrameDictEntry {{\n", sys));
     code.push_str("    char* key;\n");
     code.push_str("    void* value;\n");
+    code.push_str("    // 1 when `value` is a heap box this dict owns (a malloc'd\n");
+    code.push_str("    // double from pack_double — #81): freed on overwrite and in\n");
+    code.push_str("    // destroy, deep-copied by FrameDict_copy.\n");
+    code.push_str("    int owned;\n");
     code.push_str(&format!("    struct {}_FrameDictEntry* next;\n", sys));
     code.push_str(&format!("}} {}_FrameDictEntry;\n\n", sys));
 
@@ -90,9 +103,24 @@ fn generate_c_runtime_types(system: &SystemAst) -> String {
     code.push_str("    return d;\n");
     code.push_str("}\n\n");
 
-    // FrameDict_set
+    // FrameDict_set / FrameDict_set_owned. The `_owned` variant marks the
+    // value as a dict-owned heap box (#81: malloc'd doubles); owned values
+    // are freed when overwritten and in destroy, and deep-copied by
+    // FrameDict_copy. Plain set stores caller-owned/non-pointer values.
     code.push_str(&format!(
-        "static void {}_FrameDict_set({}_FrameDict* d, const char* key, void* value) {{\n",
+        "static void {}_FrameDict_set_({}_FrameDict* d, const char* key, void* value, int owned);\n",
+        sys, sys
+    ));
+    code.push_str(&format!(
+        "static void {}_FrameDict_set({}_FrameDict* d, const char* key, void* value) {{\n    {}_FrameDict_set_(d, key, value, 0);\n}}\n\n",
+        sys, sys, sys
+    ));
+    code.push_str(&format!(
+        "static void {}_FrameDict_set_owned({}_FrameDict* d, const char* key, void* value) {{\n    {}_FrameDict_set_(d, key, value, 1);\n}}\n\n",
+        sys, sys, sys
+    ));
+    code.push_str(&format!(
+        "static void {}_FrameDict_set_({}_FrameDict* d, const char* key, void* value, int owned) {{\n",
         sys, sys
     ));
     code.push_str(&format!(
@@ -105,7 +133,9 @@ fn generate_c_runtime_types(system: &SystemAst) -> String {
     ));
     code.push_str("    while (entry) {\n");
     code.push_str("        if (strcmp(entry->key, key) == 0) {\n");
+    code.push_str("            if (entry->owned && entry->value) free(entry->value);\n");
     code.push_str("            entry->value = value;\n");
+    code.push_str("            entry->owned = owned;\n");
     code.push_str("            return;\n");
     code.push_str("        }\n");
     code.push_str("        entry = entry->next;\n");
@@ -114,8 +144,9 @@ fn generate_c_runtime_types(system: &SystemAst) -> String {
         "    {}_FrameDictEntry* new_entry = malloc(sizeof({}_FrameDictEntry));\n",
         sys, sys
     ));
-    code.push_str("    new_entry->key = strdup(key);\n");
+    code.push_str(&format!("    new_entry->key = {}_strdup_(key);\n", sys));
     code.push_str("    new_entry->value = value;\n");
+    code.push_str("    new_entry->owned = owned;\n");
     code.push_str("    new_entry->next = d->buckets[idx];\n");
     code.push_str("    d->buckets[idx] = new_entry;\n");
     code.push_str("    d->size++;\n");
@@ -180,10 +211,22 @@ fn generate_c_runtime_types(system: &SystemAst) -> String {
         sys
     ));
     code.push_str("        while (entry) {\n");
+    code.push_str("            if (entry->owned && entry->value) {\n");
+    code.push_str("                // Owned values are heap-boxed doubles (#81): deep-copy\n");
+    code.push_str("                // so src and dst never alias (a shallow copy would\n");
+    code.push_str("                // dangle when either side frees on overwrite/destroy).\n");
+    code.push_str("                void* nb = malloc(sizeof(double));\n");
+    code.push_str("                memcpy(nb, entry->value, sizeof(double));\n");
     code.push_str(&format!(
-        "            {}_FrameDict_set(dst, entry->key, entry->value);\n",
+        "                {}_FrameDict_set_(dst, entry->key, nb, 1);\n",
         sys
     ));
+    code.push_str("            } else {\n");
+    code.push_str(&format!(
+        "                {}_FrameDict_set_(dst, entry->key, entry->value, 0);\n",
+        sys
+    ));
+    code.push_str("            }\n");
     code.push_str("            entry = entry->next;\n");
     code.push_str("        }\n");
     code.push_str("    }\n");
@@ -205,6 +248,7 @@ fn generate_c_runtime_types(system: &SystemAst) -> String {
         "            {}_FrameDictEntry* next = entry->next;\n",
         sys
     ));
+    code.push_str("            if (entry->owned && entry->value) free(entry->value);\n");
     code.push_str("            free(entry->key);\n");
     code.push_str("            free(entry);\n");
     code.push_str("            entry = next;\n");
@@ -227,6 +271,10 @@ fn generate_c_runtime_types(system: &SystemAst) -> String {
 
     code.push_str(&format!("typedef struct {{\n"));
     code.push_str("    void** items;\n");
+    code.push_str("    // owned[i] == 1 when items[i] is a heap box this vec owns (a\n");
+    code.push_str("    // malloc'd double from pack_double — #81): freed in destroy,\n");
+    code.push_str("    // deep-copied by FrameVec_copy.\n");
+    code.push_str("    unsigned char* owned;\n");
     code.push_str("    int size;\n");
     code.push_str("    int capacity;\n");
     code.push_str(&format!("}} {}_FrameVec;\n\n", sys));
@@ -243,19 +291,71 @@ fn generate_c_runtime_types(system: &SystemAst) -> String {
     code.push_str("    v->capacity = 8;\n");
     code.push_str("    v->size = 0;\n");
     code.push_str("    v->items = malloc(sizeof(void*) * v->capacity);\n");
+    code.push_str("    v->owned = calloc(v->capacity, 1);\n");
     code.push_str("    return v;\n");
     code.push_str("}\n\n");
 
-    // FrameVec_push
+    // FrameVec_push / FrameVec_push_owned. The `_owned` variant marks the
+    // item as a vec-owned heap box (#81: malloc'd doubles).
     code.push_str(&format!(
-        "static void {}_FrameVec_push({}_FrameVec* v, void* item) {{\n",
+        "static void {}_FrameVec_push_({}_FrameVec* v, void* item, unsigned char owned) {{\n",
         sys, sys
     ));
     code.push_str("    if (v->size >= v->capacity) {\n");
     code.push_str("        v->capacity *= 2;\n");
     code.push_str("        v->items = realloc(v->items, sizeof(void*) * v->capacity);\n");
+    code.push_str("        v->owned = realloc(v->owned, v->capacity);\n");
+    code.push_str("        memset(v->owned + v->size, 0, v->capacity - v->size);\n");
     code.push_str("    }\n");
+    code.push_str("    v->owned[v->size] = owned;\n");
     code.push_str("    v->items[v->size++] = item;\n");
+    code.push_str("}\n\n");
+    code.push_str(&format!(
+        "static void {}_FrameVec_push({}_FrameVec* v, void* item) {{\n    {}_FrameVec_push_(v, item, 0);\n}}\n\n",
+        sys, sys, sys
+    ));
+    code.push_str(&format!(
+        "static void {}_FrameVec_push_owned({}_FrameVec* v, void* item) {{\n    {}_FrameVec_push_(v, item, 1);\n}}\n\n",
+        sys, sys, sys
+    ));
+
+    // FrameVec_clear — empty the vec, freeing vec-owned heap boxes (#81).
+    // Storage is retained for reuse.
+    code.push_str(&format!(
+        "static void {}_FrameVec_clear({}_FrameVec* v) {{\n",
+        sys, sys
+    ));
+    code.push_str("    if (!v) return;\n");
+    code.push_str("    for (int i = 0; i < v->size; i++) {\n");
+    code.push_str("        if (v->owned[i] && v->items[i]) free(v->items[i]);\n");
+    code.push_str("    }\n");
+    code.push_str("    v->size = 0;\n");
+    code.push_str("}\n\n");
+
+    // FrameVec_extend — append all of src into dst, deep-copying vec-owned
+    // heap boxes (#81: malloc'd doubles) so dst and src can be destroyed
+    // independently. The single copy loop shared by FrameVec_copy and the
+    // __prepareEnter/__prepareExit arg fan-out.
+    code.push_str(&format!(
+        "static void {}_FrameVec_extend({}_FrameVec* dst, {}_FrameVec* src) {{\n",
+        sys, sys, sys
+    ));
+    code.push_str("    if (!src) return;\n");
+    code.push_str("    for (int i = 0; i < src->size; i++) {\n");
+    code.push_str("        if (src->owned[i] && src->items[i]) {\n");
+    code.push_str("            void* nb = malloc(sizeof(double));\n");
+    code.push_str("            memcpy(nb, src->items[i], sizeof(double));\n");
+    code.push_str(&format!(
+        "            {}_FrameVec_push_(dst, nb, 1);\n",
+        sys
+    ));
+    code.push_str("        } else {\n");
+    code.push_str(&format!(
+        "            {}_FrameVec_push_(dst, src->items[i], 0);\n",
+        sys
+    ));
+    code.push_str("        }\n");
+    code.push_str("    }\n");
     code.push_str("}\n\n");
 
     // FrameVec_pop
@@ -293,18 +393,25 @@ fn generate_c_runtime_types(system: &SystemAst) -> String {
     code.push_str("    return v->size;\n");
     code.push_str("}\n\n");
 
-    // FrameVec_destroy
+    // FrameVec_destroy — frees vec-owned heap boxes (#81) alongside the
+    // storage; caller-owned pointees are untouched.
     code.push_str(&format!(
         "static void {}_FrameVec_destroy({}_FrameVec* v) {{\n",
         sys, sys
     ));
     code.push_str("    if (!v) return;\n");
+    code.push_str("    for (int i = 0; i < v->size; i++) {\n");
+    code.push_str("        if (v->owned[i] && v->items[i]) free(v->items[i]);\n");
+    code.push_str("    }\n");
+    code.push_str("    free(v->owned);\n");
     code.push_str("    free(v->items);\n");
     code.push_str("    free(v);\n");
     code.push_str("}\n\n");
 
-    // FrameVec_copy — shallow copy (items are void*; caller owns pointees).
-    // Used by Compartment_copy when snapshotting args for push$.
+    // FrameVec_copy — shallow for caller-owned pointees; DEEP for
+    // vec-owned heap boxes (#81: malloc'd doubles — a shallow copy would
+    // dangle when either side frees in destroy). Used by Compartment_copy
+    // when snapshotting args for push$.
     code.push_str(&format!(
         "static {}_FrameVec* {}_FrameVec_copy({}_FrameVec* src) {{\n",
         sys, sys, sys
@@ -314,29 +421,31 @@ fn generate_c_runtime_types(system: &SystemAst) -> String {
         "    {}_FrameVec* v = {}_FrameVec_new();\n",
         sys, sys
     ));
-    code.push_str("    for (int i = 0; i < src->size; i++) {\n");
-    code.push_str(&format!(
-        "        {}_FrameVec_push(v, src->items[i]);\n",
-        sys
-    ));
-    code.push_str("    }\n");
+    code.push_str(&format!("    {}_FrameVec_extend(v, src);\n", sys));
     code.push_str("    return v;\n");
     code.push_str("}\n\n");
 
     // ============================================================================
-    // Double-return marshalling helpers
+    // Double marshalling helpers
     // ============================================================================
-    // `_return` is a `void*` slot. Casting a `double` through `(intptr_t)`
-    // truncates the fractional part, and casting a `void*` back to `double`
-    // is illegal C. Bit-pun through `memcpy` — legal and round-trips
-    // cleanly on every 64-bit target (both `double` and `void*` are 8
-    // bytes). The C backend emits calls to these wherever a handler's
-    // return type is `float` / `double`.
+    // `_return` / container slots are `void*`. Casting a `double` through
+    // `(intptr_t)` truncates the fractional part, and casting a `void*`
+    // back to `double` is illegal C. The former bit-pun-through-memcpy
+    // assumed `sizeof(void*) >= sizeof(double)` — true only on 64-bit
+    // hosts; on wasm32 / any 32-bit target it overflowed the 4-byte slot
+    // and silently collapsed every float to 0 (#81). Doubles are now
+    // HEAP-BOXED: `pack_double` returns a malloc'd `double*`,
+    // `unpack_double` dereferences (NULL-safe) — pointer-width
+    // independent, strict ISO C. Ownership: the `_return` slot frees the
+    // previous box on overwrite and the interface wrapper frees after its
+    // final read; container-resident boxes go through the `_owned`
+    // setter/push variants and are freed on overwrite/destroy
+    // (deep-copied by the container copy helpers).
     code.push_str(&format!(
         "// ============================================================================\n"
     ));
     code.push_str(&format!(
-        "// {}_pack_double / {}_unpack_double — bit-pun doubles through void*\n",
+        "// {}_pack_double / {}_unpack_double — heap-boxed doubles (#81:\n// pointer-width independent; the old void* bit-pun overflowed on 32-bit)\n",
         sys, sys
     ));
     code.push_str(&format!(
@@ -346,17 +455,15 @@ fn generate_c_runtime_types(system: &SystemAst) -> String {
         "static inline void* {}_pack_double(double v) {{\n",
         sys
     ));
-    code.push_str("    void* p = 0;\n");
-    code.push_str("    memcpy(&p, &v, sizeof(double));\n");
-    code.push_str("    return p;\n");
+    code.push_str("    double* p = (double*)malloc(sizeof(double));\n");
+    code.push_str("    *p = v;\n");
+    code.push_str("    return (void*)p;\n");
     code.push_str("}\n\n");
     code.push_str(&format!(
         "static inline double {}_unpack_double(void* p) {{\n",
         sys
     ));
-    code.push_str("    double d;\n");
-    code.push_str("    memcpy(&d, &p, sizeof(double));\n");
-    code.push_str("    return d;\n");
+    code.push_str("    return p ? *(double*)p : 0.0;\n");
     code.push_str("}\n\n");
 
     // ============================================================================
@@ -438,7 +545,7 @@ fn generate_c_runtime_types(system: &SystemAst) -> String {
         "static cJSON* {sys}_persist_pack_str(void* v) {{ return cJSON_CreateString(v ? (const char*)v : \"\"); }}\n"
     ));
         code.push_str(&format!(
-        "static void* {sys}_persist_unpack_str(cJSON* j) {{ const char* s = (j && j->valuestring) ? j->valuestring : \"\"; return (void*)strdup(s); }}\n\n"
+        "static void* {sys}_persist_unpack_str(cJSON* j) {{ const char* s = (j && j->valuestring) ? j->valuestring : \"\"; return (void*){sys}_strdup_(s); }}\n\n"
     ));
 
         // bool — JSON true/false.
@@ -543,7 +650,7 @@ fn generate_c_runtime_types(system: &SystemAst) -> String {
             "static cJSON* {sys}_persist_pack_field_str(void* p) {{ const char* s = *(const char**)p; return cJSON_CreateString(s ? s : \"\"); }}\n"
         ));
         code.push_str(&format!(
-            "static void {sys}_persist_unpack_field_str(cJSON* j, void* p) {{ const char* s = (j && j->valuestring) ? j->valuestring : \"\"; *(char**)p = strdup(s); }}\n"
+            "static void {sys}_persist_unpack_field_str(cJSON* j, void* p) {{ const char* s = (j && j->valuestring) ? j->valuestring : \"\"; *(char**)p = {sys}_strdup_(s); }}\n"
         ));
         code.push_str(&format!(
             "static cJSON* {sys}_persist_pack_field_list(void* p) {{ return {sys}_persist_pack_list(*({sys}_FrameVec**)p); }}\n"

--- a/framec/src/frame_c/compiler/codegen/state_dispatch.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch.rs
@@ -420,10 +420,10 @@ pub(super) fn emit_handler_return_init(
             indent, init_expr
         ),
         TargetLanguage::C => {
-            // Marshalled per `c_marshal::c_return_write` (#72): doubles
-            // bit-pun via `Sys_pack_double` (`(intptr_t)(42.0)` truncates),
-            // structs heap-box; the categorization is shared with every
-            // read site so pack and unpack cannot drift.
+            // Marshalled per `c_marshal::c_return_write` (#72, #81):
+            // doubles and structs heap-box (`(intptr_t)(42.0)` truncates);
+            // the categorization is shared with every read site so pack
+            // and unpack cannot drift.
             let ty = handler.return_type.as_deref().unwrap_or("int");
             let slot = format!("{}_CTX(self)->_return", system_name);
             format!(
@@ -858,6 +858,35 @@ pub(crate) fn generate_per_handler_methods(
         })
         .unwrap_or_default();
 
+    // Companion type maps for enter / exit handler params, mirroring
+    // `state_param_types`: (state_name, param_name) → declared type string.
+    // Used by the C transition codegen to pack each enter/exit arg per its
+    // declared category (#81 — float/double args must heap-box via
+    // pack_double and push owned; the historical `(void*)(intptr_t)` push
+    // truncates, and the handler-side read derefs a box).
+    fn param_type_str(p: &crate::frame_c::compiler::frame_ast::EventParam) -> String {
+        match &p.param_type {
+            crate::frame_c::compiler::frame_ast::Type::Custom(t) => t.clone(),
+            crate::frame_c::compiler::frame_ast::Type::Unknown => "int".to_string(),
+        }
+    }
+    let mut state_enter_param_types: std::collections::HashMap<(String, String), String> =
+        std::collections::HashMap::new();
+    let mut state_exit_param_types: std::collections::HashMap<(String, String), String> =
+        std::collections::HashMap::new();
+    for s in &machine.states {
+        if let Some(ref e) = s.enter {
+            for p in &e.params {
+                state_enter_param_types.insert((s.name.clone(), p.name.clone()), param_type_str(p));
+            }
+        }
+        if let Some(ref e) = s.exit {
+            for p in &e.params {
+                state_exit_param_types.insert((s.name.clone(), p.name.clone()), param_type_str(p));
+            }
+        }
+    }
+
     // The system's action names (RFC-0046): `@@:self.<action>(args)` is a
     // direct call and must NOT receive the self-call transition guard.
     let actions: std::collections::HashSet<String> = arcanum
@@ -951,6 +980,8 @@ pub(crate) fn generate_per_handler_methods(
                 &handler_state_var_types,
                 &state_hsm_parents,
                 state_param_types,
+                &state_enter_param_types,
+                &state_exit_param_types,
                 &domain_field_types,
             );
             methods.push(method);
@@ -986,6 +1017,8 @@ pub(crate) fn generate_per_handler_methods(
                 &handler_state_var_types,
                 &state_hsm_parents,
                 state_param_types,
+                &state_enter_param_types,
+                &state_exit_param_types,
                 &domain_field_types,
             );
             // Per-handler leading comments (from `HandlerAst.leading_comments`
@@ -1034,6 +1067,8 @@ fn generate_per_handler_method_for_lang(
     handler_state_var_types: &std::collections::HashMap<String, String>,
     state_hsm_parents: &std::collections::HashMap<String, String>,
     state_param_types: &std::collections::HashMap<(String, String), String>,
+    state_enter_param_types: &std::collections::HashMap<(String, String), String>,
+    state_exit_param_types: &std::collections::HashMap<(String, String), String>,
     domain_field_types: &std::collections::HashMap<String, String>,
 ) -> CodegenNode {
     match lang {
@@ -1315,6 +1350,8 @@ fn generate_per_handler_method_for_lang(
             handler_state_var_types,
             state_hsm_parents,
             state_param_types,
+            state_enter_param_types,
+            state_exit_param_types,
             domain_field_types,
         ),
         _ => unreachable!(
@@ -1388,6 +1425,8 @@ pub(crate) fn generate_state_method(
         state_hsm_parents: std::collections::HashMap::new(),
         current_return_type: None,
         state_param_types: std::collections::HashMap::new(),
+        state_enter_param_types: std::collections::HashMap::new(),
+        state_exit_param_types: std::collections::HashMap::new(),
         domain_field_types: std::collections::HashMap::new(),
         actions: std::collections::HashSet::new(),
     };
@@ -1638,6 +1677,8 @@ pub(crate) fn generate_handler_from_arcanum(
         state_hsm_parents: state_hsm_parents.clone(),
         current_return_type: handler.return_type.clone(),
         state_param_types: std::collections::HashMap::new(),
+        state_enter_param_types: std::collections::HashMap::new(),
+        state_exit_param_types: std::collections::HashMap::new(),
         domain_field_types: std::collections::HashMap::new(),
         actions: actions.clone(),
     };

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/c.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/c.rs
@@ -41,6 +41,8 @@ pub(crate) fn generate_c_handler_method(
     handler_state_var_types: &std::collections::HashMap<String, String>,
     state_hsm_parents: &std::collections::HashMap<String, String>,
     state_param_types: &std::collections::HashMap<(String, String), String>,
+    state_enter_param_types: &std::collections::HashMap<(String, String), String>,
+    state_exit_param_types: &std::collections::HashMap<(String, String), String>,
     domain_field_types: &std::collections::HashMap<String, String>,
 ) -> CodegenNode {
     let method_name = handler_method_name(state_name, handler);
@@ -63,6 +65,8 @@ pub(crate) fn generate_c_handler_method(
         state_hsm_parents: state_hsm_parents.clone(),
         current_return_type: handler.return_type.clone(),
         state_param_types: state_param_types.clone(),
+        state_enter_param_types: state_enter_param_types.clone(),
+        state_exit_param_types: state_exit_param_types.clone(),
         domain_field_types: domain_field_types.clone(),
     };
 
@@ -72,15 +76,17 @@ pub(crate) fn generate_c_handler_method(
     // come from `c_marshal::c_marshal_of` (#72) — the same source of truth
     // the wrapper's pack side uses, so write and read cannot drift:
     // `str` → `const char*`, `bool` → `int`, `float`/`double` → `double`
-    // (via the runtime's `Sys_unpack_double` bit-pun — `(intptr_t)(0.5)`
-    // truncates), `T*` → typed cast.
+    // (via `Sys_unpack_double`, a NULL-safe deref of the heap/stack box
+    // the push side built — #81; `(intptr_t)(0.5)` truncates), `T*` →
+    // typed cast.
     //
     // The Boxed fallback (structs / unknown typedefs) differs by slot:
     // EVENT params are pushed by the interface wrapper as stack-box
     // addresses → deref-copy here (`T v = *(T*)val`). STATE/enter/exit
-    // args are pushed by the transition sites, which still use the
-    // historical `(void*)(intptr_t)` form → keep the int fallback there
-    // (struct state-args have never been supported on C; #72 follow-up).
+    // args are pushed by the transition sites, which keep the historical
+    // `(void*)(intptr_t)` form for non-Dbl unknowns → keep the int
+    // fallback there (struct state-args have never been supported on C;
+    // #72 follow-up).
     //
     // Returns (decl_type, full_extract_expr) where the extractor takes
     // the void* value placeholder `{val}`.
@@ -171,9 +177,11 @@ pub(crate) fn generate_c_handler_method(
     }
 
     // State-var init (lifecycle enter only). Uses FrameDict_has + FrameDict_set.
-    // Packing per c_marshal (#77): float/double state-vars bit-pun via
-    // pack_double — `(void*)(intptr_t)(0.0)` truncates. The matching read-side
-    // unpack lives in `expand_state_var`'s C arm.
+    // Packing per c_marshal (#77, #81): float/double state-vars heap-box via
+    // pack_double — `(void*)(intptr_t)(0.0)` truncates, and bit-punning
+    // corrupts on 32-bit pointers. Stored OWNED so the dict frees/deep-copies
+    // the box. The matching read-side unpack lives in `expand_state_var`'s
+    // C arm.
     if handler.is_enter {
         for var in state_vars_for_init {
             let init_val = if let Some(ref init) = var.initializer_text {
@@ -181,20 +189,23 @@ pub(crate) fn generate_c_handler_method(
             } else {
                 state_var_init_value(&var.var_type, lang)
             };
-            let packed = {
+            let (packed, setter) = {
                 use crate::frame_c::compiler::codegen::c_marshal::{c_marshal_of, CMarshal};
                 let declared = match &var.var_type {
                     crate::frame_c::compiler::frame_ast::Type::Custom(t) => t.as_str(),
                     _ => "",
                 };
                 match c_marshal_of(declared) {
-                    CMarshal::Dbl => format!("{}_pack_double({})", system_name, init_val),
-                    _ => format!("(void*)(intptr_t)({})", init_val),
+                    CMarshal::Dbl => (
+                        format!("{}_pack_double({})", system_name, init_val),
+                        "FrameDict_set_owned",
+                    ),
+                    _ => (format!("(void*)(intptr_t)({})", init_val), "FrameDict_set"),
                 }
             };
             body.push_str(&format!(
-                "if (!{}_FrameDict_has(compartment->state_vars, \"{}\")) {{\n    {}_FrameDict_set(compartment->state_vars, \"{}\", {});\n}}\n",
-                system_name, var.name, system_name, var.name, packed
+                "if (!{}_FrameDict_has(compartment->state_vars, \"{}\")) {{\n    {}_{}(compartment->state_vars, \"{}\", {});\n}}\n",
+                system_name, var.name, system_name, setter, var.name, packed
             ));
         }
     }

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/cpp.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/cpp.rs
@@ -62,6 +62,8 @@ pub(crate) fn generate_cpp_handler_method(
         state_hsm_parents: state_hsm_parents.clone(),
         current_return_type: handler.return_type.clone(),
         state_param_types: std::collections::HashMap::new(),
+        state_enter_param_types: std::collections::HashMap::new(),
+        state_exit_param_types: std::collections::HashMap::new(),
         domain_field_types: domain_field_types.clone(),
     };
 

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/csharp.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/csharp.rs
@@ -61,6 +61,8 @@ pub(crate) fn generate_csharp_handler_method(
         state_hsm_parents: state_hsm_parents.clone(),
         current_return_type: handler.return_type.clone(),
         state_param_types: std::collections::HashMap::new(),
+        state_enter_param_types: std::collections::HashMap::new(),
+        state_exit_param_types: std::collections::HashMap::new(),
         domain_field_types: std::collections::HashMap::new(),
     };
 

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/dart.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/dart.rs
@@ -59,6 +59,8 @@ pub(crate) fn generate_dart_handler_method(
         state_hsm_parents: state_hsm_parents.clone(),
         current_return_type: handler.return_type.clone(),
         state_param_types: std::collections::HashMap::new(),
+        state_enter_param_types: std::collections::HashMap::new(),
+        state_exit_param_types: std::collections::HashMap::new(),
         domain_field_types: std::collections::HashMap::new(),
     };
 

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/gdscript.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/gdscript.rs
@@ -60,6 +60,8 @@ pub(crate) fn generate_gdscript_handler_method(
         state_hsm_parents: state_hsm_parents.clone(),
         current_return_type: handler.return_type.clone(),
         state_param_types: std::collections::HashMap::new(),
+        state_enter_param_types: std::collections::HashMap::new(),
+        state_exit_param_types: std::collections::HashMap::new(),
         domain_field_types: std::collections::HashMap::new(),
     };
 

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/go.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/go.rs
@@ -62,6 +62,8 @@ pub(crate) fn generate_go_handler_method(
         state_hsm_parents: state_hsm_parents.clone(),
         current_return_type: handler.return_type.clone(),
         state_param_types: std::collections::HashMap::new(),
+        state_enter_param_types: std::collections::HashMap::new(),
+        state_exit_param_types: std::collections::HashMap::new(),
         domain_field_types: std::collections::HashMap::new(),
     };
 

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/java.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/java.rs
@@ -61,6 +61,8 @@ pub(crate) fn generate_java_handler_method(
         state_hsm_parents: state_hsm_parents.clone(),
         current_return_type: handler.return_type.clone(),
         state_param_types: std::collections::HashMap::new(),
+        state_enter_param_types: std::collections::HashMap::new(),
+        state_exit_param_types: std::collections::HashMap::new(),
         domain_field_types: std::collections::HashMap::new(),
     };
 

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/kotlin.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/kotlin.rs
@@ -61,6 +61,8 @@ pub(crate) fn generate_kotlin_handler_method(
         state_hsm_parents: state_hsm_parents.clone(),
         current_return_type: handler.return_type.clone(),
         state_param_types: std::collections::HashMap::new(),
+        state_enter_param_types: std::collections::HashMap::new(),
+        state_exit_param_types: std::collections::HashMap::new(),
         domain_field_types: std::collections::HashMap::new(),
     };
 

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/lua.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/lua.rs
@@ -58,6 +58,8 @@ pub(crate) fn generate_lua_handler_method(
         state_hsm_parents: state_hsm_parents.clone(),
         current_return_type: handler.return_type.clone(),
         state_param_types: std::collections::HashMap::new(),
+        state_enter_param_types: std::collections::HashMap::new(),
+        state_exit_param_types: std::collections::HashMap::new(),
         domain_field_types: std::collections::HashMap::new(),
     };
 

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/php.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/php.rs
@@ -59,6 +59,8 @@ pub(crate) fn generate_php_handler_method(
         state_hsm_parents: state_hsm_parents.clone(),
         current_return_type: handler.return_type.clone(),
         state_param_types: std::collections::HashMap::new(),
+        state_enter_param_types: std::collections::HashMap::new(),
+        state_exit_param_types: std::collections::HashMap::new(),
         domain_field_types: std::collections::HashMap::new(),
     };
 

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/python.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/python.rs
@@ -63,6 +63,8 @@ pub(crate) fn generate_python_handler_method(
         state_hsm_parents: state_hsm_parents.clone(),
         current_return_type: handler.return_type.clone(),
         state_param_types: std::collections::HashMap::new(),
+        state_enter_param_types: std::collections::HashMap::new(),
+        state_exit_param_types: std::collections::HashMap::new(),
         domain_field_types: std::collections::HashMap::new(),
     };
 

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/ruby.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/ruby.rs
@@ -59,6 +59,8 @@ pub(crate) fn generate_ruby_handler_method(
         state_hsm_parents: state_hsm_parents.clone(),
         current_return_type: handler.return_type.clone(),
         state_param_types: std::collections::HashMap::new(),
+        state_enter_param_types: std::collections::HashMap::new(),
+        state_exit_param_types: std::collections::HashMap::new(),
         domain_field_types: std::collections::HashMap::new(),
     };
 

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/swift.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/swift.rs
@@ -61,6 +61,8 @@ pub(crate) fn generate_swift_handler_method(
         state_hsm_parents: state_hsm_parents.clone(),
         current_return_type: handler.return_type.clone(),
         state_param_types: std::collections::HashMap::new(),
+        state_enter_param_types: std::collections::HashMap::new(),
+        state_exit_param_types: std::collections::HashMap::new(),
         domain_field_types: std::collections::HashMap::new(),
     };
 

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/typescript.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/typescript.rs
@@ -60,6 +60,8 @@ pub(crate) fn generate_typescript_handler_method(
         state_hsm_parents: state_hsm_parents.clone(),
         current_return_type: handler.return_type.clone(),
         state_param_types: std::collections::HashMap::new(),
+        state_enter_param_types: std::collections::HashMap::new(),
+        state_exit_param_types: std::collections::HashMap::new(),
         domain_field_types: std::collections::HashMap::new(),
     };
 

--- a/framec/src/frame_c/compiler/pipeline_parser/mod.rs
+++ b/framec/src/frame_c/compiler/pipeline_parser/mod.rs
@@ -872,8 +872,21 @@ impl Parser {
                             }));
                         }
                         Token::StringLit(label_text) => {
-                            // -> "label" $State — transition with label
-                            let target_tok = self.lexer.next_token().map_err(ParseError::from)?;
+                            // -> "label" $State — transition with label.
+                            // The lexer reorders `$State(state_args)` to
+                            // NativeCode(state_args) BEFORE the StateRef, so
+                            // `-> "label" $State(args)` arrives as StringLit →
+                            // NativeCode → StateRef. Absorb the optional
+                            // state-args token (#81 W414 false positive:
+                            // without this the Transition statement was
+                            // dropped and the target flagged unreachable).
+                            let mut target_tok =
+                                self.lexer.next_token().map_err(ParseError::from)?;
+                            let mut state_args = None;
+                            if let Token::NativeCode(state_args_text) = target_tok.token {
+                                state_args = Some(state_args_text);
+                                target_tok = self.lexer.next_token().map_err(ParseError::from)?;
+                            }
                             if let Token::StateRef(target) = target_tok.token {
                                 statements.push(Statement::Transition(TransitionAst {
                                     target,
@@ -883,7 +896,7 @@ impl Parser {
                                     indent: 0,
                                     exit_args: None,
                                     enter_args: None,
-                                    state_args: None,
+                                    state_args,
                                     is_pop: false,
                                     is_forward: false,
                                 }));
@@ -957,9 +970,18 @@ impl Parser {
                                     }));
                                 }
                                 Token::StringLit(label_text) => {
-                                    // -> (args) "label" $State — enter args + label
-                                    let target_tok =
+                                    // -> (args) "label" $State — enter args + label.
+                                    // Absorb an optional reordered state-args
+                                    // token before the StateRef (see the
+                                    // StringLit arm above; #81 W414).
+                                    let mut target_tok =
                                         self.lexer.next_token().map_err(ParseError::from)?;
+                                    let mut state_args = None;
+                                    if let Token::NativeCode(state_args_text) = target_tok.token {
+                                        state_args = Some(state_args_text);
+                                        target_tok =
+                                            self.lexer.next_token().map_err(ParseError::from)?;
+                                    }
                                     if let Token::StateRef(target) = target_tok.token {
                                         statements.push(Statement::Transition(TransitionAst {
                                             target,
@@ -969,7 +991,33 @@ impl Parser {
                                             indent: 0,
                                             exit_args: None,
                                             enter_args: None,
-                                            state_args: None,
+                                            state_args,
+                                            is_pop: false,
+                                            is_forward: false,
+                                        }));
+                                    }
+                                }
+                                Token::NativeCode(state_args_text) => {
+                                    // -> (enter_args) $State(state_args) — the
+                                    // lexer emits state args as a second
+                                    // NativeCode BEFORE the StateRef (Arrow →
+                                    // NC(enter) → NC(state) → StateRef).
+                                    // Without this arm the combined decoration
+                                    // dropped the Transition statement and
+                                    // W414 flagged the target unreachable
+                                    // (#81 fixture surfaced it).
+                                    let target_tok =
+                                        self.lexer.next_token().map_err(ParseError::from)?;
+                                    if let Token::StateRef(target) = target_tok.token {
+                                        statements.push(Statement::Transition(TransitionAst {
+                                            target,
+                                            args: vec![Expression::NativeExpr(args)],
+                                            label: None,
+                                            span: Span::new(tok.span.start, target_tok.span.end),
+                                            indent: 0,
+                                            exit_args: None,
+                                            enter_args: None,
+                                            state_args: Some(state_args_text),
                                             is_pop: false,
                                             is_forward: false,
                                         }));
@@ -1905,6 +1953,51 @@ mod tests {
             has_transition,
             "Handler body should contain transition to $Running"
         );
+    }
+
+    #[test]
+    fn test_transition_enter_and_state_args_combined() {
+        // `-> (enter) $State(state)` — the lexer reorders state args to a
+        // second NativeCode BEFORE the StateRef. The parser used to drop
+        // the whole Transition statement on that shape, so W414 flagged
+        // the target unreachable (#81). Lock the combined decoration.
+        let sys = parse_py(
+            "machine:\n    $S {\n        go() {\n            -> (0.75) $T(2.5)\n        }\n    }\n    $T(sa: float) {\n    }",
+        );
+        let machine = sys.machine.unwrap();
+        let body = &machine.states[0].handlers[0].body;
+        let trans = body
+            .statements
+            .iter()
+            .find_map(|s| match s {
+                Statement::Transition(t) => Some(t),
+                _ => None,
+            })
+            .expect("combined enter+state args must still parse as a Transition");
+        assert_eq!(trans.target, "T");
+        assert_eq!(trans.state_args.as_deref(), Some("(2.5)"));
+    }
+
+    #[test]
+    fn test_transition_label_and_state_args_combined() {
+        // `-> "label" $State(state)` — same lexer reordering through the
+        // label arm (#81).
+        let sys = parse_py(
+            "machine:\n    $S {\n        go() {\n            -> \"hop\" $T(2.5)\n        }\n    }\n    $T(sa: float) {\n    }",
+        );
+        let machine = sys.machine.unwrap();
+        let body = &machine.states[0].handlers[0].body;
+        let trans = body
+            .statements
+            .iter()
+            .find_map(|s| match s {
+                Statement::Transition(t) => Some(t),
+                _ => None,
+            })
+            .expect("label + state args must still parse as a Transition");
+        assert_eq!(trans.target, "T");
+        assert_eq!(trans.label.as_deref(), Some("hop"));
+        assert_eq!(trans.state_args.as_deref(), Some("(2.5)"));
     }
 
     #[test]

--- a/framec/tests/c_snapshots.rs
+++ b/framec/tests/c_snapshots.rs
@@ -157,3 +157,56 @@ fn issue78_float_roundtrip_runs() {
         String::from_utf8_lossy(&run.stderr)
     );
 }
+
+/// wasm32 RUNTIME gate for the C backend (#81) — compiles the
+/// `17_float_roundtrip` fixture with Emscripten (32-bit pointers) and
+/// executes it under node. This is the exact configuration the old
+/// double-through-`void*` bit-pun silently corrupted: `sizeof(void*) == 4 <
+/// sizeof(double) == 8`, so every float collapsed toward 0 while the
+/// 64-bit native leg above stayed green. Doubles now travel as heap/stack
+/// boxes, which is pointer-width independent — this leg locks that.
+///
+/// Skipped (not failed) when emcc or node is not on PATH, matching the
+/// RFC-0034 toolchain-availability convention.
+#[test]
+fn issue81_float_roundtrip_runs_wasm32() {
+    use std::process::Command;
+    let emcc = match common::find_tool("emcc") {
+        Some(p) => p,
+        None => {
+            eprintln!("#81 wasm32 runtime gate skipped: emcc not on PATH");
+            return;
+        }
+    };
+    let node = match common::find_tool("node") {
+        Some(p) => p,
+        None => {
+            eprintln!("#81 wasm32 runtime gate skipped: node not on PATH");
+            return;
+        }
+    };
+    let code = compile_fixture("17_float_roundtrip", "c");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("17_float_roundtrip.c");
+    let js = dir.path().join("rt.js");
+    std::fs::write(&src, &code).expect("write tempfile");
+    let build = Command::new(&emcc)
+        .args(["-std=c11", "-o"])
+        .arg(&js)
+        .arg(&src)
+        .output()
+        .expect("emcc process");
+    assert!(
+        build.status.success(),
+        "#81: float fixture failed to compile for wasm32.\n--- stderr ---\n{}\n--- generated source ---\n{}",
+        String::from_utf8_lossy(&build.stderr),
+        code
+    );
+    let run = Command::new(&node).arg(&js).output().expect("node process");
+    assert!(
+        run.status.success(),
+        "#81: float fixture FAILED AT RUNTIME ON wasm32 (doubles corrupted through a 4-byte void* slot).\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+}

--- a/framec/tests/fixtures/c/17_float_roundtrip.frm
+++ b/framec/tests/fixtures/c/17_float_roundtrip.frm
@@ -1,12 +1,18 @@
-// Runtime gate fixture for the C target (#77/#78) — float state-vars through
-// the void* slot, executed (not just compiled).
+// Runtime gate fixture for the C target (#77/#78/#81) — floats through
+// every void* slot family, executed (not just compiled).
 //
-// The C state-var path stored floats via `(void*)(intptr_t)` (truncating)
-// and read them back as `(int)(intptr_t)` — values silently corrupted at
-// RUNTIME while compiling cleanly. Now packed/unpacked via the c_marshal
-// bit-pun pair, symmetric with interface returns (#72). This fixture
-// asserts the round-tripped values, covering the state-var initializer
-// (whole-number trap `0.0`), read-modify-write, and a float literal return.
+// The C float path has regressed twice while compiling cleanly: first
+// stored via `(void*)(intptr_t)` (truncating, #77/#78), then via a
+// pointer-width bit-pun that corrupted on 32-bit targets (#81). Doubles
+// now travel as heap/stack boxes with container ownership. This fixture
+// asserts round-tripped values across: state-var init + read-modify-write,
+// an interface float PARAM (wrapper stack-box), float returns (`@@:(...)`
+// and early `@@:return(...)`), and float STATE / ENTER / EXIT args
+// (typed owned pushes).
+//
+// All literals are dyadic fractions (exact in both float and double), so
+// `==` asserts are bit-sound while any integer truncation still fails:
+// a truncating slot turns 3.25 into 3, 0.75 into 0.
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -15,20 +21,37 @@
 @@system Roundtrip {
     interface:
         bump()
+        set(v: float)
         peek(): float
         radius(): float
         early(): float
+        go()
+        result(): float
+        exits(): float
     machine:
         $S {
-            $.cool: float = 0.0
+            $.cool: float = 0.25
+
+            <$(x: float) { @@:self.exit_seen = x; }
 
             bump() { $.cool = $.cool + 1.5 }
+            set(v: float) { $.cool = v }
             peek(): float { @@:($.cool) }
-            radius(): float { @@:(32.0) }
-            early(): float { @@:return(18.0) }
+            radius(): float { @@:(32.5) }
+            early(): float { @@:return(18.25) }
+            go() { (1.25) -> (0.75) $T(2.5) }
+        }
+
+        $T(sa: float) {
+            $.sum: float = 0.0
+
+            $>(ea: float) { $.sum = sa + ea }
+
+            result(): float { @@:($.sum) }
+            exits(): float { @@:(@@:self.exit_seen) }
         }
     domain:
-        r: float = 1.0
+        exit_seen: float = 0.0
 }
 
 int main() {
@@ -36,11 +59,19 @@ int main() {
     Roundtrip_bump(p);
     Roundtrip_bump(p);
     double got = Roundtrip_peek(p);
-    if (got != 3.0) { printf("FAIL peek: %f\n", got); return 1; }
+    if (got != 3.25) { printf("FAIL peek: %f\n", got); return 1; }
+    Roundtrip_set(p, 6.25);
+    double set_back = Roundtrip_peek(p);
+    if (set_back != 6.25) { printf("FAIL set/peek: %f\n", set_back); return 1; }
     double rad = Roundtrip_radius(p);
-    if (rad != 32.0) { printf("FAIL radius: %f\n", rad); return 1; }
+    if (rad != 32.5) { printf("FAIL radius: %f\n", rad); return 1; }
     double er = Roundtrip_early(p);
-    if (er != 18.0) { printf("FAIL early: %f\n", er); return 1; }
+    if (er != 18.25) { printf("FAIL early: %f\n", er); return 1; }
+    Roundtrip_go(p);
+    double res = Roundtrip_result(p);
+    if (res != 3.25) { printf("FAIL state+enter args: %f\n", res); return 1; }
+    double ex = Roundtrip_exits(p);
+    if (ex != 1.25) { printf("FAIL exit arg: %f\n", ex); return 1; }
     printf("PASS: 17_float_roundtrip\n");
     Roundtrip_destroy(p);
     return 0;

--- a/framec/tests/snapshots/c_snapshots__actions.snap
+++ b/framec/tests/snapshots/c_snapshots__actions.snap
@@ -12,9 +12,20 @@ expression: "compile_fixture(\"10_actions\", \"c\")"
 // Actions_FrameDict - String-keyed dictionary
 // ============================================================================
 
+static char* Actions_strdup_(const char* s) {
+    size_t n = strlen(s) + 1;
+    char* p = (char*)malloc(n);
+    memcpy(p, s, n);
+    return p;
+}
+
 typedef struct Actions_FrameDictEntry {
     char* key;
     void* value;
+    // 1 when `value` is a heap box this dict owns (a malloc'd
+    // double from pack_double — #81): freed on overwrite and in
+    // destroy, deep-copied by FrameDict_copy.
+    int owned;
     struct Actions_FrameDictEntry* next;
 } Actions_FrameDictEntry;
 
@@ -41,19 +52,31 @@ static Actions_FrameDict* Actions_FrameDict_new(void) {
     return d;
 }
 
+static void Actions_FrameDict_set_(Actions_FrameDict* d, const char* key, void* value, int owned);
 static void Actions_FrameDict_set(Actions_FrameDict* d, const char* key, void* value) {
+    Actions_FrameDict_set_(d, key, value, 0);
+}
+
+static void Actions_FrameDict_set_owned(Actions_FrameDict* d, const char* key, void* value) {
+    Actions_FrameDict_set_(d, key, value, 1);
+}
+
+static void Actions_FrameDict_set_(Actions_FrameDict* d, const char* key, void* value, int owned) {
     unsigned int idx = Actions_hash_string(key) % d->bucket_count;
     Actions_FrameDictEntry* entry = d->buckets[idx];
     while (entry) {
         if (strcmp(entry->key, key) == 0) {
+            if (entry->owned && entry->value) free(entry->value);
             entry->value = value;
+            entry->owned = owned;
             return;
         }
         entry = entry->next;
     }
     Actions_FrameDictEntry* new_entry = malloc(sizeof(Actions_FrameDictEntry));
-    new_entry->key = strdup(key);
+    new_entry->key = Actions_strdup_(key);
     new_entry->value = value;
+    new_entry->owned = owned;
     new_entry->next = d->buckets[idx];
     d->buckets[idx] = new_entry;
     d->size++;
@@ -88,7 +111,16 @@ static Actions_FrameDict* Actions_FrameDict_copy(Actions_FrameDict* src) {
     for (int i = 0; i < src->bucket_count; i++) {
         Actions_FrameDictEntry* entry = src->buckets[i];
         while (entry) {
-            Actions_FrameDict_set(dst, entry->key, entry->value);
+            if (entry->owned && entry->value) {
+                // Owned values are heap-boxed doubles (#81): deep-copy
+                // so src and dst never alias (a shallow copy would
+                // dangle when either side frees on overwrite/destroy).
+                void* nb = malloc(sizeof(double));
+                memcpy(nb, entry->value, sizeof(double));
+                Actions_FrameDict_set_(dst, entry->key, nb, 1);
+            } else {
+                Actions_FrameDict_set_(dst, entry->key, entry->value, 0);
+            }
             entry = entry->next;
         }
     }
@@ -100,6 +132,7 @@ static void Actions_FrameDict_destroy(Actions_FrameDict* d) {
         Actions_FrameDictEntry* entry = d->buckets[i];
         while (entry) {
             Actions_FrameDictEntry* next = entry->next;
+            if (entry->owned && entry->value) free(entry->value);
             free(entry->key);
             free(entry);
             entry = next;
@@ -115,6 +148,10 @@ static void Actions_FrameDict_destroy(Actions_FrameDict* d) {
 
 typedef struct {
     void** items;
+    // owned[i] == 1 when items[i] is a heap box this vec owns (a
+    // malloc'd double from pack_double — #81): freed in destroy,
+    // deep-copied by FrameVec_copy.
+    unsigned char* owned;
     int size;
     int capacity;
 } Actions_FrameVec;
@@ -124,15 +161,48 @@ static Actions_FrameVec* Actions_FrameVec_new(void) {
     v->capacity = 8;
     v->size = 0;
     v->items = malloc(sizeof(void*) * v->capacity);
+    v->owned = calloc(v->capacity, 1);
     return v;
 }
 
-static void Actions_FrameVec_push(Actions_FrameVec* v, void* item) {
+static void Actions_FrameVec_push_(Actions_FrameVec* v, void* item, unsigned char owned) {
     if (v->size >= v->capacity) {
         v->capacity *= 2;
         v->items = realloc(v->items, sizeof(void*) * v->capacity);
+        v->owned = realloc(v->owned, v->capacity);
+        memset(v->owned + v->size, 0, v->capacity - v->size);
     }
+    v->owned[v->size] = owned;
     v->items[v->size++] = item;
+}
+
+static void Actions_FrameVec_push(Actions_FrameVec* v, void* item) {
+    Actions_FrameVec_push_(v, item, 0);
+}
+
+static void Actions_FrameVec_push_owned(Actions_FrameVec* v, void* item) {
+    Actions_FrameVec_push_(v, item, 1);
+}
+
+static void Actions_FrameVec_clear(Actions_FrameVec* v) {
+    if (!v) return;
+    for (int i = 0; i < v->size; i++) {
+        if (v->owned[i] && v->items[i]) free(v->items[i]);
+    }
+    v->size = 0;
+}
+
+static void Actions_FrameVec_extend(Actions_FrameVec* dst, Actions_FrameVec* src) {
+    if (!src) return;
+    for (int i = 0; i < src->size; i++) {
+        if (src->owned[i] && src->items[i]) {
+            void* nb = malloc(sizeof(double));
+            memcpy(nb, src->items[i], sizeof(double));
+            Actions_FrameVec_push_(dst, nb, 1);
+        } else {
+            Actions_FrameVec_push_(dst, src->items[i], 0);
+        }
+    }
 }
 
 static void* Actions_FrameVec_pop(Actions_FrameVec* v) {
@@ -156,6 +226,10 @@ static int Actions_FrameVec_size(Actions_FrameVec* v) {
 
 static void Actions_FrameVec_destroy(Actions_FrameVec* v) {
     if (!v) return;
+    for (int i = 0; i < v->size; i++) {
+        if (v->owned[i] && v->items[i]) free(v->items[i]);
+    }
+    free(v->owned);
     free(v->items);
     free(v);
 }
@@ -163,26 +237,23 @@ static void Actions_FrameVec_destroy(Actions_FrameVec* v) {
 static Actions_FrameVec* Actions_FrameVec_copy(Actions_FrameVec* src) {
     if (!src) return NULL;
     Actions_FrameVec* v = Actions_FrameVec_new();
-    for (int i = 0; i < src->size; i++) {
-        Actions_FrameVec_push(v, src->items[i]);
-    }
+    Actions_FrameVec_extend(v, src);
     return v;
 }
 
 // ============================================================================
-// Actions_pack_double / Actions_unpack_double — bit-pun doubles through void*
+// Actions_pack_double / Actions_unpack_double — heap-boxed doubles (#81:
+// pointer-width independent; the old void* bit-pun overflowed on 32-bit)
 // ============================================================================
 
 static inline void* Actions_pack_double(double v) {
-    void* p = 0;
-    memcpy(&p, &v, sizeof(double));
-    return p;
+    double* p = (double*)malloc(sizeof(double));
+    *p = v;
+    return (void*)p;
 }
 
 static inline double Actions_unpack_double(void* p) {
-    double d;
-    memcpy(&d, &p, sizeof(double));
-    return d;
+    return p ? *(double*)p : 0.0;
 }
 
 // ============================================================================
@@ -384,12 +455,10 @@ static Actions_Compartment* Actions_prepareEnter(Actions* self, const char* leaf
     Actions_Compartment* comp = NULL;
     for (int i = 0; i < n; i++) {
         Actions_Compartment* nc = Actions_Compartment_new(chain[i]);
-        if (state_args) {
-            for (int j = 0; j < state_args->size; j++) Actions_FrameVec_push(nc->state_args, state_args->items[j]);
-        }
-        if (enter_args) {
-            for (int j = 0; j < enter_args->size; j++) Actions_FrameVec_push(nc->enter_args, enter_args->items[j]);
-        }
+        // FrameVec_extend deep-copies vec-owned heap boxes (#81: doubles)
+        // so the caller can destroy its arg vecs after this returns.
+        Actions_FrameVec_extend(nc->state_args, state_args);
+        Actions_FrameVec_extend(nc->enter_args, enter_args);
         nc->parent_compartment = comp;  // adopts ref
         comp = nc;
     }
@@ -399,11 +468,10 @@ static Actions_Compartment* Actions_prepareEnter(Actions* self, const char* leaf
 static void Actions_prepareExit(Actions* self, Actions_FrameVec* exit_args) {
     Actions_Compartment* comp = self->__compartment;
     while (comp != NULL) {
-        // Clear any prior exit_args before copying the new ones in.
-        while (comp->exit_args->size > 0) comp->exit_args->size--;
-        if (exit_args) {
-            for (int j = 0; j < exit_args->size; j++) Actions_FrameVec_push(comp->exit_args, exit_args->items[j]);
-        }
+        // Clear any prior exit_args (freeing vec-owned boxes, #81) before
+        // copying the new ones in; extend deep-copies owned entries.
+        Actions_FrameVec_clear(comp->exit_args);
+        Actions_FrameVec_extend(comp->exit_args, exit_args);
         comp = comp->parent_compartment;
     }
 }

--- a/framec/tests/snapshots/c_snapshots__consts.snap
+++ b/framec/tests/snapshots/c_snapshots__consts.snap
@@ -12,9 +12,20 @@ expression: "compile_fixture(\"11_consts\", \"c\")"
 // Consts_FrameDict - String-keyed dictionary
 // ============================================================================
 
+static char* Consts_strdup_(const char* s) {
+    size_t n = strlen(s) + 1;
+    char* p = (char*)malloc(n);
+    memcpy(p, s, n);
+    return p;
+}
+
 typedef struct Consts_FrameDictEntry {
     char* key;
     void* value;
+    // 1 when `value` is a heap box this dict owns (a malloc'd
+    // double from pack_double — #81): freed on overwrite and in
+    // destroy, deep-copied by FrameDict_copy.
+    int owned;
     struct Consts_FrameDictEntry* next;
 } Consts_FrameDictEntry;
 
@@ -41,19 +52,31 @@ static Consts_FrameDict* Consts_FrameDict_new(void) {
     return d;
 }
 
+static void Consts_FrameDict_set_(Consts_FrameDict* d, const char* key, void* value, int owned);
 static void Consts_FrameDict_set(Consts_FrameDict* d, const char* key, void* value) {
+    Consts_FrameDict_set_(d, key, value, 0);
+}
+
+static void Consts_FrameDict_set_owned(Consts_FrameDict* d, const char* key, void* value) {
+    Consts_FrameDict_set_(d, key, value, 1);
+}
+
+static void Consts_FrameDict_set_(Consts_FrameDict* d, const char* key, void* value, int owned) {
     unsigned int idx = Consts_hash_string(key) % d->bucket_count;
     Consts_FrameDictEntry* entry = d->buckets[idx];
     while (entry) {
         if (strcmp(entry->key, key) == 0) {
+            if (entry->owned && entry->value) free(entry->value);
             entry->value = value;
+            entry->owned = owned;
             return;
         }
         entry = entry->next;
     }
     Consts_FrameDictEntry* new_entry = malloc(sizeof(Consts_FrameDictEntry));
-    new_entry->key = strdup(key);
+    new_entry->key = Consts_strdup_(key);
     new_entry->value = value;
+    new_entry->owned = owned;
     new_entry->next = d->buckets[idx];
     d->buckets[idx] = new_entry;
     d->size++;
@@ -88,7 +111,16 @@ static Consts_FrameDict* Consts_FrameDict_copy(Consts_FrameDict* src) {
     for (int i = 0; i < src->bucket_count; i++) {
         Consts_FrameDictEntry* entry = src->buckets[i];
         while (entry) {
-            Consts_FrameDict_set(dst, entry->key, entry->value);
+            if (entry->owned && entry->value) {
+                // Owned values are heap-boxed doubles (#81): deep-copy
+                // so src and dst never alias (a shallow copy would
+                // dangle when either side frees on overwrite/destroy).
+                void* nb = malloc(sizeof(double));
+                memcpy(nb, entry->value, sizeof(double));
+                Consts_FrameDict_set_(dst, entry->key, nb, 1);
+            } else {
+                Consts_FrameDict_set_(dst, entry->key, entry->value, 0);
+            }
             entry = entry->next;
         }
     }
@@ -100,6 +132,7 @@ static void Consts_FrameDict_destroy(Consts_FrameDict* d) {
         Consts_FrameDictEntry* entry = d->buckets[i];
         while (entry) {
             Consts_FrameDictEntry* next = entry->next;
+            if (entry->owned && entry->value) free(entry->value);
             free(entry->key);
             free(entry);
             entry = next;
@@ -115,6 +148,10 @@ static void Consts_FrameDict_destroy(Consts_FrameDict* d) {
 
 typedef struct {
     void** items;
+    // owned[i] == 1 when items[i] is a heap box this vec owns (a
+    // malloc'd double from pack_double — #81): freed in destroy,
+    // deep-copied by FrameVec_copy.
+    unsigned char* owned;
     int size;
     int capacity;
 } Consts_FrameVec;
@@ -124,15 +161,48 @@ static Consts_FrameVec* Consts_FrameVec_new(void) {
     v->capacity = 8;
     v->size = 0;
     v->items = malloc(sizeof(void*) * v->capacity);
+    v->owned = calloc(v->capacity, 1);
     return v;
 }
 
-static void Consts_FrameVec_push(Consts_FrameVec* v, void* item) {
+static void Consts_FrameVec_push_(Consts_FrameVec* v, void* item, unsigned char owned) {
     if (v->size >= v->capacity) {
         v->capacity *= 2;
         v->items = realloc(v->items, sizeof(void*) * v->capacity);
+        v->owned = realloc(v->owned, v->capacity);
+        memset(v->owned + v->size, 0, v->capacity - v->size);
     }
+    v->owned[v->size] = owned;
     v->items[v->size++] = item;
+}
+
+static void Consts_FrameVec_push(Consts_FrameVec* v, void* item) {
+    Consts_FrameVec_push_(v, item, 0);
+}
+
+static void Consts_FrameVec_push_owned(Consts_FrameVec* v, void* item) {
+    Consts_FrameVec_push_(v, item, 1);
+}
+
+static void Consts_FrameVec_clear(Consts_FrameVec* v) {
+    if (!v) return;
+    for (int i = 0; i < v->size; i++) {
+        if (v->owned[i] && v->items[i]) free(v->items[i]);
+    }
+    v->size = 0;
+}
+
+static void Consts_FrameVec_extend(Consts_FrameVec* dst, Consts_FrameVec* src) {
+    if (!src) return;
+    for (int i = 0; i < src->size; i++) {
+        if (src->owned[i] && src->items[i]) {
+            void* nb = malloc(sizeof(double));
+            memcpy(nb, src->items[i], sizeof(double));
+            Consts_FrameVec_push_(dst, nb, 1);
+        } else {
+            Consts_FrameVec_push_(dst, src->items[i], 0);
+        }
+    }
 }
 
 static void* Consts_FrameVec_pop(Consts_FrameVec* v) {
@@ -156,6 +226,10 @@ static int Consts_FrameVec_size(Consts_FrameVec* v) {
 
 static void Consts_FrameVec_destroy(Consts_FrameVec* v) {
     if (!v) return;
+    for (int i = 0; i < v->size; i++) {
+        if (v->owned[i] && v->items[i]) free(v->items[i]);
+    }
+    free(v->owned);
     free(v->items);
     free(v);
 }
@@ -163,26 +237,23 @@ static void Consts_FrameVec_destroy(Consts_FrameVec* v) {
 static Consts_FrameVec* Consts_FrameVec_copy(Consts_FrameVec* src) {
     if (!src) return NULL;
     Consts_FrameVec* v = Consts_FrameVec_new();
-    for (int i = 0; i < src->size; i++) {
-        Consts_FrameVec_push(v, src->items[i]);
-    }
+    Consts_FrameVec_extend(v, src);
     return v;
 }
 
 // ============================================================================
-// Consts_pack_double / Consts_unpack_double — bit-pun doubles through void*
+// Consts_pack_double / Consts_unpack_double — heap-boxed doubles (#81:
+// pointer-width independent; the old void* bit-pun overflowed on 32-bit)
 // ============================================================================
 
 static inline void* Consts_pack_double(double v) {
-    void* p = 0;
-    memcpy(&p, &v, sizeof(double));
-    return p;
+    double* p = (double*)malloc(sizeof(double));
+    *p = v;
+    return (void*)p;
 }
 
 static inline double Consts_unpack_double(void* p) {
-    double d;
-    memcpy(&d, &p, sizeof(double));
-    return d;
+    return p ? *(double*)p : 0.0;
 }
 
 // ============================================================================
@@ -389,12 +460,10 @@ static Consts_Compartment* Consts_prepareEnter(Consts* self, const char* leaf, C
     Consts_Compartment* comp = NULL;
     for (int i = 0; i < n; i++) {
         Consts_Compartment* nc = Consts_Compartment_new(chain[i]);
-        if (state_args) {
-            for (int j = 0; j < state_args->size; j++) Consts_FrameVec_push(nc->state_args, state_args->items[j]);
-        }
-        if (enter_args) {
-            for (int j = 0; j < enter_args->size; j++) Consts_FrameVec_push(nc->enter_args, enter_args->items[j]);
-        }
+        // FrameVec_extend deep-copies vec-owned heap boxes (#81: doubles)
+        // so the caller can destroy its arg vecs after this returns.
+        Consts_FrameVec_extend(nc->state_args, state_args);
+        Consts_FrameVec_extend(nc->enter_args, enter_args);
         nc->parent_compartment = comp;  // adopts ref
         comp = nc;
     }
@@ -404,11 +473,10 @@ static Consts_Compartment* Consts_prepareEnter(Consts* self, const char* leaf, C
 static void Consts_prepareExit(Consts* self, Consts_FrameVec* exit_args) {
     Consts_Compartment* comp = self->__compartment;
     while (comp != NULL) {
-        // Clear any prior exit_args before copying the new ones in.
-        while (comp->exit_args->size > 0) comp->exit_args->size--;
-        if (exit_args) {
-            for (int j = 0; j < exit_args->size; j++) Consts_FrameVec_push(comp->exit_args, exit_args->items[j]);
-        }
+        // Clear any prior exit_args (freeing vec-owned boxes, #81) before
+        // copying the new ones in; extend deep-copies owned entries.
+        Consts_FrameVec_clear(comp->exit_args);
+        Consts_FrameVec_extend(comp->exit_args, exit_args);
         comp = comp->parent_compartment;
     }
 }

--- a/framec/tests/snapshots/c_snapshots__forward.snap
+++ b/framec/tests/snapshots/c_snapshots__forward.snap
@@ -12,9 +12,20 @@ expression: "compile_fixture(\"07_forward\", \"c\")"
 // Forward_FrameDict - String-keyed dictionary
 // ============================================================================
 
+static char* Forward_strdup_(const char* s) {
+    size_t n = strlen(s) + 1;
+    char* p = (char*)malloc(n);
+    memcpy(p, s, n);
+    return p;
+}
+
 typedef struct Forward_FrameDictEntry {
     char* key;
     void* value;
+    // 1 when `value` is a heap box this dict owns (a malloc'd
+    // double from pack_double — #81): freed on overwrite and in
+    // destroy, deep-copied by FrameDict_copy.
+    int owned;
     struct Forward_FrameDictEntry* next;
 } Forward_FrameDictEntry;
 
@@ -41,19 +52,31 @@ static Forward_FrameDict* Forward_FrameDict_new(void) {
     return d;
 }
 
+static void Forward_FrameDict_set_(Forward_FrameDict* d, const char* key, void* value, int owned);
 static void Forward_FrameDict_set(Forward_FrameDict* d, const char* key, void* value) {
+    Forward_FrameDict_set_(d, key, value, 0);
+}
+
+static void Forward_FrameDict_set_owned(Forward_FrameDict* d, const char* key, void* value) {
+    Forward_FrameDict_set_(d, key, value, 1);
+}
+
+static void Forward_FrameDict_set_(Forward_FrameDict* d, const char* key, void* value, int owned) {
     unsigned int idx = Forward_hash_string(key) % d->bucket_count;
     Forward_FrameDictEntry* entry = d->buckets[idx];
     while (entry) {
         if (strcmp(entry->key, key) == 0) {
+            if (entry->owned && entry->value) free(entry->value);
             entry->value = value;
+            entry->owned = owned;
             return;
         }
         entry = entry->next;
     }
     Forward_FrameDictEntry* new_entry = malloc(sizeof(Forward_FrameDictEntry));
-    new_entry->key = strdup(key);
+    new_entry->key = Forward_strdup_(key);
     new_entry->value = value;
+    new_entry->owned = owned;
     new_entry->next = d->buckets[idx];
     d->buckets[idx] = new_entry;
     d->size++;
@@ -88,7 +111,16 @@ static Forward_FrameDict* Forward_FrameDict_copy(Forward_FrameDict* src) {
     for (int i = 0; i < src->bucket_count; i++) {
         Forward_FrameDictEntry* entry = src->buckets[i];
         while (entry) {
-            Forward_FrameDict_set(dst, entry->key, entry->value);
+            if (entry->owned && entry->value) {
+                // Owned values are heap-boxed doubles (#81): deep-copy
+                // so src and dst never alias (a shallow copy would
+                // dangle when either side frees on overwrite/destroy).
+                void* nb = malloc(sizeof(double));
+                memcpy(nb, entry->value, sizeof(double));
+                Forward_FrameDict_set_(dst, entry->key, nb, 1);
+            } else {
+                Forward_FrameDict_set_(dst, entry->key, entry->value, 0);
+            }
             entry = entry->next;
         }
     }
@@ -100,6 +132,7 @@ static void Forward_FrameDict_destroy(Forward_FrameDict* d) {
         Forward_FrameDictEntry* entry = d->buckets[i];
         while (entry) {
             Forward_FrameDictEntry* next = entry->next;
+            if (entry->owned && entry->value) free(entry->value);
             free(entry->key);
             free(entry);
             entry = next;
@@ -115,6 +148,10 @@ static void Forward_FrameDict_destroy(Forward_FrameDict* d) {
 
 typedef struct {
     void** items;
+    // owned[i] == 1 when items[i] is a heap box this vec owns (a
+    // malloc'd double from pack_double — #81): freed in destroy,
+    // deep-copied by FrameVec_copy.
+    unsigned char* owned;
     int size;
     int capacity;
 } Forward_FrameVec;
@@ -124,15 +161,48 @@ static Forward_FrameVec* Forward_FrameVec_new(void) {
     v->capacity = 8;
     v->size = 0;
     v->items = malloc(sizeof(void*) * v->capacity);
+    v->owned = calloc(v->capacity, 1);
     return v;
 }
 
-static void Forward_FrameVec_push(Forward_FrameVec* v, void* item) {
+static void Forward_FrameVec_push_(Forward_FrameVec* v, void* item, unsigned char owned) {
     if (v->size >= v->capacity) {
         v->capacity *= 2;
         v->items = realloc(v->items, sizeof(void*) * v->capacity);
+        v->owned = realloc(v->owned, v->capacity);
+        memset(v->owned + v->size, 0, v->capacity - v->size);
     }
+    v->owned[v->size] = owned;
     v->items[v->size++] = item;
+}
+
+static void Forward_FrameVec_push(Forward_FrameVec* v, void* item) {
+    Forward_FrameVec_push_(v, item, 0);
+}
+
+static void Forward_FrameVec_push_owned(Forward_FrameVec* v, void* item) {
+    Forward_FrameVec_push_(v, item, 1);
+}
+
+static void Forward_FrameVec_clear(Forward_FrameVec* v) {
+    if (!v) return;
+    for (int i = 0; i < v->size; i++) {
+        if (v->owned[i] && v->items[i]) free(v->items[i]);
+    }
+    v->size = 0;
+}
+
+static void Forward_FrameVec_extend(Forward_FrameVec* dst, Forward_FrameVec* src) {
+    if (!src) return;
+    for (int i = 0; i < src->size; i++) {
+        if (src->owned[i] && src->items[i]) {
+            void* nb = malloc(sizeof(double));
+            memcpy(nb, src->items[i], sizeof(double));
+            Forward_FrameVec_push_(dst, nb, 1);
+        } else {
+            Forward_FrameVec_push_(dst, src->items[i], 0);
+        }
+    }
 }
 
 static void* Forward_FrameVec_pop(Forward_FrameVec* v) {
@@ -156,6 +226,10 @@ static int Forward_FrameVec_size(Forward_FrameVec* v) {
 
 static void Forward_FrameVec_destroy(Forward_FrameVec* v) {
     if (!v) return;
+    for (int i = 0; i < v->size; i++) {
+        if (v->owned[i] && v->items[i]) free(v->items[i]);
+    }
+    free(v->owned);
     free(v->items);
     free(v);
 }
@@ -163,26 +237,23 @@ static void Forward_FrameVec_destroy(Forward_FrameVec* v) {
 static Forward_FrameVec* Forward_FrameVec_copy(Forward_FrameVec* src) {
     if (!src) return NULL;
     Forward_FrameVec* v = Forward_FrameVec_new();
-    for (int i = 0; i < src->size; i++) {
-        Forward_FrameVec_push(v, src->items[i]);
-    }
+    Forward_FrameVec_extend(v, src);
     return v;
 }
 
 // ============================================================================
-// Forward_pack_double / Forward_unpack_double — bit-pun doubles through void*
+// Forward_pack_double / Forward_unpack_double — heap-boxed doubles (#81:
+// pointer-width independent; the old void* bit-pun overflowed on 32-bit)
 // ============================================================================
 
 static inline void* Forward_pack_double(double v) {
-    void* p = 0;
-    memcpy(&p, &v, sizeof(double));
-    return p;
+    double* p = (double*)malloc(sizeof(double));
+    *p = v;
+    return (void*)p;
 }
 
 static inline double Forward_unpack_double(void* p) {
-    double d;
-    memcpy(&d, &p, sizeof(double));
-    return d;
+    return p ? *(double*)p : 0.0;
 }
 
 // ============================================================================
@@ -400,12 +471,10 @@ static Forward_Compartment* Forward_prepareEnter(Forward* self, const char* leaf
     Forward_Compartment* comp = NULL;
     for (int i = 0; i < n; i++) {
         Forward_Compartment* nc = Forward_Compartment_new(chain[i]);
-        if (state_args) {
-            for (int j = 0; j < state_args->size; j++) Forward_FrameVec_push(nc->state_args, state_args->items[j]);
-        }
-        if (enter_args) {
-            for (int j = 0; j < enter_args->size; j++) Forward_FrameVec_push(nc->enter_args, enter_args->items[j]);
-        }
+        // FrameVec_extend deep-copies vec-owned heap boxes (#81: doubles)
+        // so the caller can destroy its arg vecs after this returns.
+        Forward_FrameVec_extend(nc->state_args, state_args);
+        Forward_FrameVec_extend(nc->enter_args, enter_args);
         nc->parent_compartment = comp;  // adopts ref
         comp = nc;
     }
@@ -415,11 +484,10 @@ static Forward_Compartment* Forward_prepareEnter(Forward* self, const char* leaf
 static void Forward_prepareExit(Forward* self, Forward_FrameVec* exit_args) {
     Forward_Compartment* comp = self->__compartment;
     while (comp != NULL) {
-        // Clear any prior exit_args before copying the new ones in.
-        while (comp->exit_args->size > 0) comp->exit_args->size--;
-        if (exit_args) {
-            for (int j = 0; j < exit_args->size; j++) Forward_FrameVec_push(comp->exit_args, exit_args->items[j]);
-        }
+        // Clear any prior exit_args (freeing vec-owned boxes, #81) before
+        // copying the new ones in; extend deep-copies owned entries.
+        Forward_FrameVec_clear(comp->exit_args);
+        Forward_FrameVec_extend(comp->exit_args, exit_args);
         comp = comp->parent_compartment;
     }
 }

--- a/framec/tests/snapshots/c_snapshots__hsm.snap
+++ b/framec/tests/snapshots/c_snapshots__hsm.snap
@@ -12,9 +12,20 @@ expression: "compile_fixture(\"02_hsm\", \"c\")"
 // MiniHsm_FrameDict - String-keyed dictionary
 // ============================================================================
 
+static char* MiniHsm_strdup_(const char* s) {
+    size_t n = strlen(s) + 1;
+    char* p = (char*)malloc(n);
+    memcpy(p, s, n);
+    return p;
+}
+
 typedef struct MiniHsm_FrameDictEntry {
     char* key;
     void* value;
+    // 1 when `value` is a heap box this dict owns (a malloc'd
+    // double from pack_double — #81): freed on overwrite and in
+    // destroy, deep-copied by FrameDict_copy.
+    int owned;
     struct MiniHsm_FrameDictEntry* next;
 } MiniHsm_FrameDictEntry;
 
@@ -41,19 +52,31 @@ static MiniHsm_FrameDict* MiniHsm_FrameDict_new(void) {
     return d;
 }
 
+static void MiniHsm_FrameDict_set_(MiniHsm_FrameDict* d, const char* key, void* value, int owned);
 static void MiniHsm_FrameDict_set(MiniHsm_FrameDict* d, const char* key, void* value) {
+    MiniHsm_FrameDict_set_(d, key, value, 0);
+}
+
+static void MiniHsm_FrameDict_set_owned(MiniHsm_FrameDict* d, const char* key, void* value) {
+    MiniHsm_FrameDict_set_(d, key, value, 1);
+}
+
+static void MiniHsm_FrameDict_set_(MiniHsm_FrameDict* d, const char* key, void* value, int owned) {
     unsigned int idx = MiniHsm_hash_string(key) % d->bucket_count;
     MiniHsm_FrameDictEntry* entry = d->buckets[idx];
     while (entry) {
         if (strcmp(entry->key, key) == 0) {
+            if (entry->owned && entry->value) free(entry->value);
             entry->value = value;
+            entry->owned = owned;
             return;
         }
         entry = entry->next;
     }
     MiniHsm_FrameDictEntry* new_entry = malloc(sizeof(MiniHsm_FrameDictEntry));
-    new_entry->key = strdup(key);
+    new_entry->key = MiniHsm_strdup_(key);
     new_entry->value = value;
+    new_entry->owned = owned;
     new_entry->next = d->buckets[idx];
     d->buckets[idx] = new_entry;
     d->size++;
@@ -88,7 +111,16 @@ static MiniHsm_FrameDict* MiniHsm_FrameDict_copy(MiniHsm_FrameDict* src) {
     for (int i = 0; i < src->bucket_count; i++) {
         MiniHsm_FrameDictEntry* entry = src->buckets[i];
         while (entry) {
-            MiniHsm_FrameDict_set(dst, entry->key, entry->value);
+            if (entry->owned && entry->value) {
+                // Owned values are heap-boxed doubles (#81): deep-copy
+                // so src and dst never alias (a shallow copy would
+                // dangle when either side frees on overwrite/destroy).
+                void* nb = malloc(sizeof(double));
+                memcpy(nb, entry->value, sizeof(double));
+                MiniHsm_FrameDict_set_(dst, entry->key, nb, 1);
+            } else {
+                MiniHsm_FrameDict_set_(dst, entry->key, entry->value, 0);
+            }
             entry = entry->next;
         }
     }
@@ -100,6 +132,7 @@ static void MiniHsm_FrameDict_destroy(MiniHsm_FrameDict* d) {
         MiniHsm_FrameDictEntry* entry = d->buckets[i];
         while (entry) {
             MiniHsm_FrameDictEntry* next = entry->next;
+            if (entry->owned && entry->value) free(entry->value);
             free(entry->key);
             free(entry);
             entry = next;
@@ -115,6 +148,10 @@ static void MiniHsm_FrameDict_destroy(MiniHsm_FrameDict* d) {
 
 typedef struct {
     void** items;
+    // owned[i] == 1 when items[i] is a heap box this vec owns (a
+    // malloc'd double from pack_double — #81): freed in destroy,
+    // deep-copied by FrameVec_copy.
+    unsigned char* owned;
     int size;
     int capacity;
 } MiniHsm_FrameVec;
@@ -124,15 +161,48 @@ static MiniHsm_FrameVec* MiniHsm_FrameVec_new(void) {
     v->capacity = 8;
     v->size = 0;
     v->items = malloc(sizeof(void*) * v->capacity);
+    v->owned = calloc(v->capacity, 1);
     return v;
 }
 
-static void MiniHsm_FrameVec_push(MiniHsm_FrameVec* v, void* item) {
+static void MiniHsm_FrameVec_push_(MiniHsm_FrameVec* v, void* item, unsigned char owned) {
     if (v->size >= v->capacity) {
         v->capacity *= 2;
         v->items = realloc(v->items, sizeof(void*) * v->capacity);
+        v->owned = realloc(v->owned, v->capacity);
+        memset(v->owned + v->size, 0, v->capacity - v->size);
     }
+    v->owned[v->size] = owned;
     v->items[v->size++] = item;
+}
+
+static void MiniHsm_FrameVec_push(MiniHsm_FrameVec* v, void* item) {
+    MiniHsm_FrameVec_push_(v, item, 0);
+}
+
+static void MiniHsm_FrameVec_push_owned(MiniHsm_FrameVec* v, void* item) {
+    MiniHsm_FrameVec_push_(v, item, 1);
+}
+
+static void MiniHsm_FrameVec_clear(MiniHsm_FrameVec* v) {
+    if (!v) return;
+    for (int i = 0; i < v->size; i++) {
+        if (v->owned[i] && v->items[i]) free(v->items[i]);
+    }
+    v->size = 0;
+}
+
+static void MiniHsm_FrameVec_extend(MiniHsm_FrameVec* dst, MiniHsm_FrameVec* src) {
+    if (!src) return;
+    for (int i = 0; i < src->size; i++) {
+        if (src->owned[i] && src->items[i]) {
+            void* nb = malloc(sizeof(double));
+            memcpy(nb, src->items[i], sizeof(double));
+            MiniHsm_FrameVec_push_(dst, nb, 1);
+        } else {
+            MiniHsm_FrameVec_push_(dst, src->items[i], 0);
+        }
+    }
 }
 
 static void* MiniHsm_FrameVec_pop(MiniHsm_FrameVec* v) {
@@ -156,6 +226,10 @@ static int MiniHsm_FrameVec_size(MiniHsm_FrameVec* v) {
 
 static void MiniHsm_FrameVec_destroy(MiniHsm_FrameVec* v) {
     if (!v) return;
+    for (int i = 0; i < v->size; i++) {
+        if (v->owned[i] && v->items[i]) free(v->items[i]);
+    }
+    free(v->owned);
     free(v->items);
     free(v);
 }
@@ -163,26 +237,23 @@ static void MiniHsm_FrameVec_destroy(MiniHsm_FrameVec* v) {
 static MiniHsm_FrameVec* MiniHsm_FrameVec_copy(MiniHsm_FrameVec* src) {
     if (!src) return NULL;
     MiniHsm_FrameVec* v = MiniHsm_FrameVec_new();
-    for (int i = 0; i < src->size; i++) {
-        MiniHsm_FrameVec_push(v, src->items[i]);
-    }
+    MiniHsm_FrameVec_extend(v, src);
     return v;
 }
 
 // ============================================================================
-// MiniHsm_pack_double / MiniHsm_unpack_double — bit-pun doubles through void*
+// MiniHsm_pack_double / MiniHsm_unpack_double — heap-boxed doubles (#81:
+// pointer-width independent; the old void* bit-pun overflowed on 32-bit)
 // ============================================================================
 
 static inline void* MiniHsm_pack_double(double v) {
-    void* p = 0;
-    memcpy(&p, &v, sizeof(double));
-    return p;
+    double* p = (double*)malloc(sizeof(double));
+    *p = v;
+    return (void*)p;
 }
 
 static inline double MiniHsm_unpack_double(void* p) {
-    double d;
-    memcpy(&d, &p, sizeof(double));
-    return d;
+    return p ? *(double*)p : 0.0;
 }
 
 // ============================================================================
@@ -408,12 +479,10 @@ static MiniHsm_Compartment* MiniHsm_prepareEnter(MiniHsm* self, const char* leaf
     MiniHsm_Compartment* comp = NULL;
     for (int i = 0; i < n; i++) {
         MiniHsm_Compartment* nc = MiniHsm_Compartment_new(chain[i]);
-        if (state_args) {
-            for (int j = 0; j < state_args->size; j++) MiniHsm_FrameVec_push(nc->state_args, state_args->items[j]);
-        }
-        if (enter_args) {
-            for (int j = 0; j < enter_args->size; j++) MiniHsm_FrameVec_push(nc->enter_args, enter_args->items[j]);
-        }
+        // FrameVec_extend deep-copies vec-owned heap boxes (#81: doubles)
+        // so the caller can destroy its arg vecs after this returns.
+        MiniHsm_FrameVec_extend(nc->state_args, state_args);
+        MiniHsm_FrameVec_extend(nc->enter_args, enter_args);
         nc->parent_compartment = comp;  // adopts ref
         comp = nc;
     }
@@ -423,11 +492,10 @@ static MiniHsm_Compartment* MiniHsm_prepareEnter(MiniHsm* self, const char* leaf
 static void MiniHsm_prepareExit(MiniHsm* self, MiniHsm_FrameVec* exit_args) {
     MiniHsm_Compartment* comp = self->__compartment;
     while (comp != NULL) {
-        // Clear any prior exit_args before copying the new ones in.
-        while (comp->exit_args->size > 0) comp->exit_args->size--;
-        if (exit_args) {
-            for (int j = 0; j < exit_args->size; j++) MiniHsm_FrameVec_push(comp->exit_args, exit_args->items[j]);
-        }
+        // Clear any prior exit_args (freeing vec-owned boxes, #81) before
+        // copying the new ones in; extend deep-copies owned entries.
+        MiniHsm_FrameVec_clear(comp->exit_args);
+        MiniHsm_FrameVec_extend(comp->exit_args, exit_args);
         comp = comp->parent_compartment;
     }
 }

--- a/framec/tests/snapshots/c_snapshots__lifecycle.snap
+++ b/framec/tests/snapshots/c_snapshots__lifecycle.snap
@@ -12,9 +12,20 @@ expression: "compile_fixture(\"08_lifecycle\", \"c\")"
 // Lifecycle_FrameDict - String-keyed dictionary
 // ============================================================================
 
+static char* Lifecycle_strdup_(const char* s) {
+    size_t n = strlen(s) + 1;
+    char* p = (char*)malloc(n);
+    memcpy(p, s, n);
+    return p;
+}
+
 typedef struct Lifecycle_FrameDictEntry {
     char* key;
     void* value;
+    // 1 when `value` is a heap box this dict owns (a malloc'd
+    // double from pack_double — #81): freed on overwrite and in
+    // destroy, deep-copied by FrameDict_copy.
+    int owned;
     struct Lifecycle_FrameDictEntry* next;
 } Lifecycle_FrameDictEntry;
 
@@ -41,19 +52,31 @@ static Lifecycle_FrameDict* Lifecycle_FrameDict_new(void) {
     return d;
 }
 
+static void Lifecycle_FrameDict_set_(Lifecycle_FrameDict* d, const char* key, void* value, int owned);
 static void Lifecycle_FrameDict_set(Lifecycle_FrameDict* d, const char* key, void* value) {
+    Lifecycle_FrameDict_set_(d, key, value, 0);
+}
+
+static void Lifecycle_FrameDict_set_owned(Lifecycle_FrameDict* d, const char* key, void* value) {
+    Lifecycle_FrameDict_set_(d, key, value, 1);
+}
+
+static void Lifecycle_FrameDict_set_(Lifecycle_FrameDict* d, const char* key, void* value, int owned) {
     unsigned int idx = Lifecycle_hash_string(key) % d->bucket_count;
     Lifecycle_FrameDictEntry* entry = d->buckets[idx];
     while (entry) {
         if (strcmp(entry->key, key) == 0) {
+            if (entry->owned && entry->value) free(entry->value);
             entry->value = value;
+            entry->owned = owned;
             return;
         }
         entry = entry->next;
     }
     Lifecycle_FrameDictEntry* new_entry = malloc(sizeof(Lifecycle_FrameDictEntry));
-    new_entry->key = strdup(key);
+    new_entry->key = Lifecycle_strdup_(key);
     new_entry->value = value;
+    new_entry->owned = owned;
     new_entry->next = d->buckets[idx];
     d->buckets[idx] = new_entry;
     d->size++;
@@ -88,7 +111,16 @@ static Lifecycle_FrameDict* Lifecycle_FrameDict_copy(Lifecycle_FrameDict* src) {
     for (int i = 0; i < src->bucket_count; i++) {
         Lifecycle_FrameDictEntry* entry = src->buckets[i];
         while (entry) {
-            Lifecycle_FrameDict_set(dst, entry->key, entry->value);
+            if (entry->owned && entry->value) {
+                // Owned values are heap-boxed doubles (#81): deep-copy
+                // so src and dst never alias (a shallow copy would
+                // dangle when either side frees on overwrite/destroy).
+                void* nb = malloc(sizeof(double));
+                memcpy(nb, entry->value, sizeof(double));
+                Lifecycle_FrameDict_set_(dst, entry->key, nb, 1);
+            } else {
+                Lifecycle_FrameDict_set_(dst, entry->key, entry->value, 0);
+            }
             entry = entry->next;
         }
     }
@@ -100,6 +132,7 @@ static void Lifecycle_FrameDict_destroy(Lifecycle_FrameDict* d) {
         Lifecycle_FrameDictEntry* entry = d->buckets[i];
         while (entry) {
             Lifecycle_FrameDictEntry* next = entry->next;
+            if (entry->owned && entry->value) free(entry->value);
             free(entry->key);
             free(entry);
             entry = next;
@@ -115,6 +148,10 @@ static void Lifecycle_FrameDict_destroy(Lifecycle_FrameDict* d) {
 
 typedef struct {
     void** items;
+    // owned[i] == 1 when items[i] is a heap box this vec owns (a
+    // malloc'd double from pack_double — #81): freed in destroy,
+    // deep-copied by FrameVec_copy.
+    unsigned char* owned;
     int size;
     int capacity;
 } Lifecycle_FrameVec;
@@ -124,15 +161,48 @@ static Lifecycle_FrameVec* Lifecycle_FrameVec_new(void) {
     v->capacity = 8;
     v->size = 0;
     v->items = malloc(sizeof(void*) * v->capacity);
+    v->owned = calloc(v->capacity, 1);
     return v;
 }
 
-static void Lifecycle_FrameVec_push(Lifecycle_FrameVec* v, void* item) {
+static void Lifecycle_FrameVec_push_(Lifecycle_FrameVec* v, void* item, unsigned char owned) {
     if (v->size >= v->capacity) {
         v->capacity *= 2;
         v->items = realloc(v->items, sizeof(void*) * v->capacity);
+        v->owned = realloc(v->owned, v->capacity);
+        memset(v->owned + v->size, 0, v->capacity - v->size);
     }
+    v->owned[v->size] = owned;
     v->items[v->size++] = item;
+}
+
+static void Lifecycle_FrameVec_push(Lifecycle_FrameVec* v, void* item) {
+    Lifecycle_FrameVec_push_(v, item, 0);
+}
+
+static void Lifecycle_FrameVec_push_owned(Lifecycle_FrameVec* v, void* item) {
+    Lifecycle_FrameVec_push_(v, item, 1);
+}
+
+static void Lifecycle_FrameVec_clear(Lifecycle_FrameVec* v) {
+    if (!v) return;
+    for (int i = 0; i < v->size; i++) {
+        if (v->owned[i] && v->items[i]) free(v->items[i]);
+    }
+    v->size = 0;
+}
+
+static void Lifecycle_FrameVec_extend(Lifecycle_FrameVec* dst, Lifecycle_FrameVec* src) {
+    if (!src) return;
+    for (int i = 0; i < src->size; i++) {
+        if (src->owned[i] && src->items[i]) {
+            void* nb = malloc(sizeof(double));
+            memcpy(nb, src->items[i], sizeof(double));
+            Lifecycle_FrameVec_push_(dst, nb, 1);
+        } else {
+            Lifecycle_FrameVec_push_(dst, src->items[i], 0);
+        }
+    }
 }
 
 static void* Lifecycle_FrameVec_pop(Lifecycle_FrameVec* v) {
@@ -156,6 +226,10 @@ static int Lifecycle_FrameVec_size(Lifecycle_FrameVec* v) {
 
 static void Lifecycle_FrameVec_destroy(Lifecycle_FrameVec* v) {
     if (!v) return;
+    for (int i = 0; i < v->size; i++) {
+        if (v->owned[i] && v->items[i]) free(v->items[i]);
+    }
+    free(v->owned);
     free(v->items);
     free(v);
 }
@@ -163,26 +237,23 @@ static void Lifecycle_FrameVec_destroy(Lifecycle_FrameVec* v) {
 static Lifecycle_FrameVec* Lifecycle_FrameVec_copy(Lifecycle_FrameVec* src) {
     if (!src) return NULL;
     Lifecycle_FrameVec* v = Lifecycle_FrameVec_new();
-    for (int i = 0; i < src->size; i++) {
-        Lifecycle_FrameVec_push(v, src->items[i]);
-    }
+    Lifecycle_FrameVec_extend(v, src);
     return v;
 }
 
 // ============================================================================
-// Lifecycle_pack_double / Lifecycle_unpack_double — bit-pun doubles through void*
+// Lifecycle_pack_double / Lifecycle_unpack_double — heap-boxed doubles (#81:
+// pointer-width independent; the old void* bit-pun overflowed on 32-bit)
 // ============================================================================
 
 static inline void* Lifecycle_pack_double(double v) {
-    void* p = 0;
-    memcpy(&p, &v, sizeof(double));
-    return p;
+    double* p = (double*)malloc(sizeof(double));
+    *p = v;
+    return (void*)p;
 }
 
 static inline double Lifecycle_unpack_double(void* p) {
-    double d;
-    memcpy(&d, &p, sizeof(double));
-    return d;
+    return p ? *(double*)p : 0.0;
 }
 
 // ============================================================================
@@ -397,12 +468,10 @@ static Lifecycle_Compartment* Lifecycle_prepareEnter(Lifecycle* self, const char
     Lifecycle_Compartment* comp = NULL;
     for (int i = 0; i < n; i++) {
         Lifecycle_Compartment* nc = Lifecycle_Compartment_new(chain[i]);
-        if (state_args) {
-            for (int j = 0; j < state_args->size; j++) Lifecycle_FrameVec_push(nc->state_args, state_args->items[j]);
-        }
-        if (enter_args) {
-            for (int j = 0; j < enter_args->size; j++) Lifecycle_FrameVec_push(nc->enter_args, enter_args->items[j]);
-        }
+        // FrameVec_extend deep-copies vec-owned heap boxes (#81: doubles)
+        // so the caller can destroy its arg vecs after this returns.
+        Lifecycle_FrameVec_extend(nc->state_args, state_args);
+        Lifecycle_FrameVec_extend(nc->enter_args, enter_args);
         nc->parent_compartment = comp;  // adopts ref
         comp = nc;
     }
@@ -412,11 +481,10 @@ static Lifecycle_Compartment* Lifecycle_prepareEnter(Lifecycle* self, const char
 static void Lifecycle_prepareExit(Lifecycle* self, Lifecycle_FrameVec* exit_args) {
     Lifecycle_Compartment* comp = self->__compartment;
     while (comp != NULL) {
-        // Clear any prior exit_args before copying the new ones in.
-        while (comp->exit_args->size > 0) comp->exit_args->size--;
-        if (exit_args) {
-            for (int j = 0; j < exit_args->size; j++) Lifecycle_FrameVec_push(comp->exit_args, exit_args->items[j]);
-        }
+        // Clear any prior exit_args (freeing vec-owned boxes, #81) before
+        // copying the new ones in; extend deep-copies owned entries.
+        Lifecycle_FrameVec_clear(comp->exit_args);
+        Lifecycle_FrameVec_extend(comp->exit_args, exit_args);
         comp = comp->parent_compartment;
     }
 }

--- a/framec/tests/snapshots/c_snapshots__lifecycle_args.snap
+++ b/framec/tests/snapshots/c_snapshots__lifecycle_args.snap
@@ -12,9 +12,20 @@ expression: "compile_fixture(\"13_lifecycle_args\", \"c\")"
 // LifecycleArgs_FrameDict - String-keyed dictionary
 // ============================================================================
 
+static char* LifecycleArgs_strdup_(const char* s) {
+    size_t n = strlen(s) + 1;
+    char* p = (char*)malloc(n);
+    memcpy(p, s, n);
+    return p;
+}
+
 typedef struct LifecycleArgs_FrameDictEntry {
     char* key;
     void* value;
+    // 1 when `value` is a heap box this dict owns (a malloc'd
+    // double from pack_double — #81): freed on overwrite and in
+    // destroy, deep-copied by FrameDict_copy.
+    int owned;
     struct LifecycleArgs_FrameDictEntry* next;
 } LifecycleArgs_FrameDictEntry;
 
@@ -41,19 +52,31 @@ static LifecycleArgs_FrameDict* LifecycleArgs_FrameDict_new(void) {
     return d;
 }
 
+static void LifecycleArgs_FrameDict_set_(LifecycleArgs_FrameDict* d, const char* key, void* value, int owned);
 static void LifecycleArgs_FrameDict_set(LifecycleArgs_FrameDict* d, const char* key, void* value) {
+    LifecycleArgs_FrameDict_set_(d, key, value, 0);
+}
+
+static void LifecycleArgs_FrameDict_set_owned(LifecycleArgs_FrameDict* d, const char* key, void* value) {
+    LifecycleArgs_FrameDict_set_(d, key, value, 1);
+}
+
+static void LifecycleArgs_FrameDict_set_(LifecycleArgs_FrameDict* d, const char* key, void* value, int owned) {
     unsigned int idx = LifecycleArgs_hash_string(key) % d->bucket_count;
     LifecycleArgs_FrameDictEntry* entry = d->buckets[idx];
     while (entry) {
         if (strcmp(entry->key, key) == 0) {
+            if (entry->owned && entry->value) free(entry->value);
             entry->value = value;
+            entry->owned = owned;
             return;
         }
         entry = entry->next;
     }
     LifecycleArgs_FrameDictEntry* new_entry = malloc(sizeof(LifecycleArgs_FrameDictEntry));
-    new_entry->key = strdup(key);
+    new_entry->key = LifecycleArgs_strdup_(key);
     new_entry->value = value;
+    new_entry->owned = owned;
     new_entry->next = d->buckets[idx];
     d->buckets[idx] = new_entry;
     d->size++;
@@ -88,7 +111,16 @@ static LifecycleArgs_FrameDict* LifecycleArgs_FrameDict_copy(LifecycleArgs_Frame
     for (int i = 0; i < src->bucket_count; i++) {
         LifecycleArgs_FrameDictEntry* entry = src->buckets[i];
         while (entry) {
-            LifecycleArgs_FrameDict_set(dst, entry->key, entry->value);
+            if (entry->owned && entry->value) {
+                // Owned values are heap-boxed doubles (#81): deep-copy
+                // so src and dst never alias (a shallow copy would
+                // dangle when either side frees on overwrite/destroy).
+                void* nb = malloc(sizeof(double));
+                memcpy(nb, entry->value, sizeof(double));
+                LifecycleArgs_FrameDict_set_(dst, entry->key, nb, 1);
+            } else {
+                LifecycleArgs_FrameDict_set_(dst, entry->key, entry->value, 0);
+            }
             entry = entry->next;
         }
     }
@@ -100,6 +132,7 @@ static void LifecycleArgs_FrameDict_destroy(LifecycleArgs_FrameDict* d) {
         LifecycleArgs_FrameDictEntry* entry = d->buckets[i];
         while (entry) {
             LifecycleArgs_FrameDictEntry* next = entry->next;
+            if (entry->owned && entry->value) free(entry->value);
             free(entry->key);
             free(entry);
             entry = next;
@@ -115,6 +148,10 @@ static void LifecycleArgs_FrameDict_destroy(LifecycleArgs_FrameDict* d) {
 
 typedef struct {
     void** items;
+    // owned[i] == 1 when items[i] is a heap box this vec owns (a
+    // malloc'd double from pack_double — #81): freed in destroy,
+    // deep-copied by FrameVec_copy.
+    unsigned char* owned;
     int size;
     int capacity;
 } LifecycleArgs_FrameVec;
@@ -124,15 +161,48 @@ static LifecycleArgs_FrameVec* LifecycleArgs_FrameVec_new(void) {
     v->capacity = 8;
     v->size = 0;
     v->items = malloc(sizeof(void*) * v->capacity);
+    v->owned = calloc(v->capacity, 1);
     return v;
 }
 
-static void LifecycleArgs_FrameVec_push(LifecycleArgs_FrameVec* v, void* item) {
+static void LifecycleArgs_FrameVec_push_(LifecycleArgs_FrameVec* v, void* item, unsigned char owned) {
     if (v->size >= v->capacity) {
         v->capacity *= 2;
         v->items = realloc(v->items, sizeof(void*) * v->capacity);
+        v->owned = realloc(v->owned, v->capacity);
+        memset(v->owned + v->size, 0, v->capacity - v->size);
     }
+    v->owned[v->size] = owned;
     v->items[v->size++] = item;
+}
+
+static void LifecycleArgs_FrameVec_push(LifecycleArgs_FrameVec* v, void* item) {
+    LifecycleArgs_FrameVec_push_(v, item, 0);
+}
+
+static void LifecycleArgs_FrameVec_push_owned(LifecycleArgs_FrameVec* v, void* item) {
+    LifecycleArgs_FrameVec_push_(v, item, 1);
+}
+
+static void LifecycleArgs_FrameVec_clear(LifecycleArgs_FrameVec* v) {
+    if (!v) return;
+    for (int i = 0; i < v->size; i++) {
+        if (v->owned[i] && v->items[i]) free(v->items[i]);
+    }
+    v->size = 0;
+}
+
+static void LifecycleArgs_FrameVec_extend(LifecycleArgs_FrameVec* dst, LifecycleArgs_FrameVec* src) {
+    if (!src) return;
+    for (int i = 0; i < src->size; i++) {
+        if (src->owned[i] && src->items[i]) {
+            void* nb = malloc(sizeof(double));
+            memcpy(nb, src->items[i], sizeof(double));
+            LifecycleArgs_FrameVec_push_(dst, nb, 1);
+        } else {
+            LifecycleArgs_FrameVec_push_(dst, src->items[i], 0);
+        }
+    }
 }
 
 static void* LifecycleArgs_FrameVec_pop(LifecycleArgs_FrameVec* v) {
@@ -156,6 +226,10 @@ static int LifecycleArgs_FrameVec_size(LifecycleArgs_FrameVec* v) {
 
 static void LifecycleArgs_FrameVec_destroy(LifecycleArgs_FrameVec* v) {
     if (!v) return;
+    for (int i = 0; i < v->size; i++) {
+        if (v->owned[i] && v->items[i]) free(v->items[i]);
+    }
+    free(v->owned);
     free(v->items);
     free(v);
 }
@@ -163,26 +237,23 @@ static void LifecycleArgs_FrameVec_destroy(LifecycleArgs_FrameVec* v) {
 static LifecycleArgs_FrameVec* LifecycleArgs_FrameVec_copy(LifecycleArgs_FrameVec* src) {
     if (!src) return NULL;
     LifecycleArgs_FrameVec* v = LifecycleArgs_FrameVec_new();
-    for (int i = 0; i < src->size; i++) {
-        LifecycleArgs_FrameVec_push(v, src->items[i]);
-    }
+    LifecycleArgs_FrameVec_extend(v, src);
     return v;
 }
 
 // ============================================================================
-// LifecycleArgs_pack_double / LifecycleArgs_unpack_double — bit-pun doubles through void*
+// LifecycleArgs_pack_double / LifecycleArgs_unpack_double — heap-boxed doubles (#81:
+// pointer-width independent; the old void* bit-pun overflowed on 32-bit)
 // ============================================================================
 
 static inline void* LifecycleArgs_pack_double(double v) {
-    void* p = 0;
-    memcpy(&p, &v, sizeof(double));
-    return p;
+    double* p = (double*)malloc(sizeof(double));
+    *p = v;
+    return (void*)p;
 }
 
 static inline double LifecycleArgs_unpack_double(void* p) {
-    double d;
-    memcpy(&d, &p, sizeof(double));
-    return d;
+    return p ? *(double*)p : 0.0;
 }
 
 // ============================================================================
@@ -395,12 +466,10 @@ static LifecycleArgs_Compartment* LifecycleArgs_prepareEnter(LifecycleArgs* self
     LifecycleArgs_Compartment* comp = NULL;
     for (int i = 0; i < n; i++) {
         LifecycleArgs_Compartment* nc = LifecycleArgs_Compartment_new(chain[i]);
-        if (state_args) {
-            for (int j = 0; j < state_args->size; j++) LifecycleArgs_FrameVec_push(nc->state_args, state_args->items[j]);
-        }
-        if (enter_args) {
-            for (int j = 0; j < enter_args->size; j++) LifecycleArgs_FrameVec_push(nc->enter_args, enter_args->items[j]);
-        }
+        // FrameVec_extend deep-copies vec-owned heap boxes (#81: doubles)
+        // so the caller can destroy its arg vecs after this returns.
+        LifecycleArgs_FrameVec_extend(nc->state_args, state_args);
+        LifecycleArgs_FrameVec_extend(nc->enter_args, enter_args);
         nc->parent_compartment = comp;  // adopts ref
         comp = nc;
     }
@@ -410,11 +479,10 @@ static LifecycleArgs_Compartment* LifecycleArgs_prepareEnter(LifecycleArgs* self
 static void LifecycleArgs_prepareExit(LifecycleArgs* self, LifecycleArgs_FrameVec* exit_args) {
     LifecycleArgs_Compartment* comp = self->__compartment;
     while (comp != NULL) {
-        // Clear any prior exit_args before copying the new ones in.
-        while (comp->exit_args->size > 0) comp->exit_args->size--;
-        if (exit_args) {
-            for (int j = 0; j < exit_args->size; j++) LifecycleArgs_FrameVec_push(comp->exit_args, exit_args->items[j]);
-        }
+        // Clear any prior exit_args (freeing vec-owned boxes, #81) before
+        // copying the new ones in; extend deep-copies owned entries.
+        LifecycleArgs_FrameVec_clear(comp->exit_args);
+        LifecycleArgs_FrameVec_extend(comp->exit_args, exit_args);
         comp = comp->parent_compartment;
     }
 }

--- a/framec/tests/snapshots/c_snapshots__linear_fsm.snap
+++ b/framec/tests/snapshots/c_snapshots__linear_fsm.snap
@@ -12,9 +12,20 @@ expression: "compile_fixture(\"01_linear_fsm\", \"c\")"
 // LinearFsm_FrameDict - String-keyed dictionary
 // ============================================================================
 
+static char* LinearFsm_strdup_(const char* s) {
+    size_t n = strlen(s) + 1;
+    char* p = (char*)malloc(n);
+    memcpy(p, s, n);
+    return p;
+}
+
 typedef struct LinearFsm_FrameDictEntry {
     char* key;
     void* value;
+    // 1 when `value` is a heap box this dict owns (a malloc'd
+    // double from pack_double — #81): freed on overwrite and in
+    // destroy, deep-copied by FrameDict_copy.
+    int owned;
     struct LinearFsm_FrameDictEntry* next;
 } LinearFsm_FrameDictEntry;
 
@@ -41,19 +52,31 @@ static LinearFsm_FrameDict* LinearFsm_FrameDict_new(void) {
     return d;
 }
 
+static void LinearFsm_FrameDict_set_(LinearFsm_FrameDict* d, const char* key, void* value, int owned);
 static void LinearFsm_FrameDict_set(LinearFsm_FrameDict* d, const char* key, void* value) {
+    LinearFsm_FrameDict_set_(d, key, value, 0);
+}
+
+static void LinearFsm_FrameDict_set_owned(LinearFsm_FrameDict* d, const char* key, void* value) {
+    LinearFsm_FrameDict_set_(d, key, value, 1);
+}
+
+static void LinearFsm_FrameDict_set_(LinearFsm_FrameDict* d, const char* key, void* value, int owned) {
     unsigned int idx = LinearFsm_hash_string(key) % d->bucket_count;
     LinearFsm_FrameDictEntry* entry = d->buckets[idx];
     while (entry) {
         if (strcmp(entry->key, key) == 0) {
+            if (entry->owned && entry->value) free(entry->value);
             entry->value = value;
+            entry->owned = owned;
             return;
         }
         entry = entry->next;
     }
     LinearFsm_FrameDictEntry* new_entry = malloc(sizeof(LinearFsm_FrameDictEntry));
-    new_entry->key = strdup(key);
+    new_entry->key = LinearFsm_strdup_(key);
     new_entry->value = value;
+    new_entry->owned = owned;
     new_entry->next = d->buckets[idx];
     d->buckets[idx] = new_entry;
     d->size++;
@@ -88,7 +111,16 @@ static LinearFsm_FrameDict* LinearFsm_FrameDict_copy(LinearFsm_FrameDict* src) {
     for (int i = 0; i < src->bucket_count; i++) {
         LinearFsm_FrameDictEntry* entry = src->buckets[i];
         while (entry) {
-            LinearFsm_FrameDict_set(dst, entry->key, entry->value);
+            if (entry->owned && entry->value) {
+                // Owned values are heap-boxed doubles (#81): deep-copy
+                // so src and dst never alias (a shallow copy would
+                // dangle when either side frees on overwrite/destroy).
+                void* nb = malloc(sizeof(double));
+                memcpy(nb, entry->value, sizeof(double));
+                LinearFsm_FrameDict_set_(dst, entry->key, nb, 1);
+            } else {
+                LinearFsm_FrameDict_set_(dst, entry->key, entry->value, 0);
+            }
             entry = entry->next;
         }
     }
@@ -100,6 +132,7 @@ static void LinearFsm_FrameDict_destroy(LinearFsm_FrameDict* d) {
         LinearFsm_FrameDictEntry* entry = d->buckets[i];
         while (entry) {
             LinearFsm_FrameDictEntry* next = entry->next;
+            if (entry->owned && entry->value) free(entry->value);
             free(entry->key);
             free(entry);
             entry = next;
@@ -115,6 +148,10 @@ static void LinearFsm_FrameDict_destroy(LinearFsm_FrameDict* d) {
 
 typedef struct {
     void** items;
+    // owned[i] == 1 when items[i] is a heap box this vec owns (a
+    // malloc'd double from pack_double — #81): freed in destroy,
+    // deep-copied by FrameVec_copy.
+    unsigned char* owned;
     int size;
     int capacity;
 } LinearFsm_FrameVec;
@@ -124,15 +161,48 @@ static LinearFsm_FrameVec* LinearFsm_FrameVec_new(void) {
     v->capacity = 8;
     v->size = 0;
     v->items = malloc(sizeof(void*) * v->capacity);
+    v->owned = calloc(v->capacity, 1);
     return v;
 }
 
-static void LinearFsm_FrameVec_push(LinearFsm_FrameVec* v, void* item) {
+static void LinearFsm_FrameVec_push_(LinearFsm_FrameVec* v, void* item, unsigned char owned) {
     if (v->size >= v->capacity) {
         v->capacity *= 2;
         v->items = realloc(v->items, sizeof(void*) * v->capacity);
+        v->owned = realloc(v->owned, v->capacity);
+        memset(v->owned + v->size, 0, v->capacity - v->size);
     }
+    v->owned[v->size] = owned;
     v->items[v->size++] = item;
+}
+
+static void LinearFsm_FrameVec_push(LinearFsm_FrameVec* v, void* item) {
+    LinearFsm_FrameVec_push_(v, item, 0);
+}
+
+static void LinearFsm_FrameVec_push_owned(LinearFsm_FrameVec* v, void* item) {
+    LinearFsm_FrameVec_push_(v, item, 1);
+}
+
+static void LinearFsm_FrameVec_clear(LinearFsm_FrameVec* v) {
+    if (!v) return;
+    for (int i = 0; i < v->size; i++) {
+        if (v->owned[i] && v->items[i]) free(v->items[i]);
+    }
+    v->size = 0;
+}
+
+static void LinearFsm_FrameVec_extend(LinearFsm_FrameVec* dst, LinearFsm_FrameVec* src) {
+    if (!src) return;
+    for (int i = 0; i < src->size; i++) {
+        if (src->owned[i] && src->items[i]) {
+            void* nb = malloc(sizeof(double));
+            memcpy(nb, src->items[i], sizeof(double));
+            LinearFsm_FrameVec_push_(dst, nb, 1);
+        } else {
+            LinearFsm_FrameVec_push_(dst, src->items[i], 0);
+        }
+    }
 }
 
 static void* LinearFsm_FrameVec_pop(LinearFsm_FrameVec* v) {
@@ -156,6 +226,10 @@ static int LinearFsm_FrameVec_size(LinearFsm_FrameVec* v) {
 
 static void LinearFsm_FrameVec_destroy(LinearFsm_FrameVec* v) {
     if (!v) return;
+    for (int i = 0; i < v->size; i++) {
+        if (v->owned[i] && v->items[i]) free(v->items[i]);
+    }
+    free(v->owned);
     free(v->items);
     free(v);
 }
@@ -163,26 +237,23 @@ static void LinearFsm_FrameVec_destroy(LinearFsm_FrameVec* v) {
 static LinearFsm_FrameVec* LinearFsm_FrameVec_copy(LinearFsm_FrameVec* src) {
     if (!src) return NULL;
     LinearFsm_FrameVec* v = LinearFsm_FrameVec_new();
-    for (int i = 0; i < src->size; i++) {
-        LinearFsm_FrameVec_push(v, src->items[i]);
-    }
+    LinearFsm_FrameVec_extend(v, src);
     return v;
 }
 
 // ============================================================================
-// LinearFsm_pack_double / LinearFsm_unpack_double — bit-pun doubles through void*
+// LinearFsm_pack_double / LinearFsm_unpack_double — heap-boxed doubles (#81:
+// pointer-width independent; the old void* bit-pun overflowed on 32-bit)
 // ============================================================================
 
 static inline void* LinearFsm_pack_double(double v) {
-    void* p = 0;
-    memcpy(&p, &v, sizeof(double));
-    return p;
+    double* p = (double*)malloc(sizeof(double));
+    *p = v;
+    return (void*)p;
 }
 
 static inline double LinearFsm_unpack_double(void* p) {
-    double d;
-    memcpy(&d, &p, sizeof(double));
-    return d;
+    return p ? *(double*)p : 0.0;
 }
 
 // ============================================================================
@@ -397,12 +468,10 @@ static LinearFsm_Compartment* LinearFsm_prepareEnter(LinearFsm* self, const char
     LinearFsm_Compartment* comp = NULL;
     for (int i = 0; i < n; i++) {
         LinearFsm_Compartment* nc = LinearFsm_Compartment_new(chain[i]);
-        if (state_args) {
-            for (int j = 0; j < state_args->size; j++) LinearFsm_FrameVec_push(nc->state_args, state_args->items[j]);
-        }
-        if (enter_args) {
-            for (int j = 0; j < enter_args->size; j++) LinearFsm_FrameVec_push(nc->enter_args, enter_args->items[j]);
-        }
+        // FrameVec_extend deep-copies vec-owned heap boxes (#81: doubles)
+        // so the caller can destroy its arg vecs after this returns.
+        LinearFsm_FrameVec_extend(nc->state_args, state_args);
+        LinearFsm_FrameVec_extend(nc->enter_args, enter_args);
         nc->parent_compartment = comp;  // adopts ref
         comp = nc;
     }
@@ -412,11 +481,10 @@ static LinearFsm_Compartment* LinearFsm_prepareEnter(LinearFsm* self, const char
 static void LinearFsm_prepareExit(LinearFsm* self, LinearFsm_FrameVec* exit_args) {
     LinearFsm_Compartment* comp = self->__compartment;
     while (comp != NULL) {
-        // Clear any prior exit_args before copying the new ones in.
-        while (comp->exit_args->size > 0) comp->exit_args->size--;
-        if (exit_args) {
-            for (int j = 0; j < exit_args->size; j++) LinearFsm_FrameVec_push(comp->exit_args, exit_args->items[j]);
-        }
+        // Clear any prior exit_args (freeing vec-owned boxes, #81) before
+        // copying the new ones in; extend deep-copies owned entries.
+        LinearFsm_FrameVec_clear(comp->exit_args);
+        LinearFsm_FrameVec_extend(comp->exit_args, exit_args);
         comp = comp->parent_compartment;
     }
 }

--- a/framec/tests/snapshots/c_snapshots__no_persist.snap
+++ b/framec/tests/snapshots/c_snapshots__no_persist.snap
@@ -12,9 +12,20 @@ expression: "compile_fixture(\"12_no_persist\", \"c\")"
 // NoPersist_FrameDict - String-keyed dictionary
 // ============================================================================
 
+static char* NoPersist_strdup_(const char* s) {
+    size_t n = strlen(s) + 1;
+    char* p = (char*)malloc(n);
+    memcpy(p, s, n);
+    return p;
+}
+
 typedef struct NoPersist_FrameDictEntry {
     char* key;
     void* value;
+    // 1 when `value` is a heap box this dict owns (a malloc'd
+    // double from pack_double — #81): freed on overwrite and in
+    // destroy, deep-copied by FrameDict_copy.
+    int owned;
     struct NoPersist_FrameDictEntry* next;
 } NoPersist_FrameDictEntry;
 
@@ -41,19 +52,31 @@ static NoPersist_FrameDict* NoPersist_FrameDict_new(void) {
     return d;
 }
 
+static void NoPersist_FrameDict_set_(NoPersist_FrameDict* d, const char* key, void* value, int owned);
 static void NoPersist_FrameDict_set(NoPersist_FrameDict* d, const char* key, void* value) {
+    NoPersist_FrameDict_set_(d, key, value, 0);
+}
+
+static void NoPersist_FrameDict_set_owned(NoPersist_FrameDict* d, const char* key, void* value) {
+    NoPersist_FrameDict_set_(d, key, value, 1);
+}
+
+static void NoPersist_FrameDict_set_(NoPersist_FrameDict* d, const char* key, void* value, int owned) {
     unsigned int idx = NoPersist_hash_string(key) % d->bucket_count;
     NoPersist_FrameDictEntry* entry = d->buckets[idx];
     while (entry) {
         if (strcmp(entry->key, key) == 0) {
+            if (entry->owned && entry->value) free(entry->value);
             entry->value = value;
+            entry->owned = owned;
             return;
         }
         entry = entry->next;
     }
     NoPersist_FrameDictEntry* new_entry = malloc(sizeof(NoPersist_FrameDictEntry));
-    new_entry->key = strdup(key);
+    new_entry->key = NoPersist_strdup_(key);
     new_entry->value = value;
+    new_entry->owned = owned;
     new_entry->next = d->buckets[idx];
     d->buckets[idx] = new_entry;
     d->size++;
@@ -88,7 +111,16 @@ static NoPersist_FrameDict* NoPersist_FrameDict_copy(NoPersist_FrameDict* src) {
     for (int i = 0; i < src->bucket_count; i++) {
         NoPersist_FrameDictEntry* entry = src->buckets[i];
         while (entry) {
-            NoPersist_FrameDict_set(dst, entry->key, entry->value);
+            if (entry->owned && entry->value) {
+                // Owned values are heap-boxed doubles (#81): deep-copy
+                // so src and dst never alias (a shallow copy would
+                // dangle when either side frees on overwrite/destroy).
+                void* nb = malloc(sizeof(double));
+                memcpy(nb, entry->value, sizeof(double));
+                NoPersist_FrameDict_set_(dst, entry->key, nb, 1);
+            } else {
+                NoPersist_FrameDict_set_(dst, entry->key, entry->value, 0);
+            }
             entry = entry->next;
         }
     }
@@ -100,6 +132,7 @@ static void NoPersist_FrameDict_destroy(NoPersist_FrameDict* d) {
         NoPersist_FrameDictEntry* entry = d->buckets[i];
         while (entry) {
             NoPersist_FrameDictEntry* next = entry->next;
+            if (entry->owned && entry->value) free(entry->value);
             free(entry->key);
             free(entry);
             entry = next;
@@ -115,6 +148,10 @@ static void NoPersist_FrameDict_destroy(NoPersist_FrameDict* d) {
 
 typedef struct {
     void** items;
+    // owned[i] == 1 when items[i] is a heap box this vec owns (a
+    // malloc'd double from pack_double — #81): freed in destroy,
+    // deep-copied by FrameVec_copy.
+    unsigned char* owned;
     int size;
     int capacity;
 } NoPersist_FrameVec;
@@ -124,15 +161,48 @@ static NoPersist_FrameVec* NoPersist_FrameVec_new(void) {
     v->capacity = 8;
     v->size = 0;
     v->items = malloc(sizeof(void*) * v->capacity);
+    v->owned = calloc(v->capacity, 1);
     return v;
 }
 
-static void NoPersist_FrameVec_push(NoPersist_FrameVec* v, void* item) {
+static void NoPersist_FrameVec_push_(NoPersist_FrameVec* v, void* item, unsigned char owned) {
     if (v->size >= v->capacity) {
         v->capacity *= 2;
         v->items = realloc(v->items, sizeof(void*) * v->capacity);
+        v->owned = realloc(v->owned, v->capacity);
+        memset(v->owned + v->size, 0, v->capacity - v->size);
     }
+    v->owned[v->size] = owned;
     v->items[v->size++] = item;
+}
+
+static void NoPersist_FrameVec_push(NoPersist_FrameVec* v, void* item) {
+    NoPersist_FrameVec_push_(v, item, 0);
+}
+
+static void NoPersist_FrameVec_push_owned(NoPersist_FrameVec* v, void* item) {
+    NoPersist_FrameVec_push_(v, item, 1);
+}
+
+static void NoPersist_FrameVec_clear(NoPersist_FrameVec* v) {
+    if (!v) return;
+    for (int i = 0; i < v->size; i++) {
+        if (v->owned[i] && v->items[i]) free(v->items[i]);
+    }
+    v->size = 0;
+}
+
+static void NoPersist_FrameVec_extend(NoPersist_FrameVec* dst, NoPersist_FrameVec* src) {
+    if (!src) return;
+    for (int i = 0; i < src->size; i++) {
+        if (src->owned[i] && src->items[i]) {
+            void* nb = malloc(sizeof(double));
+            memcpy(nb, src->items[i], sizeof(double));
+            NoPersist_FrameVec_push_(dst, nb, 1);
+        } else {
+            NoPersist_FrameVec_push_(dst, src->items[i], 0);
+        }
+    }
 }
 
 static void* NoPersist_FrameVec_pop(NoPersist_FrameVec* v) {
@@ -156,6 +226,10 @@ static int NoPersist_FrameVec_size(NoPersist_FrameVec* v) {
 
 static void NoPersist_FrameVec_destroy(NoPersist_FrameVec* v) {
     if (!v) return;
+    for (int i = 0; i < v->size; i++) {
+        if (v->owned[i] && v->items[i]) free(v->items[i]);
+    }
+    free(v->owned);
     free(v->items);
     free(v);
 }
@@ -163,26 +237,23 @@ static void NoPersist_FrameVec_destroy(NoPersist_FrameVec* v) {
 static NoPersist_FrameVec* NoPersist_FrameVec_copy(NoPersist_FrameVec* src) {
     if (!src) return NULL;
     NoPersist_FrameVec* v = NoPersist_FrameVec_new();
-    for (int i = 0; i < src->size; i++) {
-        NoPersist_FrameVec_push(v, src->items[i]);
-    }
+    NoPersist_FrameVec_extend(v, src);
     return v;
 }
 
 // ============================================================================
-// NoPersist_pack_double / NoPersist_unpack_double — bit-pun doubles through void*
+// NoPersist_pack_double / NoPersist_unpack_double — heap-boxed doubles (#81:
+// pointer-width independent; the old void* bit-pun overflowed on 32-bit)
 // ============================================================================
 
 static inline void* NoPersist_pack_double(double v) {
-    void* p = 0;
-    memcpy(&p, &v, sizeof(double));
-    return p;
+    double* p = (double*)malloc(sizeof(double));
+    *p = v;
+    return (void*)p;
 }
 
 static inline double NoPersist_unpack_double(void* p) {
-    double d;
-    memcpy(&d, &p, sizeof(double));
-    return d;
+    return p ? *(double*)p : 0.0;
 }
 
 // ============================================================================
@@ -209,7 +280,7 @@ static cJSON* NoPersist_persist_pack_double(void* v) { return cJSON_CreateNumber
 static void* NoPersist_persist_unpack_double(cJSON* j) { return NoPersist_pack_double(j ? j->valuedouble : 0.0); }
 
 static cJSON* NoPersist_persist_pack_str(void* v) { return cJSON_CreateString(v ? (const char*)v : ""); }
-static void* NoPersist_persist_unpack_str(cJSON* j) { const char* s = (j && j->valuestring) ? j->valuestring : ""; return (void*)strdup(s); }
+static void* NoPersist_persist_unpack_str(cJSON* j) { const char* s = (j && j->valuestring) ? j->valuestring : ""; return (void*)NoPersist_strdup_(s); }
 
 static cJSON* NoPersist_persist_pack_bool(void* v) { return cJSON_CreateBool((intptr_t)v != 0); }
 static void* NoPersist_persist_unpack_bool(cJSON* j) { return (void*)(intptr_t)(j && cJSON_IsTrue(j) ? 1 : 0); }
@@ -265,7 +336,7 @@ static void NoPersist_persist_unpack_field_double(cJSON* j, void* p) { *(double*
 static cJSON* NoPersist_persist_pack_field_bool(void* p) { return cJSON_CreateBool(*(bool*)p); }
 static void NoPersist_persist_unpack_field_bool(cJSON* j, void* p) { *(bool*)p = (bool)(j && cJSON_IsTrue(j)); }
 static cJSON* NoPersist_persist_pack_field_str(void* p) { const char* s = *(const char**)p; return cJSON_CreateString(s ? s : ""); }
-static void NoPersist_persist_unpack_field_str(cJSON* j, void* p) { const char* s = (j && j->valuestring) ? j->valuestring : ""; *(char**)p = strdup(s); }
+static void NoPersist_persist_unpack_field_str(cJSON* j, void* p) { const char* s = (j && j->valuestring) ? j->valuestring : ""; *(char**)p = NoPersist_strdup_(s); }
 static cJSON* NoPersist_persist_pack_field_list(void* p) { return NoPersist_persist_pack_list(*(NoPersist_FrameVec**)p); }
 static void NoPersist_persist_unpack_field_list(cJSON* j, void* p) { *(NoPersist_FrameVec**)p = (NoPersist_FrameVec*)NoPersist_persist_unpack_list(j); }
 static cJSON* NoPersist_persist_pack_field_dict(void* p) { return NoPersist_persist_pack_dict(*(NoPersist_FrameDict**)p); }
@@ -478,12 +549,10 @@ static NoPersist_Compartment* NoPersist_prepareEnter(NoPersist* self, const char
     NoPersist_Compartment* comp = NULL;
     for (int i = 0; i < n; i++) {
         NoPersist_Compartment* nc = NoPersist_Compartment_new(chain[i]);
-        if (state_args) {
-            for (int j = 0; j < state_args->size; j++) NoPersist_FrameVec_push(nc->state_args, state_args->items[j]);
-        }
-        if (enter_args) {
-            for (int j = 0; j < enter_args->size; j++) NoPersist_FrameVec_push(nc->enter_args, enter_args->items[j]);
-        }
+        // FrameVec_extend deep-copies vec-owned heap boxes (#81: doubles)
+        // so the caller can destroy its arg vecs after this returns.
+        NoPersist_FrameVec_extend(nc->state_args, state_args);
+        NoPersist_FrameVec_extend(nc->enter_args, enter_args);
         nc->parent_compartment = comp;  // adopts ref
         comp = nc;
     }
@@ -493,11 +562,10 @@ static NoPersist_Compartment* NoPersist_prepareEnter(NoPersist* self, const char
 static void NoPersist_prepareExit(NoPersist* self, NoPersist_FrameVec* exit_args) {
     NoPersist_Compartment* comp = self->__compartment;
     while (comp != NULL) {
-        // Clear any prior exit_args before copying the new ones in.
-        while (comp->exit_args->size > 0) comp->exit_args->size--;
-        if (exit_args) {
-            for (int j = 0; j < exit_args->size; j++) NoPersist_FrameVec_push(comp->exit_args, exit_args->items[j]);
-        }
+        // Clear any prior exit_args (freeing vec-owned boxes, #81) before
+        // copying the new ones in; extend deep-copies owned entries.
+        NoPersist_FrameVec_clear(comp->exit_args);
+        NoPersist_FrameVec_extend(comp->exit_args, exit_args);
         comp = comp->parent_compartment;
     }
 }
@@ -661,13 +729,6 @@ static cJSON* NoPersist_serialize_compartment(NoPersist_Compartment* comp) {
     cJSON* vars = cJSON_CreateObject();
     NoPersist_FrameDict* sv = comp->state_vars;
     if (sv) {
-        for (int i = 0; i < sv->bucket_count; i++) {
-            NoPersist_FrameDictEntry* entry = sv->buckets[i];
-            while (entry) {
-                cJSON_AddNumberToObject(vars, entry->key, (double)(intptr_t)entry->value);
-                entry = entry->next;
-            }
-        }
     }
     cJSON_AddItemToObject(obj, "state_vars", vars);
     cJSON* sa = cJSON_CreateArray();
@@ -685,13 +746,9 @@ static cJSON* NoPersist_serialize_compartment(NoPersist_Compartment* comp) {
 static NoPersist_Compartment* NoPersist_deserialize_compartment(cJSON* data) {
     if (!data || cJSON_IsNull(data)) return NULL;
     cJSON* state_item = cJSON_GetObjectItem(data, "state");
-    NoPersist_Compartment* comp = NoPersist_Compartment_new(strdup(state_item->valuestring));
+    NoPersist_Compartment* comp = NoPersist_Compartment_new(NoPersist_strdup_(state_item->valuestring));
     cJSON* vars = cJSON_GetObjectItem(data, "state_vars");
     if (vars) {
-        cJSON* var_item;
-        cJSON_ArrayForEach(var_item, vars) {
-            NoPersist_FrameDict_set(comp->state_vars, var_item->string, (void*)(intptr_t)(int)var_item->valuedouble);
-        }
     }
     cJSON* sa = cJSON_GetObjectItem(data, "state_args");
     if (sa) {

--- a/framec/tests/snapshots/c_snapshots__persist.snap
+++ b/framec/tests/snapshots/c_snapshots__persist.snap
@@ -12,9 +12,20 @@ expression: "compile_fixture(\"03_persist\", \"c\")"
 // Counter_FrameDict - String-keyed dictionary
 // ============================================================================
 
+static char* Counter_strdup_(const char* s) {
+    size_t n = strlen(s) + 1;
+    char* p = (char*)malloc(n);
+    memcpy(p, s, n);
+    return p;
+}
+
 typedef struct Counter_FrameDictEntry {
     char* key;
     void* value;
+    // 1 when `value` is a heap box this dict owns (a malloc'd
+    // double from pack_double — #81): freed on overwrite and in
+    // destroy, deep-copied by FrameDict_copy.
+    int owned;
     struct Counter_FrameDictEntry* next;
 } Counter_FrameDictEntry;
 
@@ -41,19 +52,31 @@ static Counter_FrameDict* Counter_FrameDict_new(void) {
     return d;
 }
 
+static void Counter_FrameDict_set_(Counter_FrameDict* d, const char* key, void* value, int owned);
 static void Counter_FrameDict_set(Counter_FrameDict* d, const char* key, void* value) {
+    Counter_FrameDict_set_(d, key, value, 0);
+}
+
+static void Counter_FrameDict_set_owned(Counter_FrameDict* d, const char* key, void* value) {
+    Counter_FrameDict_set_(d, key, value, 1);
+}
+
+static void Counter_FrameDict_set_(Counter_FrameDict* d, const char* key, void* value, int owned) {
     unsigned int idx = Counter_hash_string(key) % d->bucket_count;
     Counter_FrameDictEntry* entry = d->buckets[idx];
     while (entry) {
         if (strcmp(entry->key, key) == 0) {
+            if (entry->owned && entry->value) free(entry->value);
             entry->value = value;
+            entry->owned = owned;
             return;
         }
         entry = entry->next;
     }
     Counter_FrameDictEntry* new_entry = malloc(sizeof(Counter_FrameDictEntry));
-    new_entry->key = strdup(key);
+    new_entry->key = Counter_strdup_(key);
     new_entry->value = value;
+    new_entry->owned = owned;
     new_entry->next = d->buckets[idx];
     d->buckets[idx] = new_entry;
     d->size++;
@@ -88,7 +111,16 @@ static Counter_FrameDict* Counter_FrameDict_copy(Counter_FrameDict* src) {
     for (int i = 0; i < src->bucket_count; i++) {
         Counter_FrameDictEntry* entry = src->buckets[i];
         while (entry) {
-            Counter_FrameDict_set(dst, entry->key, entry->value);
+            if (entry->owned && entry->value) {
+                // Owned values are heap-boxed doubles (#81): deep-copy
+                // so src and dst never alias (a shallow copy would
+                // dangle when either side frees on overwrite/destroy).
+                void* nb = malloc(sizeof(double));
+                memcpy(nb, entry->value, sizeof(double));
+                Counter_FrameDict_set_(dst, entry->key, nb, 1);
+            } else {
+                Counter_FrameDict_set_(dst, entry->key, entry->value, 0);
+            }
             entry = entry->next;
         }
     }
@@ -100,6 +132,7 @@ static void Counter_FrameDict_destroy(Counter_FrameDict* d) {
         Counter_FrameDictEntry* entry = d->buckets[i];
         while (entry) {
             Counter_FrameDictEntry* next = entry->next;
+            if (entry->owned && entry->value) free(entry->value);
             free(entry->key);
             free(entry);
             entry = next;
@@ -115,6 +148,10 @@ static void Counter_FrameDict_destroy(Counter_FrameDict* d) {
 
 typedef struct {
     void** items;
+    // owned[i] == 1 when items[i] is a heap box this vec owns (a
+    // malloc'd double from pack_double — #81): freed in destroy,
+    // deep-copied by FrameVec_copy.
+    unsigned char* owned;
     int size;
     int capacity;
 } Counter_FrameVec;
@@ -124,15 +161,48 @@ static Counter_FrameVec* Counter_FrameVec_new(void) {
     v->capacity = 8;
     v->size = 0;
     v->items = malloc(sizeof(void*) * v->capacity);
+    v->owned = calloc(v->capacity, 1);
     return v;
 }
 
-static void Counter_FrameVec_push(Counter_FrameVec* v, void* item) {
+static void Counter_FrameVec_push_(Counter_FrameVec* v, void* item, unsigned char owned) {
     if (v->size >= v->capacity) {
         v->capacity *= 2;
         v->items = realloc(v->items, sizeof(void*) * v->capacity);
+        v->owned = realloc(v->owned, v->capacity);
+        memset(v->owned + v->size, 0, v->capacity - v->size);
     }
+    v->owned[v->size] = owned;
     v->items[v->size++] = item;
+}
+
+static void Counter_FrameVec_push(Counter_FrameVec* v, void* item) {
+    Counter_FrameVec_push_(v, item, 0);
+}
+
+static void Counter_FrameVec_push_owned(Counter_FrameVec* v, void* item) {
+    Counter_FrameVec_push_(v, item, 1);
+}
+
+static void Counter_FrameVec_clear(Counter_FrameVec* v) {
+    if (!v) return;
+    for (int i = 0; i < v->size; i++) {
+        if (v->owned[i] && v->items[i]) free(v->items[i]);
+    }
+    v->size = 0;
+}
+
+static void Counter_FrameVec_extend(Counter_FrameVec* dst, Counter_FrameVec* src) {
+    if (!src) return;
+    for (int i = 0; i < src->size; i++) {
+        if (src->owned[i] && src->items[i]) {
+            void* nb = malloc(sizeof(double));
+            memcpy(nb, src->items[i], sizeof(double));
+            Counter_FrameVec_push_(dst, nb, 1);
+        } else {
+            Counter_FrameVec_push_(dst, src->items[i], 0);
+        }
+    }
 }
 
 static void* Counter_FrameVec_pop(Counter_FrameVec* v) {
@@ -156,6 +226,10 @@ static int Counter_FrameVec_size(Counter_FrameVec* v) {
 
 static void Counter_FrameVec_destroy(Counter_FrameVec* v) {
     if (!v) return;
+    for (int i = 0; i < v->size; i++) {
+        if (v->owned[i] && v->items[i]) free(v->items[i]);
+    }
+    free(v->owned);
     free(v->items);
     free(v);
 }
@@ -163,26 +237,23 @@ static void Counter_FrameVec_destroy(Counter_FrameVec* v) {
 static Counter_FrameVec* Counter_FrameVec_copy(Counter_FrameVec* src) {
     if (!src) return NULL;
     Counter_FrameVec* v = Counter_FrameVec_new();
-    for (int i = 0; i < src->size; i++) {
-        Counter_FrameVec_push(v, src->items[i]);
-    }
+    Counter_FrameVec_extend(v, src);
     return v;
 }
 
 // ============================================================================
-// Counter_pack_double / Counter_unpack_double — bit-pun doubles through void*
+// Counter_pack_double / Counter_unpack_double — heap-boxed doubles (#81:
+// pointer-width independent; the old void* bit-pun overflowed on 32-bit)
 // ============================================================================
 
 static inline void* Counter_pack_double(double v) {
-    void* p = 0;
-    memcpy(&p, &v, sizeof(double));
-    return p;
+    double* p = (double*)malloc(sizeof(double));
+    *p = v;
+    return (void*)p;
 }
 
 static inline double Counter_unpack_double(void* p) {
-    double d;
-    memcpy(&d, &p, sizeof(double));
-    return d;
+    return p ? *(double*)p : 0.0;
 }
 
 // ============================================================================
@@ -209,7 +280,7 @@ static cJSON* Counter_persist_pack_double(void* v) { return cJSON_CreateNumber(C
 static void* Counter_persist_unpack_double(cJSON* j) { return Counter_pack_double(j ? j->valuedouble : 0.0); }
 
 static cJSON* Counter_persist_pack_str(void* v) { return cJSON_CreateString(v ? (const char*)v : ""); }
-static void* Counter_persist_unpack_str(cJSON* j) { const char* s = (j && j->valuestring) ? j->valuestring : ""; return (void*)strdup(s); }
+static void* Counter_persist_unpack_str(cJSON* j) { const char* s = (j && j->valuestring) ? j->valuestring : ""; return (void*)Counter_strdup_(s); }
 
 static cJSON* Counter_persist_pack_bool(void* v) { return cJSON_CreateBool((intptr_t)v != 0); }
 static void* Counter_persist_unpack_bool(cJSON* j) { return (void*)(intptr_t)(j && cJSON_IsTrue(j) ? 1 : 0); }
@@ -265,7 +336,7 @@ static void Counter_persist_unpack_field_double(cJSON* j, void* p) { *(double*)p
 static cJSON* Counter_persist_pack_field_bool(void* p) { return cJSON_CreateBool(*(bool*)p); }
 static void Counter_persist_unpack_field_bool(cJSON* j, void* p) { *(bool*)p = (bool)(j && cJSON_IsTrue(j)); }
 static cJSON* Counter_persist_pack_field_str(void* p) { const char* s = *(const char**)p; return cJSON_CreateString(s ? s : ""); }
-static void Counter_persist_unpack_field_str(cJSON* j, void* p) { const char* s = (j && j->valuestring) ? j->valuestring : ""; *(char**)p = strdup(s); }
+static void Counter_persist_unpack_field_str(cJSON* j, void* p) { const char* s = (j && j->valuestring) ? j->valuestring : ""; *(char**)p = Counter_strdup_(s); }
 static cJSON* Counter_persist_pack_field_list(void* p) { return Counter_persist_pack_list(*(Counter_FrameVec**)p); }
 static void Counter_persist_unpack_field_list(cJSON* j, void* p) { *(Counter_FrameVec**)p = (Counter_FrameVec*)Counter_persist_unpack_list(j); }
 static cJSON* Counter_persist_pack_field_dict(void* p) { return Counter_persist_pack_dict(*(Counter_FrameDict**)p); }
@@ -471,12 +542,10 @@ static Counter_Compartment* Counter_prepareEnter(Counter* self, const char* leaf
     Counter_Compartment* comp = NULL;
     for (int i = 0; i < n; i++) {
         Counter_Compartment* nc = Counter_Compartment_new(chain[i]);
-        if (state_args) {
-            for (int j = 0; j < state_args->size; j++) Counter_FrameVec_push(nc->state_args, state_args->items[j]);
-        }
-        if (enter_args) {
-            for (int j = 0; j < enter_args->size; j++) Counter_FrameVec_push(nc->enter_args, enter_args->items[j]);
-        }
+        // FrameVec_extend deep-copies vec-owned heap boxes (#81: doubles)
+        // so the caller can destroy its arg vecs after this returns.
+        Counter_FrameVec_extend(nc->state_args, state_args);
+        Counter_FrameVec_extend(nc->enter_args, enter_args);
         nc->parent_compartment = comp;  // adopts ref
         comp = nc;
     }
@@ -486,11 +555,10 @@ static Counter_Compartment* Counter_prepareEnter(Counter* self, const char* leaf
 static void Counter_prepareExit(Counter* self, Counter_FrameVec* exit_args) {
     Counter_Compartment* comp = self->__compartment;
     while (comp != NULL) {
-        // Clear any prior exit_args before copying the new ones in.
-        while (comp->exit_args->size > 0) comp->exit_args->size--;
-        if (exit_args) {
-            for (int j = 0; j < exit_args->size; j++) Counter_FrameVec_push(comp->exit_args, exit_args->items[j]);
-        }
+        // Clear any prior exit_args (freeing vec-owned boxes, #81) before
+        // copying the new ones in; extend deep-copies owned entries.
+        Counter_FrameVec_clear(comp->exit_args);
+        Counter_FrameVec_extend(comp->exit_args, exit_args);
         comp = comp->parent_compartment;
     }
 }
@@ -617,13 +685,6 @@ static cJSON* Counter_serialize_compartment(Counter_Compartment* comp) {
     cJSON* vars = cJSON_CreateObject();
     Counter_FrameDict* sv = comp->state_vars;
     if (sv) {
-        for (int i = 0; i < sv->bucket_count; i++) {
-            Counter_FrameDictEntry* entry = sv->buckets[i];
-            while (entry) {
-                cJSON_AddNumberToObject(vars, entry->key, (double)(intptr_t)entry->value);
-                entry = entry->next;
-            }
-        }
     }
     cJSON_AddItemToObject(obj, "state_vars", vars);
     cJSON* sa = cJSON_CreateArray();
@@ -641,13 +702,9 @@ static cJSON* Counter_serialize_compartment(Counter_Compartment* comp) {
 static Counter_Compartment* Counter_deserialize_compartment(cJSON* data) {
     if (!data || cJSON_IsNull(data)) return NULL;
     cJSON* state_item = cJSON_GetObjectItem(data, "state");
-    Counter_Compartment* comp = Counter_Compartment_new(strdup(state_item->valuestring));
+    Counter_Compartment* comp = Counter_Compartment_new(Counter_strdup_(state_item->valuestring));
     cJSON* vars = cJSON_GetObjectItem(data, "state_vars");
     if (vars) {
-        cJSON* var_item;
-        cJSON_ArrayForEach(var_item, vars) {
-            Counter_FrameDict_set(comp->state_vars, var_item->string, (void*)(intptr_t)(int)var_item->valuedouble);
-        }
     }
     cJSON* sa = cJSON_GetObjectItem(data, "state_args");
     if (sa) {

--- a/framec/tests/snapshots/c_snapshots__pushpop.snap
+++ b/framec/tests/snapshots/c_snapshots__pushpop.snap
@@ -12,9 +12,20 @@ expression: "compile_fixture(\"05_pushpop\", \"c\")"
 // PushPop_FrameDict - String-keyed dictionary
 // ============================================================================
 
+static char* PushPop_strdup_(const char* s) {
+    size_t n = strlen(s) + 1;
+    char* p = (char*)malloc(n);
+    memcpy(p, s, n);
+    return p;
+}
+
 typedef struct PushPop_FrameDictEntry {
     char* key;
     void* value;
+    // 1 when `value` is a heap box this dict owns (a malloc'd
+    // double from pack_double — #81): freed on overwrite and in
+    // destroy, deep-copied by FrameDict_copy.
+    int owned;
     struct PushPop_FrameDictEntry* next;
 } PushPop_FrameDictEntry;
 
@@ -41,19 +52,31 @@ static PushPop_FrameDict* PushPop_FrameDict_new(void) {
     return d;
 }
 
+static void PushPop_FrameDict_set_(PushPop_FrameDict* d, const char* key, void* value, int owned);
 static void PushPop_FrameDict_set(PushPop_FrameDict* d, const char* key, void* value) {
+    PushPop_FrameDict_set_(d, key, value, 0);
+}
+
+static void PushPop_FrameDict_set_owned(PushPop_FrameDict* d, const char* key, void* value) {
+    PushPop_FrameDict_set_(d, key, value, 1);
+}
+
+static void PushPop_FrameDict_set_(PushPop_FrameDict* d, const char* key, void* value, int owned) {
     unsigned int idx = PushPop_hash_string(key) % d->bucket_count;
     PushPop_FrameDictEntry* entry = d->buckets[idx];
     while (entry) {
         if (strcmp(entry->key, key) == 0) {
+            if (entry->owned && entry->value) free(entry->value);
             entry->value = value;
+            entry->owned = owned;
             return;
         }
         entry = entry->next;
     }
     PushPop_FrameDictEntry* new_entry = malloc(sizeof(PushPop_FrameDictEntry));
-    new_entry->key = strdup(key);
+    new_entry->key = PushPop_strdup_(key);
     new_entry->value = value;
+    new_entry->owned = owned;
     new_entry->next = d->buckets[idx];
     d->buckets[idx] = new_entry;
     d->size++;
@@ -88,7 +111,16 @@ static PushPop_FrameDict* PushPop_FrameDict_copy(PushPop_FrameDict* src) {
     for (int i = 0; i < src->bucket_count; i++) {
         PushPop_FrameDictEntry* entry = src->buckets[i];
         while (entry) {
-            PushPop_FrameDict_set(dst, entry->key, entry->value);
+            if (entry->owned && entry->value) {
+                // Owned values are heap-boxed doubles (#81): deep-copy
+                // so src and dst never alias (a shallow copy would
+                // dangle when either side frees on overwrite/destroy).
+                void* nb = malloc(sizeof(double));
+                memcpy(nb, entry->value, sizeof(double));
+                PushPop_FrameDict_set_(dst, entry->key, nb, 1);
+            } else {
+                PushPop_FrameDict_set_(dst, entry->key, entry->value, 0);
+            }
             entry = entry->next;
         }
     }
@@ -100,6 +132,7 @@ static void PushPop_FrameDict_destroy(PushPop_FrameDict* d) {
         PushPop_FrameDictEntry* entry = d->buckets[i];
         while (entry) {
             PushPop_FrameDictEntry* next = entry->next;
+            if (entry->owned && entry->value) free(entry->value);
             free(entry->key);
             free(entry);
             entry = next;
@@ -115,6 +148,10 @@ static void PushPop_FrameDict_destroy(PushPop_FrameDict* d) {
 
 typedef struct {
     void** items;
+    // owned[i] == 1 when items[i] is a heap box this vec owns (a
+    // malloc'd double from pack_double — #81): freed in destroy,
+    // deep-copied by FrameVec_copy.
+    unsigned char* owned;
     int size;
     int capacity;
 } PushPop_FrameVec;
@@ -124,15 +161,48 @@ static PushPop_FrameVec* PushPop_FrameVec_new(void) {
     v->capacity = 8;
     v->size = 0;
     v->items = malloc(sizeof(void*) * v->capacity);
+    v->owned = calloc(v->capacity, 1);
     return v;
 }
 
-static void PushPop_FrameVec_push(PushPop_FrameVec* v, void* item) {
+static void PushPop_FrameVec_push_(PushPop_FrameVec* v, void* item, unsigned char owned) {
     if (v->size >= v->capacity) {
         v->capacity *= 2;
         v->items = realloc(v->items, sizeof(void*) * v->capacity);
+        v->owned = realloc(v->owned, v->capacity);
+        memset(v->owned + v->size, 0, v->capacity - v->size);
     }
+    v->owned[v->size] = owned;
     v->items[v->size++] = item;
+}
+
+static void PushPop_FrameVec_push(PushPop_FrameVec* v, void* item) {
+    PushPop_FrameVec_push_(v, item, 0);
+}
+
+static void PushPop_FrameVec_push_owned(PushPop_FrameVec* v, void* item) {
+    PushPop_FrameVec_push_(v, item, 1);
+}
+
+static void PushPop_FrameVec_clear(PushPop_FrameVec* v) {
+    if (!v) return;
+    for (int i = 0; i < v->size; i++) {
+        if (v->owned[i] && v->items[i]) free(v->items[i]);
+    }
+    v->size = 0;
+}
+
+static void PushPop_FrameVec_extend(PushPop_FrameVec* dst, PushPop_FrameVec* src) {
+    if (!src) return;
+    for (int i = 0; i < src->size; i++) {
+        if (src->owned[i] && src->items[i]) {
+            void* nb = malloc(sizeof(double));
+            memcpy(nb, src->items[i], sizeof(double));
+            PushPop_FrameVec_push_(dst, nb, 1);
+        } else {
+            PushPop_FrameVec_push_(dst, src->items[i], 0);
+        }
+    }
 }
 
 static void* PushPop_FrameVec_pop(PushPop_FrameVec* v) {
@@ -156,6 +226,10 @@ static int PushPop_FrameVec_size(PushPop_FrameVec* v) {
 
 static void PushPop_FrameVec_destroy(PushPop_FrameVec* v) {
     if (!v) return;
+    for (int i = 0; i < v->size; i++) {
+        if (v->owned[i] && v->items[i]) free(v->items[i]);
+    }
+    free(v->owned);
     free(v->items);
     free(v);
 }
@@ -163,26 +237,23 @@ static void PushPop_FrameVec_destroy(PushPop_FrameVec* v) {
 static PushPop_FrameVec* PushPop_FrameVec_copy(PushPop_FrameVec* src) {
     if (!src) return NULL;
     PushPop_FrameVec* v = PushPop_FrameVec_new();
-    for (int i = 0; i < src->size; i++) {
-        PushPop_FrameVec_push(v, src->items[i]);
-    }
+    PushPop_FrameVec_extend(v, src);
     return v;
 }
 
 // ============================================================================
-// PushPop_pack_double / PushPop_unpack_double — bit-pun doubles through void*
+// PushPop_pack_double / PushPop_unpack_double — heap-boxed doubles (#81:
+// pointer-width independent; the old void* bit-pun overflowed on 32-bit)
 // ============================================================================
 
 static inline void* PushPop_pack_double(double v) {
-    void* p = 0;
-    memcpy(&p, &v, sizeof(double));
-    return p;
+    double* p = (double*)malloc(sizeof(double));
+    *p = v;
+    return (void*)p;
 }
 
 static inline double PushPop_unpack_double(void* p) {
-    double d;
-    memcpy(&d, &p, sizeof(double));
-    return d;
+    return p ? *(double*)p : 0.0;
 }
 
 // ============================================================================
@@ -396,12 +467,10 @@ static PushPop_Compartment* PushPop_prepareEnter(PushPop* self, const char* leaf
     PushPop_Compartment* comp = NULL;
     for (int i = 0; i < n; i++) {
         PushPop_Compartment* nc = PushPop_Compartment_new(chain[i]);
-        if (state_args) {
-            for (int j = 0; j < state_args->size; j++) PushPop_FrameVec_push(nc->state_args, state_args->items[j]);
-        }
-        if (enter_args) {
-            for (int j = 0; j < enter_args->size; j++) PushPop_FrameVec_push(nc->enter_args, enter_args->items[j]);
-        }
+        // FrameVec_extend deep-copies vec-owned heap boxes (#81: doubles)
+        // so the caller can destroy its arg vecs after this returns.
+        PushPop_FrameVec_extend(nc->state_args, state_args);
+        PushPop_FrameVec_extend(nc->enter_args, enter_args);
         nc->parent_compartment = comp;  // adopts ref
         comp = nc;
     }
@@ -411,11 +480,10 @@ static PushPop_Compartment* PushPop_prepareEnter(PushPop* self, const char* leaf
 static void PushPop_prepareExit(PushPop* self, PushPop_FrameVec* exit_args) {
     PushPop_Compartment* comp = self->__compartment;
     while (comp != NULL) {
-        // Clear any prior exit_args before copying the new ones in.
-        while (comp->exit_args->size > 0) comp->exit_args->size--;
-        if (exit_args) {
-            for (int j = 0; j < exit_args->size; j++) PushPop_FrameVec_push(comp->exit_args, exit_args->items[j]);
-        }
+        // Clear any prior exit_args (freeing vec-owned boxes, #81) before
+        // copying the new ones in; extend deep-copies owned entries.
+        PushPop_FrameVec_clear(comp->exit_args);
+        PushPop_FrameVec_extend(comp->exit_args, exit_args);
         comp = comp->parent_compartment;
     }
 }

--- a/framec/tests/snapshots/c_snapshots__return_explicit.snap
+++ b/framec/tests/snapshots/c_snapshots__return_explicit.snap
@@ -12,9 +12,20 @@ expression: "compile_fixture(\"09_return_explicit\", \"c\")"
 // ReturnExplicit_FrameDict - String-keyed dictionary
 // ============================================================================
 
+static char* ReturnExplicit_strdup_(const char* s) {
+    size_t n = strlen(s) + 1;
+    char* p = (char*)malloc(n);
+    memcpy(p, s, n);
+    return p;
+}
+
 typedef struct ReturnExplicit_FrameDictEntry {
     char* key;
     void* value;
+    // 1 when `value` is a heap box this dict owns (a malloc'd
+    // double from pack_double — #81): freed on overwrite and in
+    // destroy, deep-copied by FrameDict_copy.
+    int owned;
     struct ReturnExplicit_FrameDictEntry* next;
 } ReturnExplicit_FrameDictEntry;
 
@@ -41,19 +52,31 @@ static ReturnExplicit_FrameDict* ReturnExplicit_FrameDict_new(void) {
     return d;
 }
 
+static void ReturnExplicit_FrameDict_set_(ReturnExplicit_FrameDict* d, const char* key, void* value, int owned);
 static void ReturnExplicit_FrameDict_set(ReturnExplicit_FrameDict* d, const char* key, void* value) {
+    ReturnExplicit_FrameDict_set_(d, key, value, 0);
+}
+
+static void ReturnExplicit_FrameDict_set_owned(ReturnExplicit_FrameDict* d, const char* key, void* value) {
+    ReturnExplicit_FrameDict_set_(d, key, value, 1);
+}
+
+static void ReturnExplicit_FrameDict_set_(ReturnExplicit_FrameDict* d, const char* key, void* value, int owned) {
     unsigned int idx = ReturnExplicit_hash_string(key) % d->bucket_count;
     ReturnExplicit_FrameDictEntry* entry = d->buckets[idx];
     while (entry) {
         if (strcmp(entry->key, key) == 0) {
+            if (entry->owned && entry->value) free(entry->value);
             entry->value = value;
+            entry->owned = owned;
             return;
         }
         entry = entry->next;
     }
     ReturnExplicit_FrameDictEntry* new_entry = malloc(sizeof(ReturnExplicit_FrameDictEntry));
-    new_entry->key = strdup(key);
+    new_entry->key = ReturnExplicit_strdup_(key);
     new_entry->value = value;
+    new_entry->owned = owned;
     new_entry->next = d->buckets[idx];
     d->buckets[idx] = new_entry;
     d->size++;
@@ -88,7 +111,16 @@ static ReturnExplicit_FrameDict* ReturnExplicit_FrameDict_copy(ReturnExplicit_Fr
     for (int i = 0; i < src->bucket_count; i++) {
         ReturnExplicit_FrameDictEntry* entry = src->buckets[i];
         while (entry) {
-            ReturnExplicit_FrameDict_set(dst, entry->key, entry->value);
+            if (entry->owned && entry->value) {
+                // Owned values are heap-boxed doubles (#81): deep-copy
+                // so src and dst never alias (a shallow copy would
+                // dangle when either side frees on overwrite/destroy).
+                void* nb = malloc(sizeof(double));
+                memcpy(nb, entry->value, sizeof(double));
+                ReturnExplicit_FrameDict_set_(dst, entry->key, nb, 1);
+            } else {
+                ReturnExplicit_FrameDict_set_(dst, entry->key, entry->value, 0);
+            }
             entry = entry->next;
         }
     }
@@ -100,6 +132,7 @@ static void ReturnExplicit_FrameDict_destroy(ReturnExplicit_FrameDict* d) {
         ReturnExplicit_FrameDictEntry* entry = d->buckets[i];
         while (entry) {
             ReturnExplicit_FrameDictEntry* next = entry->next;
+            if (entry->owned && entry->value) free(entry->value);
             free(entry->key);
             free(entry);
             entry = next;
@@ -115,6 +148,10 @@ static void ReturnExplicit_FrameDict_destroy(ReturnExplicit_FrameDict* d) {
 
 typedef struct {
     void** items;
+    // owned[i] == 1 when items[i] is a heap box this vec owns (a
+    // malloc'd double from pack_double — #81): freed in destroy,
+    // deep-copied by FrameVec_copy.
+    unsigned char* owned;
     int size;
     int capacity;
 } ReturnExplicit_FrameVec;
@@ -124,15 +161,48 @@ static ReturnExplicit_FrameVec* ReturnExplicit_FrameVec_new(void) {
     v->capacity = 8;
     v->size = 0;
     v->items = malloc(sizeof(void*) * v->capacity);
+    v->owned = calloc(v->capacity, 1);
     return v;
 }
 
-static void ReturnExplicit_FrameVec_push(ReturnExplicit_FrameVec* v, void* item) {
+static void ReturnExplicit_FrameVec_push_(ReturnExplicit_FrameVec* v, void* item, unsigned char owned) {
     if (v->size >= v->capacity) {
         v->capacity *= 2;
         v->items = realloc(v->items, sizeof(void*) * v->capacity);
+        v->owned = realloc(v->owned, v->capacity);
+        memset(v->owned + v->size, 0, v->capacity - v->size);
     }
+    v->owned[v->size] = owned;
     v->items[v->size++] = item;
+}
+
+static void ReturnExplicit_FrameVec_push(ReturnExplicit_FrameVec* v, void* item) {
+    ReturnExplicit_FrameVec_push_(v, item, 0);
+}
+
+static void ReturnExplicit_FrameVec_push_owned(ReturnExplicit_FrameVec* v, void* item) {
+    ReturnExplicit_FrameVec_push_(v, item, 1);
+}
+
+static void ReturnExplicit_FrameVec_clear(ReturnExplicit_FrameVec* v) {
+    if (!v) return;
+    for (int i = 0; i < v->size; i++) {
+        if (v->owned[i] && v->items[i]) free(v->items[i]);
+    }
+    v->size = 0;
+}
+
+static void ReturnExplicit_FrameVec_extend(ReturnExplicit_FrameVec* dst, ReturnExplicit_FrameVec* src) {
+    if (!src) return;
+    for (int i = 0; i < src->size; i++) {
+        if (src->owned[i] && src->items[i]) {
+            void* nb = malloc(sizeof(double));
+            memcpy(nb, src->items[i], sizeof(double));
+            ReturnExplicit_FrameVec_push_(dst, nb, 1);
+        } else {
+            ReturnExplicit_FrameVec_push_(dst, src->items[i], 0);
+        }
+    }
 }
 
 static void* ReturnExplicit_FrameVec_pop(ReturnExplicit_FrameVec* v) {
@@ -156,6 +226,10 @@ static int ReturnExplicit_FrameVec_size(ReturnExplicit_FrameVec* v) {
 
 static void ReturnExplicit_FrameVec_destroy(ReturnExplicit_FrameVec* v) {
     if (!v) return;
+    for (int i = 0; i < v->size; i++) {
+        if (v->owned[i] && v->items[i]) free(v->items[i]);
+    }
+    free(v->owned);
     free(v->items);
     free(v);
 }
@@ -163,26 +237,23 @@ static void ReturnExplicit_FrameVec_destroy(ReturnExplicit_FrameVec* v) {
 static ReturnExplicit_FrameVec* ReturnExplicit_FrameVec_copy(ReturnExplicit_FrameVec* src) {
     if (!src) return NULL;
     ReturnExplicit_FrameVec* v = ReturnExplicit_FrameVec_new();
-    for (int i = 0; i < src->size; i++) {
-        ReturnExplicit_FrameVec_push(v, src->items[i]);
-    }
+    ReturnExplicit_FrameVec_extend(v, src);
     return v;
 }
 
 // ============================================================================
-// ReturnExplicit_pack_double / ReturnExplicit_unpack_double — bit-pun doubles through void*
+// ReturnExplicit_pack_double / ReturnExplicit_unpack_double — heap-boxed doubles (#81:
+// pointer-width independent; the old void* bit-pun overflowed on 32-bit)
 // ============================================================================
 
 static inline void* ReturnExplicit_pack_double(double v) {
-    void* p = 0;
-    memcpy(&p, &v, sizeof(double));
-    return p;
+    double* p = (double*)malloc(sizeof(double));
+    *p = v;
+    return (void*)p;
 }
 
 static inline double ReturnExplicit_unpack_double(void* p) {
-    double d;
-    memcpy(&d, &p, sizeof(double));
-    return d;
+    return p ? *(double*)p : 0.0;
 }
 
 // ============================================================================
@@ -378,12 +449,10 @@ static ReturnExplicit_Compartment* ReturnExplicit_prepareEnter(ReturnExplicit* s
     ReturnExplicit_Compartment* comp = NULL;
     for (int i = 0; i < n; i++) {
         ReturnExplicit_Compartment* nc = ReturnExplicit_Compartment_new(chain[i]);
-        if (state_args) {
-            for (int j = 0; j < state_args->size; j++) ReturnExplicit_FrameVec_push(nc->state_args, state_args->items[j]);
-        }
-        if (enter_args) {
-            for (int j = 0; j < enter_args->size; j++) ReturnExplicit_FrameVec_push(nc->enter_args, enter_args->items[j]);
-        }
+        // FrameVec_extend deep-copies vec-owned heap boxes (#81: doubles)
+        // so the caller can destroy its arg vecs after this returns.
+        ReturnExplicit_FrameVec_extend(nc->state_args, state_args);
+        ReturnExplicit_FrameVec_extend(nc->enter_args, enter_args);
         nc->parent_compartment = comp;  // adopts ref
         comp = nc;
     }
@@ -393,11 +462,10 @@ static ReturnExplicit_Compartment* ReturnExplicit_prepareEnter(ReturnExplicit* s
 static void ReturnExplicit_prepareExit(ReturnExplicit* self, ReturnExplicit_FrameVec* exit_args) {
     ReturnExplicit_Compartment* comp = self->__compartment;
     while (comp != NULL) {
-        // Clear any prior exit_args before copying the new ones in.
-        while (comp->exit_args->size > 0) comp->exit_args->size--;
-        if (exit_args) {
-            for (int j = 0; j < exit_args->size; j++) ReturnExplicit_FrameVec_push(comp->exit_args, exit_args->items[j]);
-        }
+        // Clear any prior exit_args (freeing vec-owned boxes, #81) before
+        // copying the new ones in; extend deep-copies owned entries.
+        ReturnExplicit_FrameVec_clear(comp->exit_args);
+        ReturnExplicit_FrameVec_extend(comp->exit_args, exit_args);
         comp = comp->parent_compartment;
     }
 }

--- a/framec/tests/snapshots/c_snapshots__selfcall.snap
+++ b/framec/tests/snapshots/c_snapshots__selfcall.snap
@@ -12,9 +12,20 @@ expression: "compile_fixture(\"06_selfcall\", \"c\")"
 // SelfCall_FrameDict - String-keyed dictionary
 // ============================================================================
 
+static char* SelfCall_strdup_(const char* s) {
+    size_t n = strlen(s) + 1;
+    char* p = (char*)malloc(n);
+    memcpy(p, s, n);
+    return p;
+}
+
 typedef struct SelfCall_FrameDictEntry {
     char* key;
     void* value;
+    // 1 when `value` is a heap box this dict owns (a malloc'd
+    // double from pack_double — #81): freed on overwrite and in
+    // destroy, deep-copied by FrameDict_copy.
+    int owned;
     struct SelfCall_FrameDictEntry* next;
 } SelfCall_FrameDictEntry;
 
@@ -41,19 +52,31 @@ static SelfCall_FrameDict* SelfCall_FrameDict_new(void) {
     return d;
 }
 
+static void SelfCall_FrameDict_set_(SelfCall_FrameDict* d, const char* key, void* value, int owned);
 static void SelfCall_FrameDict_set(SelfCall_FrameDict* d, const char* key, void* value) {
+    SelfCall_FrameDict_set_(d, key, value, 0);
+}
+
+static void SelfCall_FrameDict_set_owned(SelfCall_FrameDict* d, const char* key, void* value) {
+    SelfCall_FrameDict_set_(d, key, value, 1);
+}
+
+static void SelfCall_FrameDict_set_(SelfCall_FrameDict* d, const char* key, void* value, int owned) {
     unsigned int idx = SelfCall_hash_string(key) % d->bucket_count;
     SelfCall_FrameDictEntry* entry = d->buckets[idx];
     while (entry) {
         if (strcmp(entry->key, key) == 0) {
+            if (entry->owned && entry->value) free(entry->value);
             entry->value = value;
+            entry->owned = owned;
             return;
         }
         entry = entry->next;
     }
     SelfCall_FrameDictEntry* new_entry = malloc(sizeof(SelfCall_FrameDictEntry));
-    new_entry->key = strdup(key);
+    new_entry->key = SelfCall_strdup_(key);
     new_entry->value = value;
+    new_entry->owned = owned;
     new_entry->next = d->buckets[idx];
     d->buckets[idx] = new_entry;
     d->size++;
@@ -88,7 +111,16 @@ static SelfCall_FrameDict* SelfCall_FrameDict_copy(SelfCall_FrameDict* src) {
     for (int i = 0; i < src->bucket_count; i++) {
         SelfCall_FrameDictEntry* entry = src->buckets[i];
         while (entry) {
-            SelfCall_FrameDict_set(dst, entry->key, entry->value);
+            if (entry->owned && entry->value) {
+                // Owned values are heap-boxed doubles (#81): deep-copy
+                // so src and dst never alias (a shallow copy would
+                // dangle when either side frees on overwrite/destroy).
+                void* nb = malloc(sizeof(double));
+                memcpy(nb, entry->value, sizeof(double));
+                SelfCall_FrameDict_set_(dst, entry->key, nb, 1);
+            } else {
+                SelfCall_FrameDict_set_(dst, entry->key, entry->value, 0);
+            }
             entry = entry->next;
         }
     }
@@ -100,6 +132,7 @@ static void SelfCall_FrameDict_destroy(SelfCall_FrameDict* d) {
         SelfCall_FrameDictEntry* entry = d->buckets[i];
         while (entry) {
             SelfCall_FrameDictEntry* next = entry->next;
+            if (entry->owned && entry->value) free(entry->value);
             free(entry->key);
             free(entry);
             entry = next;
@@ -115,6 +148,10 @@ static void SelfCall_FrameDict_destroy(SelfCall_FrameDict* d) {
 
 typedef struct {
     void** items;
+    // owned[i] == 1 when items[i] is a heap box this vec owns (a
+    // malloc'd double from pack_double — #81): freed in destroy,
+    // deep-copied by FrameVec_copy.
+    unsigned char* owned;
     int size;
     int capacity;
 } SelfCall_FrameVec;
@@ -124,15 +161,48 @@ static SelfCall_FrameVec* SelfCall_FrameVec_new(void) {
     v->capacity = 8;
     v->size = 0;
     v->items = malloc(sizeof(void*) * v->capacity);
+    v->owned = calloc(v->capacity, 1);
     return v;
 }
 
-static void SelfCall_FrameVec_push(SelfCall_FrameVec* v, void* item) {
+static void SelfCall_FrameVec_push_(SelfCall_FrameVec* v, void* item, unsigned char owned) {
     if (v->size >= v->capacity) {
         v->capacity *= 2;
         v->items = realloc(v->items, sizeof(void*) * v->capacity);
+        v->owned = realloc(v->owned, v->capacity);
+        memset(v->owned + v->size, 0, v->capacity - v->size);
     }
+    v->owned[v->size] = owned;
     v->items[v->size++] = item;
+}
+
+static void SelfCall_FrameVec_push(SelfCall_FrameVec* v, void* item) {
+    SelfCall_FrameVec_push_(v, item, 0);
+}
+
+static void SelfCall_FrameVec_push_owned(SelfCall_FrameVec* v, void* item) {
+    SelfCall_FrameVec_push_(v, item, 1);
+}
+
+static void SelfCall_FrameVec_clear(SelfCall_FrameVec* v) {
+    if (!v) return;
+    for (int i = 0; i < v->size; i++) {
+        if (v->owned[i] && v->items[i]) free(v->items[i]);
+    }
+    v->size = 0;
+}
+
+static void SelfCall_FrameVec_extend(SelfCall_FrameVec* dst, SelfCall_FrameVec* src) {
+    if (!src) return;
+    for (int i = 0; i < src->size; i++) {
+        if (src->owned[i] && src->items[i]) {
+            void* nb = malloc(sizeof(double));
+            memcpy(nb, src->items[i], sizeof(double));
+            SelfCall_FrameVec_push_(dst, nb, 1);
+        } else {
+            SelfCall_FrameVec_push_(dst, src->items[i], 0);
+        }
+    }
 }
 
 static void* SelfCall_FrameVec_pop(SelfCall_FrameVec* v) {
@@ -156,6 +226,10 @@ static int SelfCall_FrameVec_size(SelfCall_FrameVec* v) {
 
 static void SelfCall_FrameVec_destroy(SelfCall_FrameVec* v) {
     if (!v) return;
+    for (int i = 0; i < v->size; i++) {
+        if (v->owned[i] && v->items[i]) free(v->items[i]);
+    }
+    free(v->owned);
     free(v->items);
     free(v);
 }
@@ -163,26 +237,23 @@ static void SelfCall_FrameVec_destroy(SelfCall_FrameVec* v) {
 static SelfCall_FrameVec* SelfCall_FrameVec_copy(SelfCall_FrameVec* src) {
     if (!src) return NULL;
     SelfCall_FrameVec* v = SelfCall_FrameVec_new();
-    for (int i = 0; i < src->size; i++) {
-        SelfCall_FrameVec_push(v, src->items[i]);
-    }
+    SelfCall_FrameVec_extend(v, src);
     return v;
 }
 
 // ============================================================================
-// SelfCall_pack_double / SelfCall_unpack_double — bit-pun doubles through void*
+// SelfCall_pack_double / SelfCall_unpack_double — heap-boxed doubles (#81:
+// pointer-width independent; the old void* bit-pun overflowed on 32-bit)
 // ============================================================================
 
 static inline void* SelfCall_pack_double(double v) {
-    void* p = 0;
-    memcpy(&p, &v, sizeof(double));
-    return p;
+    double* p = (double*)malloc(sizeof(double));
+    *p = v;
+    return (void*)p;
 }
 
 static inline double SelfCall_unpack_double(void* p) {
-    double d;
-    memcpy(&d, &p, sizeof(double));
-    return d;
+    return p ? *(double*)p : 0.0;
 }
 
 // ============================================================================
@@ -383,12 +454,10 @@ static SelfCall_Compartment* SelfCall_prepareEnter(SelfCall* self, const char* l
     SelfCall_Compartment* comp = NULL;
     for (int i = 0; i < n; i++) {
         SelfCall_Compartment* nc = SelfCall_Compartment_new(chain[i]);
-        if (state_args) {
-            for (int j = 0; j < state_args->size; j++) SelfCall_FrameVec_push(nc->state_args, state_args->items[j]);
-        }
-        if (enter_args) {
-            for (int j = 0; j < enter_args->size; j++) SelfCall_FrameVec_push(nc->enter_args, enter_args->items[j]);
-        }
+        // FrameVec_extend deep-copies vec-owned heap boxes (#81: doubles)
+        // so the caller can destroy its arg vecs after this returns.
+        SelfCall_FrameVec_extend(nc->state_args, state_args);
+        SelfCall_FrameVec_extend(nc->enter_args, enter_args);
         nc->parent_compartment = comp;  // adopts ref
         comp = nc;
     }
@@ -398,11 +467,10 @@ static SelfCall_Compartment* SelfCall_prepareEnter(SelfCall* self, const char* l
 static void SelfCall_prepareExit(SelfCall* self, SelfCall_FrameVec* exit_args) {
     SelfCall_Compartment* comp = self->__compartment;
     while (comp != NULL) {
-        // Clear any prior exit_args before copying the new ones in.
-        while (comp->exit_args->size > 0) comp->exit_args->size--;
-        if (exit_args) {
-            for (int j = 0; j < exit_args->size; j++) SelfCall_FrameVec_push(comp->exit_args, exit_args->items[j]);
-        }
+        // Clear any prior exit_args (freeing vec-owned boxes, #81) before
+        // copying the new ones in; extend deep-copies owned entries.
+        SelfCall_FrameVec_clear(comp->exit_args);
+        SelfCall_FrameVec_extend(comp->exit_args, exit_args);
         comp = comp->parent_compartment;
     }
 }

--- a/framec/tests/snapshots/c_snapshots__state_args.snap
+++ b/framec/tests/snapshots/c_snapshots__state_args.snap
@@ -12,9 +12,20 @@ expression: "compile_fixture(\"04_state_args\", \"c\")"
 // StateArgs_FrameDict - String-keyed dictionary
 // ============================================================================
 
+static char* StateArgs_strdup_(const char* s) {
+    size_t n = strlen(s) + 1;
+    char* p = (char*)malloc(n);
+    memcpy(p, s, n);
+    return p;
+}
+
 typedef struct StateArgs_FrameDictEntry {
     char* key;
     void* value;
+    // 1 when `value` is a heap box this dict owns (a malloc'd
+    // double from pack_double — #81): freed on overwrite and in
+    // destroy, deep-copied by FrameDict_copy.
+    int owned;
     struct StateArgs_FrameDictEntry* next;
 } StateArgs_FrameDictEntry;
 
@@ -41,19 +52,31 @@ static StateArgs_FrameDict* StateArgs_FrameDict_new(void) {
     return d;
 }
 
+static void StateArgs_FrameDict_set_(StateArgs_FrameDict* d, const char* key, void* value, int owned);
 static void StateArgs_FrameDict_set(StateArgs_FrameDict* d, const char* key, void* value) {
+    StateArgs_FrameDict_set_(d, key, value, 0);
+}
+
+static void StateArgs_FrameDict_set_owned(StateArgs_FrameDict* d, const char* key, void* value) {
+    StateArgs_FrameDict_set_(d, key, value, 1);
+}
+
+static void StateArgs_FrameDict_set_(StateArgs_FrameDict* d, const char* key, void* value, int owned) {
     unsigned int idx = StateArgs_hash_string(key) % d->bucket_count;
     StateArgs_FrameDictEntry* entry = d->buckets[idx];
     while (entry) {
         if (strcmp(entry->key, key) == 0) {
+            if (entry->owned && entry->value) free(entry->value);
             entry->value = value;
+            entry->owned = owned;
             return;
         }
         entry = entry->next;
     }
     StateArgs_FrameDictEntry* new_entry = malloc(sizeof(StateArgs_FrameDictEntry));
-    new_entry->key = strdup(key);
+    new_entry->key = StateArgs_strdup_(key);
     new_entry->value = value;
+    new_entry->owned = owned;
     new_entry->next = d->buckets[idx];
     d->buckets[idx] = new_entry;
     d->size++;
@@ -88,7 +111,16 @@ static StateArgs_FrameDict* StateArgs_FrameDict_copy(StateArgs_FrameDict* src) {
     for (int i = 0; i < src->bucket_count; i++) {
         StateArgs_FrameDictEntry* entry = src->buckets[i];
         while (entry) {
-            StateArgs_FrameDict_set(dst, entry->key, entry->value);
+            if (entry->owned && entry->value) {
+                // Owned values are heap-boxed doubles (#81): deep-copy
+                // so src and dst never alias (a shallow copy would
+                // dangle when either side frees on overwrite/destroy).
+                void* nb = malloc(sizeof(double));
+                memcpy(nb, entry->value, sizeof(double));
+                StateArgs_FrameDict_set_(dst, entry->key, nb, 1);
+            } else {
+                StateArgs_FrameDict_set_(dst, entry->key, entry->value, 0);
+            }
             entry = entry->next;
         }
     }
@@ -100,6 +132,7 @@ static void StateArgs_FrameDict_destroy(StateArgs_FrameDict* d) {
         StateArgs_FrameDictEntry* entry = d->buckets[i];
         while (entry) {
             StateArgs_FrameDictEntry* next = entry->next;
+            if (entry->owned && entry->value) free(entry->value);
             free(entry->key);
             free(entry);
             entry = next;
@@ -115,6 +148,10 @@ static void StateArgs_FrameDict_destroy(StateArgs_FrameDict* d) {
 
 typedef struct {
     void** items;
+    // owned[i] == 1 when items[i] is a heap box this vec owns (a
+    // malloc'd double from pack_double — #81): freed in destroy,
+    // deep-copied by FrameVec_copy.
+    unsigned char* owned;
     int size;
     int capacity;
 } StateArgs_FrameVec;
@@ -124,15 +161,48 @@ static StateArgs_FrameVec* StateArgs_FrameVec_new(void) {
     v->capacity = 8;
     v->size = 0;
     v->items = malloc(sizeof(void*) * v->capacity);
+    v->owned = calloc(v->capacity, 1);
     return v;
 }
 
-static void StateArgs_FrameVec_push(StateArgs_FrameVec* v, void* item) {
+static void StateArgs_FrameVec_push_(StateArgs_FrameVec* v, void* item, unsigned char owned) {
     if (v->size >= v->capacity) {
         v->capacity *= 2;
         v->items = realloc(v->items, sizeof(void*) * v->capacity);
+        v->owned = realloc(v->owned, v->capacity);
+        memset(v->owned + v->size, 0, v->capacity - v->size);
     }
+    v->owned[v->size] = owned;
     v->items[v->size++] = item;
+}
+
+static void StateArgs_FrameVec_push(StateArgs_FrameVec* v, void* item) {
+    StateArgs_FrameVec_push_(v, item, 0);
+}
+
+static void StateArgs_FrameVec_push_owned(StateArgs_FrameVec* v, void* item) {
+    StateArgs_FrameVec_push_(v, item, 1);
+}
+
+static void StateArgs_FrameVec_clear(StateArgs_FrameVec* v) {
+    if (!v) return;
+    for (int i = 0; i < v->size; i++) {
+        if (v->owned[i] && v->items[i]) free(v->items[i]);
+    }
+    v->size = 0;
+}
+
+static void StateArgs_FrameVec_extend(StateArgs_FrameVec* dst, StateArgs_FrameVec* src) {
+    if (!src) return;
+    for (int i = 0; i < src->size; i++) {
+        if (src->owned[i] && src->items[i]) {
+            void* nb = malloc(sizeof(double));
+            memcpy(nb, src->items[i], sizeof(double));
+            StateArgs_FrameVec_push_(dst, nb, 1);
+        } else {
+            StateArgs_FrameVec_push_(dst, src->items[i], 0);
+        }
+    }
 }
 
 static void* StateArgs_FrameVec_pop(StateArgs_FrameVec* v) {
@@ -156,6 +226,10 @@ static int StateArgs_FrameVec_size(StateArgs_FrameVec* v) {
 
 static void StateArgs_FrameVec_destroy(StateArgs_FrameVec* v) {
     if (!v) return;
+    for (int i = 0; i < v->size; i++) {
+        if (v->owned[i] && v->items[i]) free(v->items[i]);
+    }
+    free(v->owned);
     free(v->items);
     free(v);
 }
@@ -163,26 +237,23 @@ static void StateArgs_FrameVec_destroy(StateArgs_FrameVec* v) {
 static StateArgs_FrameVec* StateArgs_FrameVec_copy(StateArgs_FrameVec* src) {
     if (!src) return NULL;
     StateArgs_FrameVec* v = StateArgs_FrameVec_new();
-    for (int i = 0; i < src->size; i++) {
-        StateArgs_FrameVec_push(v, src->items[i]);
-    }
+    StateArgs_FrameVec_extend(v, src);
     return v;
 }
 
 // ============================================================================
-// StateArgs_pack_double / StateArgs_unpack_double — bit-pun doubles through void*
+// StateArgs_pack_double / StateArgs_unpack_double — heap-boxed doubles (#81:
+// pointer-width independent; the old void* bit-pun overflowed on 32-bit)
 // ============================================================================
 
 static inline void* StateArgs_pack_double(double v) {
-    void* p = 0;
-    memcpy(&p, &v, sizeof(double));
-    return p;
+    double* p = (double*)malloc(sizeof(double));
+    *p = v;
+    return (void*)p;
 }
 
 static inline double StateArgs_unpack_double(void* p) {
-    double d;
-    memcpy(&d, &p, sizeof(double));
-    return d;
+    return p ? *(double*)p : 0.0;
 }
 
 // ============================================================================
@@ -388,12 +459,10 @@ static StateArgs_Compartment* StateArgs_prepareEnter(StateArgs* self, const char
     StateArgs_Compartment* comp = NULL;
     for (int i = 0; i < n; i++) {
         StateArgs_Compartment* nc = StateArgs_Compartment_new(chain[i]);
-        if (state_args) {
-            for (int j = 0; j < state_args->size; j++) StateArgs_FrameVec_push(nc->state_args, state_args->items[j]);
-        }
-        if (enter_args) {
-            for (int j = 0; j < enter_args->size; j++) StateArgs_FrameVec_push(nc->enter_args, enter_args->items[j]);
-        }
+        // FrameVec_extend deep-copies vec-owned heap boxes (#81: doubles)
+        // so the caller can destroy its arg vecs after this returns.
+        StateArgs_FrameVec_extend(nc->state_args, state_args);
+        StateArgs_FrameVec_extend(nc->enter_args, enter_args);
         nc->parent_compartment = comp;  // adopts ref
         comp = nc;
     }
@@ -403,11 +472,10 @@ static StateArgs_Compartment* StateArgs_prepareEnter(StateArgs* self, const char
 static void StateArgs_prepareExit(StateArgs* self, StateArgs_FrameVec* exit_args) {
     StateArgs_Compartment* comp = self->__compartment;
     while (comp != NULL) {
-        // Clear any prior exit_args before copying the new ones in.
-        while (comp->exit_args->size > 0) comp->exit_args->size--;
-        if (exit_args) {
-            for (int j = 0; j < exit_args->size; j++) StateArgs_FrameVec_push(comp->exit_args, exit_args->items[j]);
-        }
+        // Clear any prior exit_args (freeing vec-owned boxes, #81) before
+        // copying the new ones in; extend deep-copies owned entries.
+        StateArgs_FrameVec_clear(comp->exit_args);
+        StateArgs_FrameVec_extend(comp->exit_args, exit_args);
         comp = comp->parent_compartment;
     }
 }


### PR DESCRIPTION
Fixes #81.

## Problem
The C target bit-punned doubles into the `void*` slot value itself — `sizeof(void*) >= sizeof(double)` holds on 64-bit hosts but not wasm32, where every float silently collapsed toward 0 while all gates stayed green. The issue also flagged `strdup` (POSIX, not ISO C) and asked for a wasm32 CI leg.

## Fix
**Heap/stack-boxed doubles, pointer-width independent:**
- `pack_double` mallocs an 8-byte cell; `unpack_double` is a NULL-safe deref.
- `FrameDict`/`FrameVec` gain owned-entry tracking (`set_owned`/`push_owned`/`clear`/`extend`): owned boxes freed on overwrite/destroy, deep-copied on compartment copy. `__prepareEnter`/`__prepareExit` use the runtime copy helpers instead of raw element loops.
- Interface wrapper stack-boxes double params (zero allocations) and frees the return box after its final read; `c_return_write` frees any previous box; state-var init/assign store owned; transition state args push owned.
- New `state_enter_param_types`/`state_exit_param_types` plumbing types the enter/exit-arg pushes — float enter/exit args previously truncated through `intptr_t` (pre-existing, uncovered). **Residual:** float `pop$` enter-args remain unsupported (popped target statically unknowable) — documented at the push site.
- Persist: state_vars now round-trip through the typed `persist_pack/_unpack` dispatch per declared var (the generic dict walk int-punned every entry — only ints ever round-tripped); double restores store owned.
- ISO C: all emitted `strdup` uses replaced with a `Sys_strdup_` shim (`-std=c11`/emcc clean).

**Drive-by parser fix:** the combined `-> (enter) $State(state)` decoration dropped the `Transition` statement (the lexer reorders state args before the `StateRef`), so W414 falsely flagged the target unreachable. Fixed in the Arrow arms + 2 regression tests.

**Gates:** fixture 17 now exercises the full float surface with dyadic fractional values (state-var init/RMW, interface param, returns, state/enter/exit args). New `issue81_float_roundtrip_runs_wasm32` compiles with emcc and executes under node — skipped when emcc is absent, per the RFC-0034 toolchain convention.

## Validation
- `cargo test` 821 passed / 0 failed (snapshot churn reviewed hunk-by-hunk — all #81 runtime/ownership material)
- `cargo clippy -- -D warnings` + `cargo fmt --check` clean
- C matrix 332/0; full 17-language matrix 5,464/0
- Fuzz phase 2 (persist) 81/81 on c + python_3 oracle; phase 9 (nested) 6/6

🤖 Generated with [Claude Code](https://claude.com/claude-code)