### PR TITLE
fix: E610 — require state-var initializers; delete the synthesized-default type table (#84)

### DIFF
--- a/docs/frame_cookbook.md
+++ b/docs/frame_cookbook.md
@@ -5589,7 +5589,7 @@ This recipe is the natural complement to #53: the scanner handles token recognit
         }
 
         $Nested {
-            $.items: list
+            $.items: list = []
 
             open() {
                 push$

--- a/docs/frame_language.md
+++ b/docs/frame_language.md
@@ -360,7 +360,7 @@ $.<varName> (: <type>)? = <initializer_expr>
 | `$.` | Yes | State variable prefix |
 | `<varName>` | Yes | Identifier |
 | `: <type>` | No | Type annotation |
-| `= <initializer_expr>` | Yes | Native expression; evaluated on every state entry |
+| `= <initializer_expr>` | Yes | Native expression; evaluated on every state entry. Omitting it is an error (**E610**) — Frame does not synthesize default values |
 
 **Scope rules:**
 - `$.x` always refers to the enclosing state's variable `x`
@@ -1288,6 +1288,7 @@ Both `@@:self` and `@@:system` are syntactic prefixes. Bare forms are errors (E6
 |------|------|-------------|
 | E605 | `static-field-no-type` | Static target requires explicit type on domain field |
 | E607 | `state-args-on-pop` | State arguments on `pop$` — popped compartment carries its own |
+| E610 | `state-var-no-initializer` | State variable declared without an initializer — Frame does not synthesize default values |
 | E613 | `field-shadows-param` | Domain field name shadows a system parameter |
 | E614 | `duplicate-field` | Duplicate domain field name |
 | E615 | `const-field-assign` | Assignment to `const` domain field in handler body |

--- a/framec/src/frame_c/compiler/codegen/codegen_utils.rs
+++ b/framec/src/frame_c/compiler/codegen/codegen_utils.rs
@@ -123,136 +123,22 @@ pub(crate) fn erased_write_coercion(lang: TargetLanguage, declared: &str, expr: 
     }
 }
 
-/// Get default initialization value for a type
-pub(crate) fn state_var_init_value(var_type: &Type, lang: TargetLanguage) -> String {
-    match var_type {
-        Type::Custom(name) => {
-            match name.to_lowercase().as_str() {
-                "int" | "i32" | "i64" | "u32" | "u64" | "number" => "0".to_string(),
-                "float" | "f32" | "f64" => "0.0".to_string(),
-                "bool" | "boolean" => match lang {
-                    TargetLanguage::Python3 => "False".to_string(),
-                    TargetLanguage::GDScript
-                    | TargetLanguage::TypeScript
-                    | TargetLanguage::JavaScript
-                    | TargetLanguage::Rust
-                    | TargetLanguage::C
-                    | TargetLanguage::Cpp
-                    | TargetLanguage::Java
-                    | TargetLanguage::Kotlin
-                    | TargetLanguage::Swift
-                    | TargetLanguage::CSharp
-                    | TargetLanguage::Go
-                    | TargetLanguage::Php
-                    | TargetLanguage::Ruby
-                    | TargetLanguage::Erlang
-                    | TargetLanguage::Lua
-                    | TargetLanguage::Dart => "false".to_string(),
-                    TargetLanguage::Graphviz => unreachable!(),
-                },
-                "str" | "string" => match lang {
-                    // Rust: `""` is `&str`, not `String`. The Default impl
-                    // for typed XContext structs needs a `String` value.
-                    TargetLanguage::Rust => "String::new()".to_string(),
-                    // C++: `""` is `const char*`, not `std::string`. Values
-                    // stored in `std::any("")` fail `std::any_cast<std::string>`.
-                    TargetLanguage::Cpp => "std::string()".to_string(),
-                    _ => "\"\"".to_string(),
-                },
-                "list" | "array" => match lang {
-                    TargetLanguage::Python3 | TargetLanguage::GDScript => "[]".to_string(),
-                    TargetLanguage::Rust => "Vec::new()".to_string(),
-                    TargetLanguage::TypeScript
-                    | TargetLanguage::JavaScript
-                    | TargetLanguage::Dart => "[]".to_string(),
-                    TargetLanguage::Java => "new java.util.ArrayList<>()".to_string(),
-                    TargetLanguage::Kotlin => "mutableListOf()".to_string(),
-                    TargetLanguage::Swift => "[]".to_string(),
-                    TargetLanguage::CSharp => "new List<object>()".to_string(),
-                    TargetLanguage::Cpp => "std::vector<std::any>()".to_string(),
-                    TargetLanguage::Go => "[]interface{}{}".to_string(),
-                    TargetLanguage::Php => "[]".to_string(),
-                    TargetLanguage::Ruby | TargetLanguage::Lua => "{}".to_string(),
-                    TargetLanguage::C => "NULL".to_string(),
-                    TargetLanguage::Erlang => "[]".to_string(),
-                    TargetLanguage::Graphviz => unreachable!(),
-                },
-                "dict" | "dictionary" | "map" => match lang {
-                    TargetLanguage::Python3 => "{}".to_string(),
-                    TargetLanguage::GDScript => "{}".to_string(),
-                    TargetLanguage::Rust => "HashMap::new()".to_string(),
-                    TargetLanguage::TypeScript | TargetLanguage::JavaScript => "{}".to_string(),
-                    TargetLanguage::Java => "new java.util.HashMap<>()".to_string(),
-                    TargetLanguage::Kotlin => "mutableMapOf()".to_string(),
-                    TargetLanguage::Swift => "[:]".to_string(),
-                    TargetLanguage::CSharp => "new Dictionary<string, object>()".to_string(),
-                    TargetLanguage::Cpp => {
-                        "std::unordered_map<std::string, std::any>()".to_string()
-                    }
-                    TargetLanguage::Go => "map[string]interface{}{}".to_string(),
-                    TargetLanguage::Php => "[]".to_string(),
-                    TargetLanguage::Ruby => "{}".to_string(),
-                    TargetLanguage::Lua => "{}".to_string(),
-                    TargetLanguage::Dart => "{}".to_string(),
-                    TargetLanguage::C => "NULL".to_string(),
-                    TargetLanguage::Erlang => "#{}".to_string(),
-                    TargetLanguage::Graphviz => unreachable!(),
-                },
-                "set" => match lang {
-                    TargetLanguage::Python3 => "set()".to_string(),
-                    TargetLanguage::GDScript => "{}".to_string(),
-                    TargetLanguage::Rust => "HashSet::new()".to_string(),
-                    TargetLanguage::TypeScript | TargetLanguage::JavaScript => {
-                        "new Set()".to_string()
-                    }
-                    TargetLanguage::Java => "new HashSet<>()".to_string(),
-                    TargetLanguage::Kotlin => "mutableSetOf()".to_string(),
-                    TargetLanguage::Swift => "Set<AnyHashable>()".to_string(),
-                    TargetLanguage::CSharp => "new HashSet<object>()".to_string(),
-                    TargetLanguage::Dart => "<dynamic>{}".to_string(),
-                    _ => "null".to_string(),
-                },
-                _ => match lang {
-                    TargetLanguage::Python3 | TargetLanguage::Rust => "None".to_string(),
-                    TargetLanguage::Cpp => "nullptr".to_string(),
-                    TargetLanguage::Go
-                    | TargetLanguage::Swift
-                    | TargetLanguage::Ruby
-                    | TargetLanguage::Lua => "nil".to_string(),
-                    TargetLanguage::C => "NULL".to_string(),
-                    TargetLanguage::Erlang => "undefined".to_string(),
-                    TargetLanguage::GDScript
-                    | TargetLanguage::Dart
-                    | TargetLanguage::TypeScript
-                    | TargetLanguage::JavaScript
-                    | TargetLanguage::Java
-                    | TargetLanguage::Kotlin
-                    | TargetLanguage::CSharp
-                    | TargetLanguage::Php => "null".to_string(),
-                    TargetLanguage::Graphviz => unreachable!(),
-                },
-            }
-        }
-        Type::Unknown => match lang {
-            TargetLanguage::Python3 | TargetLanguage::Rust => "None".to_string(),
-            TargetLanguage::Cpp => "nullptr".to_string(),
-            TargetLanguage::Go
-            | TargetLanguage::Swift
-            | TargetLanguage::Ruby
-            | TargetLanguage::Lua => "nil".to_string(),
-            TargetLanguage::C => "NULL".to_string(),
-            TargetLanguage::Erlang => "undefined".to_string(),
-            TargetLanguage::GDScript
-            | TargetLanguage::Dart
-            | TargetLanguage::TypeScript
-            | TargetLanguage::JavaScript
-            | TargetLanguage::Java
-            | TargetLanguage::Kotlin
-            | TargetLanguage::CSharp
-            | TargetLanguage::Php => "null".to_string(),
-            TargetLanguage::Graphviz => unreachable!(),
-        },
-    }
+/// The state-var initializer, verbatim.
+///
+/// E610 rejects state-vars without an initializer before codegen runs, so
+/// the text is always present here. Frame does not synthesize default
+/// values — the per-target default table that used to live here picked a
+/// value by lowercase-matching the TYPE NAME, the alias-table species the
+/// 4.5.0 verbatim-passthrough release exterminated (issue #84).
+pub(crate) fn state_var_initializer(
+    var: &crate::frame_c::compiler::frame_ast::StateVarAst,
+) -> String {
+    var.initializer_text.clone().unwrap_or_else(|| {
+        unreachable!(
+            "state-var '$.{}' has no initializer — E610 must reject this before codegen",
+            var.name
+        )
+    })
 }
 
 // `typed_init_expr` (removed): previously wrapped portable state-var init
@@ -640,87 +526,35 @@ mod tests {
     use crate::frame_c::visitors::TargetLanguage;
 
     // =========================================================
-    // state_var_init_value — type-correct defaults per language
+    // =========================================================
+    // state_var_initializer — verbatim passthrough, no synthesis
     // =========================================================
 
     #[test]
-    fn test_state_var_init_string_rust() {
-        assert_eq!(
-            state_var_init_value(&Type::Custom("str".into()), TargetLanguage::Rust),
-            "String::new()"
-        );
-        assert_eq!(
-            state_var_init_value(&Type::Custom("string".into()), TargetLanguage::Rust),
-            "String::new()"
-        );
+    fn test_state_var_initializer_is_verbatim() {
+        // The user's initializer text is emitted untouched — Frame does
+        // not interpret values (issue #84; E610 guarantees presence).
+        let var = crate::frame_c::compiler::frame_ast::StateVarAst {
+            name: "cool".to_string(),
+            var_type: Type::Custom("float".to_string()),
+            initializer_text: Some("0.25f /* native */".to_string()),
+            span: crate::frame_c::compiler::frame_ast::Span::new(0, 0),
+        };
+        assert_eq!(state_var_initializer(&var), "0.25f /* native */");
     }
 
     #[test]
-    fn test_state_var_init_string_cpp() {
-        assert_eq!(
-            state_var_init_value(&Type::Custom("str".into()), TargetLanguage::Cpp),
-            "std::string()"
-        );
-        assert_eq!(
-            state_var_init_value(&Type::Custom("string".into()), TargetLanguage::Cpp),
-            "std::string()"
-        );
-    }
-
-    #[test]
-    fn test_state_var_init_string_python() {
-        assert_eq!(
-            state_var_init_value(&Type::Custom("str".into()), TargetLanguage::Python3),
-            "\"\""
-        );
-    }
-
-    #[test]
-    fn test_state_var_init_int() {
-        assert_eq!(
-            state_var_init_value(&Type::Custom("int".into()), TargetLanguage::Rust),
-            "0"
-        );
-        assert_eq!(
-            state_var_init_value(&Type::Custom("i64".into()), TargetLanguage::Cpp),
-            "0"
-        );
-        assert_eq!(
-            state_var_init_value(&Type::Custom("number".into()), TargetLanguage::Python3),
-            "0"
-        );
-    }
-
-    #[test]
-    fn test_state_var_init_bool_python() {
-        assert_eq!(
-            state_var_init_value(&Type::Custom("bool".into()), TargetLanguage::Python3),
-            "False"
-        );
-    }
-
-    #[test]
-    fn test_state_var_init_bool_rust() {
-        assert_eq!(
-            state_var_init_value(&Type::Custom("bool".into()), TargetLanguage::Rust),
-            "false"
-        );
-    }
-
-    #[test]
-    fn test_state_var_init_unknown_rust() {
-        assert_eq!(
-            state_var_init_value(&Type::Unknown, TargetLanguage::Rust),
-            "None"
-        );
-    }
-
-    #[test]
-    fn test_state_var_init_unknown_python() {
-        assert_eq!(
-            state_var_init_value(&Type::Unknown, TargetLanguage::Python3),
-            "None"
-        );
+    #[should_panic(expected = "E610")]
+    fn test_state_var_initializer_missing_is_unreachable() {
+        // E610 rejects this before codegen; reaching the helper without
+        // an initializer is an internal invariant violation.
+        let var = crate::frame_c::compiler::frame_ast::StateVarAst {
+            name: "cool".to_string(),
+            var_type: Type::Custom("int".to_string()),
+            initializer_text: None,
+            span: crate::frame_c::compiler::frame_ast::Span::new(0, 0),
+        };
+        let _ = state_var_initializer(&var);
     }
 
     // =========================================================

--- a/framec/src/frame_c/compiler/codegen/frame_expansion.rs
+++ b/framec/src/frame_c/compiler/codegen/frame_expansion.rs
@@ -46,8 +46,8 @@ pub(crate) use utility::{
 
 use super::codegen_utils::{
     cpp_map_type, cpp_wrap_any_arg, csharp_map_type, expression_to_string, go_map_type,
-    java_map_type, kotlin_map_type, replace_outside_strings_and_comments, state_var_init_value,
-    swift_map_type, to_snake_case, type_to_cpp_string, HandlerContext,
+    java_map_type, kotlin_map_type, replace_outside_strings_and_comments, swift_map_type,
+    to_snake_case, type_to_cpp_string, HandlerContext,
 };
 use crate::frame_c::compiler::frame_ast::Type;
 use crate::frame_c::compiler::native_region_scanner::{

--- a/framec/src/frame_c/compiler/codegen/runtime.rs
+++ b/framec/src/frame_c/compiler/codegen/runtime.rs
@@ -7,7 +7,7 @@
 mod c;
 
 use super::ast::{CodegenNode, Field, Param, Visibility};
-use super::codegen_utils::{expression_to_string, state_var_init_value, type_to_string};
+use super::codegen_utils::{expression_to_string, type_to_string};
 use crate::frame_c::compiler::frame_ast::{Expression, SystemAst, Type};
 use crate::frame_c::visitors::TargetLanguage;
 pub use c::generate_c_compartment_types;

--- a/framec/src/frame_c/compiler/codegen/state_dispatch.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch.rs
@@ -21,7 +21,7 @@ use handler_methods::{
 use super::ast::{CodegenNode, Param, Visibility};
 use super::codegen_utils::{
     cpp_map_type, cpp_wrap_any_arg, csharp_map_type, expression_to_string, go_map_type,
-    java_map_type, kotlin_map_type, state_var_init_value, swift_map_type, to_snake_case,
+    java_map_type, kotlin_map_type, state_var_initializer, swift_map_type, to_snake_case,
     type_to_cpp_string, HandlerContext,
 };
 use super::frame_expansion::{
@@ -100,11 +100,7 @@ pub(crate) fn generate_unified_state_dispatch(
     if !state_vars.is_empty() && !has_enter_handler {
         code.push_str(&(syn.fmt_if)("$>"));
         for var in state_vars {
-            let init_val = if let Some(ref init) = var.initializer_text {
-                init.clone()
-            } else {
-                state_var_init_value(&var.var_type, syn.lang)
-            };
+            let init_val = state_var_initializer(var);
             code.push_str(&(syn.fmt_init_sv)(
                 &var.name,
                 &init_val,
@@ -144,11 +140,7 @@ pub(crate) fn generate_unified_state_dispatch(
         // State var init in enter handler — only the lifecycle `$>` key.
         if event == "$>" && !state_vars.is_empty() {
             for var in state_vars {
-                let init_val = if let Some(ref init) = var.initializer_text {
-                    init.clone()
-                } else {
-                    state_var_init_value(&var.var_type, syn.lang)
-                };
+                let init_val = state_var_initializer(var);
                 code.push_str(&(syn.fmt_init_sv)(
                     &var.name,
                     &init_val,

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/c.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/c.rs
@@ -5,7 +5,7 @@
 use super::super::super::ast::{CodegenNode, Param, Visibility};
 use super::super::super::codegen_utils::{
     cpp_map_type, csharp_map_type, expression_to_string, go_map_type, java_map_type,
-    kotlin_map_type, state_var_init_value, swift_map_type, to_snake_case, type_to_cpp_string,
+    kotlin_map_type, state_var_initializer, swift_map_type, to_snake_case, type_to_cpp_string,
     HandlerContext,
 };
 use super::super::super::frame_expansion::{
@@ -184,11 +184,7 @@ pub(crate) fn generate_c_handler_method(
     // C arm.
     if handler.is_enter {
         for var in state_vars_for_init {
-            let init_val = if let Some(ref init) = var.initializer_text {
-                init.clone()
-            } else {
-                state_var_init_value(&var.var_type, lang)
-            };
+            let init_val = state_var_initializer(var);
             let (packed, setter) = {
                 use crate::frame_c::compiler::codegen::c_marshal::{c_marshal_of, CMarshal};
                 let declared = match &var.var_type {

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/cpp.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/cpp.rs
@@ -5,7 +5,7 @@
 use super::super::super::ast::{CodegenNode, Param, Visibility};
 use super::super::super::codegen_utils::{
     cpp_map_type, csharp_map_type, expression_to_string, go_map_type, java_map_type,
-    kotlin_map_type, state_var_init_value, swift_map_type, to_snake_case, type_to_cpp_string,
+    kotlin_map_type, state_var_initializer, swift_map_type, to_snake_case, type_to_cpp_string,
     HandlerContext,
 };
 use super::super::super::frame_expansion::{
@@ -127,11 +127,7 @@ pub(crate) fn generate_cpp_handler_method(
     // matches fmt_init_sv's existing carve-out in the legacy path.
     if handler.is_enter {
         for var in state_vars_for_init {
-            let init_val = if let Some(ref init) = var.initializer_text {
-                init.clone()
-            } else {
-                state_var_init_value(&var.var_type, lang)
-            };
+            let init_val = state_var_initializer(var);
             // #77: coerce the initializer to the DECLARED float-family type
             // before it enters the erased container (a bare literal deduces
             // to the default float width; the declared-type exact-match read

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/csharp.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/csharp.rs
@@ -5,7 +5,7 @@
 use super::super::super::ast::{CodegenNode, Param, Visibility};
 use super::super::super::codegen_utils::{
     cpp_map_type, csharp_map_type, expression_to_string, go_map_type, java_map_type,
-    kotlin_map_type, state_var_init_value, swift_map_type, to_snake_case, type_to_cpp_string,
+    kotlin_map_type, state_var_initializer, swift_map_type, to_snake_case, type_to_cpp_string,
     HandlerContext,
 };
 use super::super::super::frame_expansion::{
@@ -134,11 +134,7 @@ pub(crate) fn generate_csharp_handler_method(
     // State-var init (lifecycle enter only).
     if handler.is_enter {
         for var in state_vars_for_init {
-            let init_val = if let Some(ref init) = var.initializer_text {
-                init.clone()
-            } else {
-                state_var_init_value(&var.var_type, lang)
-            };
+            let init_val = state_var_initializer(var);
             // #77: coerce the initializer to the DECLARED float-family type
             // before it enters the erased container (a bare literal deduces
             // to the default float width; the declared-type exact-match read

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/dart.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/dart.rs
@@ -5,7 +5,7 @@
 use super::super::super::ast::{CodegenNode, Param, Visibility};
 use super::super::super::codegen_utils::{
     cpp_map_type, csharp_map_type, expression_to_string, go_map_type, java_map_type,
-    kotlin_map_type, state_var_init_value, swift_map_type, to_snake_case, type_to_cpp_string,
+    kotlin_map_type, state_var_initializer, swift_map_type, to_snake_case, type_to_cpp_string,
     HandlerContext,
 };
 use super::super::super::frame_expansion::{
@@ -116,11 +116,7 @@ pub(crate) fn generate_dart_handler_method(
     // State-var init (lifecycle enter only).
     if handler.is_enter {
         for var in state_vars_for_init {
-            let init_val = if let Some(ref init) = var.initializer_text {
-                init.clone()
-            } else {
-                state_var_init_value(&var.var_type, lang)
-            };
+            let init_val = state_var_initializer(var);
             body.push_str(&format!(
                 "if (!compartment.state_vars.containsKey(\"{}\")) {{\n    compartment.state_vars[\"{}\"] = {};\n}}\n",
                 var.name, var.name, init_val

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/gdscript.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/gdscript.rs
@@ -5,7 +5,7 @@
 use super::super::super::ast::{CodegenNode, Param, Visibility};
 use super::super::super::codegen_utils::{
     cpp_map_type, csharp_map_type, expression_to_string, go_map_type, java_map_type,
-    kotlin_map_type, state_var_init_value, swift_map_type, to_snake_case, type_to_cpp_string,
+    kotlin_map_type, state_var_initializer, swift_map_type, to_snake_case, type_to_cpp_string,
     HandlerContext,
 };
 use super::super::super::frame_expansion::{
@@ -93,11 +93,7 @@ pub(crate) fn generate_gdscript_handler_method(
 
     if handler.is_enter {
         for var in state_vars_for_init {
-            let init_val = if let Some(ref init) = var.initializer_text {
-                init.clone()
-            } else {
-                state_var_init_value(&var.var_type, lang)
-            };
+            let init_val = state_var_initializer(var);
             body.push_str(&format!(
                 "if not \"{}\" in compartment.state_vars:\n    compartment.state_vars[\"{}\"] = {}\n",
                 var.name, var.name, init_val

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/go.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/go.rs
@@ -5,7 +5,7 @@
 use super::super::super::ast::{CodegenNode, Param, Visibility};
 use super::super::super::codegen_utils::{
     cpp_map_type, csharp_map_type, expression_to_string, go_map_type, java_map_type,
-    kotlin_map_type, state_var_init_value, swift_map_type, to_snake_case, type_to_cpp_string,
+    kotlin_map_type, state_var_initializer, swift_map_type, to_snake_case, type_to_cpp_string,
     HandlerContext,
 };
 use super::super::super::frame_expansion::{
@@ -112,11 +112,7 @@ pub(crate) fn generate_go_handler_method(
     // State-var init (lifecycle enter only).
     if handler.is_enter {
         for var in state_vars_for_init {
-            let init_val = if let Some(ref init) = var.initializer_text {
-                init.clone()
-            } else {
-                state_var_init_value(&var.var_type, lang)
-            };
+            let init_val = state_var_initializer(var);
             // #77: coerce the initializer to the DECLARED float-family type
             // before it enters the erased container (a bare literal deduces
             // to the default float width; the declared-type exact-match read

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/java.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/java.rs
@@ -5,7 +5,7 @@
 use super::super::super::ast::{CodegenNode, Param, Visibility};
 use super::super::super::codegen_utils::{
     cpp_map_type, csharp_map_type, expression_to_string, go_map_type, java_map_type,
-    kotlin_map_type, state_var_init_value, swift_map_type, to_snake_case, type_to_cpp_string,
+    kotlin_map_type, state_var_initializer, swift_map_type, to_snake_case, type_to_cpp_string,
     HandlerContext,
 };
 use super::super::super::frame_expansion::{
@@ -132,11 +132,7 @@ pub(crate) fn generate_java_handler_method(
     // State-var init (lifecycle enter only).
     if handler.is_enter {
         for var in state_vars_for_init {
-            let init_val = if let Some(ref init) = var.initializer_text {
-                init.clone()
-            } else {
-                state_var_init_value(&var.var_type, lang)
-            };
+            let init_val = state_var_initializer(var);
             // #77: coerce the initializer to the DECLARED float-family type
             // before it enters the erased container (a bare literal deduces
             // to the default float width; the declared-type exact-match read

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/kotlin.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/kotlin.rs
@@ -5,7 +5,7 @@
 use super::super::super::ast::{CodegenNode, Param, Visibility};
 use super::super::super::codegen_utils::{
     cpp_map_type, csharp_map_type, expression_to_string, go_map_type, java_map_type,
-    kotlin_map_type, state_var_init_value, swift_map_type, to_snake_case, type_to_cpp_string,
+    kotlin_map_type, state_var_initializer, swift_map_type, to_snake_case, type_to_cpp_string,
     HandlerContext,
 };
 use super::super::super::frame_expansion::{
@@ -115,11 +115,7 @@ pub(crate) fn generate_kotlin_handler_method(
     // State-var init (lifecycle enter only).
     if handler.is_enter {
         for var in state_vars_for_init {
-            let init_val = if let Some(ref init) = var.initializer_text {
-                init.clone()
-            } else {
-                state_var_init_value(&var.var_type, lang)
-            };
+            let init_val = state_var_initializer(var);
             // #77: coerce the initializer to the DECLARED float-family type
             // before it enters the erased container (a bare literal deduces
             // to the default float width; the declared-type exact-match read

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/lua.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/lua.rs
@@ -5,7 +5,7 @@
 use super::super::super::ast::{CodegenNode, Param, Visibility};
 use super::super::super::codegen_utils::{
     cpp_map_type, csharp_map_type, expression_to_string, go_map_type, java_map_type,
-    kotlin_map_type, state_var_init_value, swift_map_type, to_snake_case, type_to_cpp_string,
+    kotlin_map_type, state_var_initializer, swift_map_type, to_snake_case, type_to_cpp_string,
     HandlerContext,
 };
 use super::super::super::frame_expansion::{
@@ -94,11 +94,7 @@ pub(crate) fn generate_lua_handler_method(
 
     if handler.is_enter {
         for var in state_vars_for_init {
-            let init_val = if let Some(ref init) = var.initializer_text {
-                init.clone()
-            } else {
-                state_var_init_value(&var.var_type, lang)
-            };
+            let init_val = state_var_initializer(var);
             // Lua: nil check since tables return nil for missing keys.
             body.push_str(&format!(
                 "if compartment.state_vars[\"{}\"] == nil then\n    compartment.state_vars[\"{}\"] = {}\nend\n",

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/php.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/php.rs
@@ -5,7 +5,7 @@
 use super::super::super::ast::{CodegenNode, Param, Visibility};
 use super::super::super::codegen_utils::{
     cpp_map_type, csharp_map_type, expression_to_string, go_map_type, java_map_type,
-    kotlin_map_type, state_var_init_value, swift_map_type, to_snake_case, type_to_cpp_string,
+    kotlin_map_type, state_var_initializer, swift_map_type, to_snake_case, type_to_cpp_string,
     HandlerContext,
 };
 use super::super::super::frame_expansion::{
@@ -85,11 +85,7 @@ pub(crate) fn generate_php_handler_method(
 
     if handler.is_enter {
         for var in state_vars_for_init {
-            let init_val = if let Some(ref init) = var.initializer_text {
-                init.clone()
-            } else {
-                state_var_init_value(&var.var_type, lang)
-            };
+            let init_val = state_var_initializer(var);
             body.push_str(&format!(
                 "if (!array_key_exists(\"{}\", $compartment->state_vars)) {{\n    $compartment->state_vars[\"{}\"] = {};\n}}\n",
                 var.name, var.name, init_val

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/python.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/python.rs
@@ -5,7 +5,7 @@
 use super::super::super::ast::{CodegenNode, Param, Visibility};
 use super::super::super::codegen_utils::{
     cpp_map_type, csharp_map_type, expression_to_string, go_map_type, java_map_type,
-    kotlin_map_type, state_var_init_value, swift_map_type, to_snake_case, type_to_cpp_string,
+    kotlin_map_type, state_var_initializer, swift_map_type, to_snake_case, type_to_cpp_string,
     HandlerContext,
 };
 use super::super::super::frame_expansion::{
@@ -97,11 +97,7 @@ pub(crate) fn generate_python_handler_method(
     // The `if not in` guard preserves pop$ restore semantics.
     if handler.is_enter {
         for var in state_vars_for_init {
-            let init_val = if let Some(ref init) = var.initializer_text {
-                init.clone()
-            } else {
-                state_var_init_value(&var.var_type, TargetLanguage::Python3)
-            };
+            let init_val = state_var_initializer(var);
             body.push_str(&format!(
                 "if \"{}\" not in compartment.state_vars:\n    compartment.state_vars[\"{}\"] = {}\n",
                 var.name, var.name, init_val

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/ruby.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/ruby.rs
@@ -5,7 +5,7 @@
 use super::super::super::ast::{CodegenNode, Param, Visibility};
 use super::super::super::codegen_utils::{
     cpp_map_type, csharp_map_type, expression_to_string, go_map_type, java_map_type,
-    kotlin_map_type, state_var_init_value, swift_map_type, to_snake_case, type_to_cpp_string,
+    kotlin_map_type, state_var_initializer, swift_map_type, to_snake_case, type_to_cpp_string,
     HandlerContext,
 };
 use super::super::super::frame_expansion::{
@@ -88,11 +88,7 @@ pub(crate) fn generate_ruby_handler_method(
     // State-var init — lifecycle enter only, guarded via `unless key?`.
     if handler.is_enter {
         for var in state_vars_for_init {
-            let init_val = if let Some(ref init) = var.initializer_text {
-                init.clone()
-            } else {
-                state_var_init_value(&var.var_type, lang)
-            };
+            let init_val = state_var_initializer(var);
             body.push_str(&format!(
                 "unless compartment.state_vars.key?(\"{}\")\n    compartment.state_vars[\"{}\"] = {}\nend\n",
                 var.name, var.name, init_val

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/swift.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/swift.rs
@@ -5,7 +5,7 @@
 use super::super::super::ast::{CodegenNode, Param, Visibility};
 use super::super::super::codegen_utils::{
     cpp_map_type, csharp_map_type, expression_to_string, go_map_type, java_map_type,
-    kotlin_map_type, state_var_init_value, swift_map_type, to_snake_case, type_to_cpp_string,
+    kotlin_map_type, state_var_initializer, swift_map_type, to_snake_case, type_to_cpp_string,
     HandlerContext,
 };
 use super::super::super::frame_expansion::{
@@ -115,11 +115,7 @@ pub(crate) fn generate_swift_handler_method(
     // State-var init (lifecycle enter only).
     if handler.is_enter {
         for var in state_vars_for_init {
-            let init_val = if let Some(ref init) = var.initializer_text {
-                init.clone()
-            } else {
-                state_var_init_value(&var.var_type, lang)
-            };
+            let init_val = state_var_initializer(var);
             // #77: coerce the initializer to the DECLARED float-family type
             // before it enters the erased container (a bare literal deduces
             // to the default float width; the declared-type exact-match read

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/typescript.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/typescript.rs
@@ -5,7 +5,7 @@
 use super::super::super::ast::{CodegenNode, Param, Visibility};
 use super::super::super::codegen_utils::{
     cpp_map_type, csharp_map_type, expression_to_string, go_map_type, java_map_type,
-    kotlin_map_type, state_var_init_value, swift_map_type, to_snake_case, type_to_cpp_string,
+    kotlin_map_type, state_var_initializer, swift_map_type, to_snake_case, type_to_cpp_string,
     HandlerContext,
 };
 use super::super::super::frame_expansion::{
@@ -106,11 +106,7 @@ pub(crate) fn generate_typescript_handler_method(
     // `if not in` guard preserves pop$ restore semantics.
     if handler.is_enter {
         for var in state_vars_for_init {
-            let init_val = if let Some(ref init) = var.initializer_text {
-                init.clone()
-            } else {
-                state_var_init_value(&var.var_type, lang)
-            };
+            let init_val = state_var_initializer(var);
             body.push_str(&format!(
                 "if (!(\"{}\" in compartment.state_vars)) {{\n    compartment.state_vars[\"{}\"] = {};\n}}\n",
                 var.name, var.name, init_val

--- a/framec/src/frame_c/compiler/codegen/system_codegen.rs
+++ b/framec/src/frame_c/compiler/codegen/system_codegen.rs
@@ -32,8 +32,8 @@ use super::ast::*;
 use super::backend::get_backend;
 use super::codegen_utils::{
     convert_expression, convert_literal, cpp_map_type, cpp_wrap_any_arg, csharp_map_type,
-    expression_to_string, go_map_type, java_map_type, kotlin_map_type, state_var_init_value,
-    swift_map_type, to_snake_case, type_to_cpp_string, type_to_string, HandlerContext,
+    expression_to_string, go_map_type, java_map_type, kotlin_map_type, swift_map_type,
+    to_snake_case, type_to_cpp_string, type_to_string, HandlerContext,
 };
 use super::frame_expansion::{generate_frame_expansion, get_native_scanner, normalize_indentation};
 use super::interface_gen::{
@@ -613,8 +613,8 @@ mod tests {
     use super::*;
     use crate::frame_c::compiler::codegen::codegen_utils::{
         convert_expression, convert_literal, cpp_map_type, cpp_wrap_any_arg, csharp_map_type,
-        expression_to_string, go_map_type, java_map_type, kotlin_map_type, state_var_init_value,
-        swift_map_type, to_snake_case, type_to_cpp_string, type_to_string, HandlerContext,
+        expression_to_string, go_map_type, java_map_type, kotlin_map_type, swift_map_type,
+        to_snake_case, type_to_cpp_string, type_to_string, HandlerContext,
     };
     use crate::frame_c::compiler::frame_ast::{
         DomainVar, Expression, Literal, Span, SystemAst, Type,

--- a/framec/src/frame_c/compiler/codegen/system_codegen/constructor.rs
+++ b/framec/src/frame_c/compiler/codegen/system_codegen/constructor.rs
@@ -22,8 +22,7 @@ use super::super::ast::{CodegenNode, Field, Param, Visibility};
 use super::super::backend::ClassSyntax;
 use super::super::codegen_utils::{
     cpp_map_type, csharp_map_type, expression_to_string, go_map_type, java_map_type,
-    kotlin_map_type, state_var_init_value, swift_map_type, to_snake_case, type_to_cpp_string,
-    type_to_string,
+    kotlin_map_type, swift_map_type, to_snake_case, type_to_cpp_string, type_to_string,
 };
 use crate::frame_c::compiler::frame_ast::{Expression, ParamKind, StateAst, SystemAst, Type};
 use crate::frame_c::visitors::TargetLanguage;

--- a/framec/src/frame_c/compiler/frame_validator.rs
+++ b/framec/src/frame_c/compiler/frame_validator.rs
@@ -2546,6 +2546,51 @@ mod tests {
         }
     }
 
+    // ===== Issue #84: state-vars must have an initializer (E610) —
+    //                  Frame does not synthesize default values =====
+
+    #[test]
+    fn test_e610_uninitialized_state_var() {
+        let source = r#"
+@@system R {
+    interface:
+        go()
+    machine:
+        $Active {
+            $.count: int
+
+            go() { $.count = $.count + 1 }
+        }
+}"#;
+        let codes = v4_codes(source);
+        assert!(
+            codes.iter().any(|c| c == "E610"),
+            "expected E610 for a state-var with no initializer, got {:?}",
+            codes
+        );
+    }
+
+    #[test]
+    fn test_initialized_state_var_accepted() {
+        let source = r#"
+@@system R {
+    interface:
+        go()
+    machine:
+        $Active {
+            $.count: int = 0
+
+            go() { $.count = $.count + 1 }
+        }
+}"#;
+        let codes = v4_codes(source);
+        assert!(
+            !codes.iter().any(|c| c == "E610"),
+            "an initialized state-var must not fire E610, got {:?}",
+            codes
+        );
+    }
+
     // ===== RFC-0045: state-name relocation to `@@:system.state.name`,
     //                 bare `@@:system.state` reserved (E608) =====
 

--- a/framec/src/frame_c/compiler/frame_validator/transitions.rs
+++ b/framec/src/frame_c/compiler/frame_validator/transitions.rs
@@ -20,6 +20,12 @@ impl FrameValidator {
         _operations: &HashSet<String>,
     ) {
         // E410: Validate no duplicate state variable names
+        // E610: every state variable must have an initializer. Frame has no
+        // type system and does not invent values — without an initializer,
+        // codegen would have to synthesize a per-target default from the
+        // type NAME (the alias-table species exterminated in 4.5.0). The
+        // initializer is emitted verbatim, so the author writes exactly
+        // what the target receives (issue #84).
         {
             let mut seen_vars: HashSet<String> = HashSet::new();
             for sv in &state.state_vars {
@@ -30,6 +36,21 @@ impl FrameValidator {
                             format!(
                                 "Duplicate state variable '$.{}' in state '{}'",
                                 sv.name, state.name
+                            ),
+                        )
+                        .with_span(sv.span.clone()),
+                    );
+                }
+                if sv.initializer_text.is_none() {
+                    self.errors.push(
+                        ValidationError::new(
+                            "E610",
+                            format!(
+                                "State variable '$.{}' in state '{}' has no initializer. \
+                                 Frame does not synthesize default values — write one \
+                                 explicitly (e.g. `$.{}: <type> = <value>`); it is passed \
+                                 through to the target verbatim.",
+                                sv.name, state.name, sv.name
                             ),
                         )
                         .with_span(sv.span.clone()),


### PR DESCRIPTION
Fixes #84. No magic: Frame does not invent values.

## Problem
`state_var_init_value` synthesized a default for uninitialized state-vars by **lowercase-matching the type name** — a surviving type-name interpretation table of the alias species 4.5.0 exterminated. It silently contradicted the language reference (which already marks the initializer **Required**) and was nearly dead in practice: zero uninitialized state-vars in the in-repo fixtures or the entire 17-language test-env corpus. The pre-commit doc-sample gate caught exactly one cookbook recipe (#54 BracketParser) relying on the synthesized `[]` — now initialized explicitly.

## Fix
- **E610**: a state variable must have an initializer (`$.x: int = 0`). Fails compilation with a clear message (exit 65).
- The table + all 16 codegen fallbacks deleted (net −164 lines); codegen consumes `initializer_text` **verbatim** via `state_var_initializer`, which treats a missing initializer as an unreachable internal invariant.
- Docs: state-var section notes the enforcement; error catalog gains E610; cookbook recipe 54 fixed.

Deliberately retained (runtime-ABI marshalling at framec-synthesized boundaries, user expression preserved inside): `c_marshal` categorization, `erased_write_coercion` (#77), persist blessed-type dispatch, Rust `String::from`/`.clone()` boxing.

## Validation
- `cargo test` 817/0 (table tests replaced with verbatim + invariant tests; 2 new validator tests; E610 verified end-to-end via CLI)
- `cargo clippy -- -D warnings` + `cargo fmt --check` clean; **zero snapshot churn**; doc-sample gate 118/118
- Full 17-language matrix clean. One swift `unrecognized output` was the documented container-state flake: green after `compose --force-recreate`, and the generated swift for that fixture is byte-identical between this branch and the pre-change compiler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)