### PR TITLE
fix(cpp): exception-free dispatch via RAII scope-guard (#86)

### DIFF
--- a/docs/frame_language.md
+++ b/docs/frame_language.md
@@ -29,6 +29,7 @@ Complete reference for the Frame language. For a tutorial introduction, see [Get
 - [System Instantiation](#system-instantiation)
 - [Versioning & Stability](#versioning--stability)
 - [Token Summary](#token-summary)
+- [Exception Policy](#exception-policy)
 - [Error Codes](#error-codes)
 - [Complete Example](#complete-example)
 - [Appendix: Frame Syntax Taxonomy](#appendix-frame-syntax-taxonomy)
@@ -1234,6 +1235,42 @@ Both `@@:self` and `@@:system` are syntactic prefixes. Bare forms are errors (E6
 |-------|---------|
 | `@@:self.method()` | Self interface call (reentrant) |
 | `@@:system.state.name` | Current state name (read-only) |
+
+---
+
+## Exception Policy
+
+Frame-generated code maintains its runtime invariants — most importantly the
+context-stack balance `len_after == len_before` around every dispatch — using
+**each language's idiomatic scope-cleanup construct, never a mandatory
+catch-and-rethrow**:
+
+| Family | Backends | Cleanup |
+|--------|----------|---------|
+| RAII (destructor / `Drop`) | C++, Rust | scope-guard pops on scope exit |
+| Scope-exit defer | Go | `defer { pop }` |
+| `try`/`finally` (always present) | Java, C#, Kotlin, Dart, TypeScript, JavaScript, PHP, Python, Ruby | `finally` pops |
+| Unconditional pop | Swift, C, GDScript | single post-dispatch pop (exception-free) |
+
+Because the cleanup never depends on a thrown-and-caught exception, **core
+generated code compiles under a target's no-exceptions mode wherever one exists**
+— notably C++ `-fno-exceptions`, which Godot's web (wasm) engine requires for
+GDExtensions (issue #86). Frame event handlers are state transitions and do not
+throw, so there is nothing for a `catch` to handle on the normal path.
+
+Exceptions appear **only in opt-in features whose semantics are inherently
+fallible**, and each is documented as requiring host exception support:
+
+- **`@@[async]`** — a concurrent second driver raises **E703** (single-driver
+  violation), surfaced per backend as a thrown error / rejected future. On C++ the
+  coroutine machinery additionally uses `rethrow_exception`. Async systems are not
+  exception-free.
+- **`@@[persist]`** — the C++ save/load path probes `std::any` slot types, which
+  today uses `try { any_cast } catch`. (Convertible to no-throw pointer-form
+  `any_cast<T>(&v)`; tracked separately.)
+
+In short: **exceptions are optional, not the rule.** A plain synchronous,
+non-persisted system generates exception-free code on every backend.
 
 ---
 

--- a/docs/rfcs/rfc-0044.md
+++ b/docs/rfcs/rfc-0044.md
@@ -5,7 +5,15 @@ nav_exclude: true
 
 # RFC-0044: Kernel context-stack must clean up on exception
 
-- **Status:** Draft — surfaced by RFC-0043 fixture-expansion research (2026-06-01); not yet implemented
+- **Status:** Partially implemented — the **C++** row is implemented (2026-06-13,
+  issue #86): the interface dispatch wrapper now uses a method-local RAII
+  scope-guard (`struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard(){
+  s.pop_back(); } }`) instead of `try/catch(...) { pop; throw; }`. This both keeps
+  the cleanup invariant on every exit path AND makes C++ output compile under
+  `-fno-exceptions` (the Godot-web requirement that motivated #86). The remaining
+  per-backend rows below (including Swift's `defer`, deferred to avoid entangling
+  #86 with a pre-existing async-stdout test flake) are still Phase-2 work.
+  Original status: Draft — surfaced by RFC-0043 fixture-expansion research (2026-06-01).
 - **Author:** Mark Truluck <mark.truluck@cogiton.com>
 - **Created:** 2026-06-01
 - **Builds on:** RFC-0020 (runtime kernel), RFC-0043 (async layered architecture)
@@ -122,7 +130,7 @@ runs the pop on both code paths.
 | Swift | `defer { ... pop ... }` |
 | Dart | `try { ... } finally { ... pop ... }` |
 | Rust | RAII guard struct with `Drop` impl (split-borrow on the stack) |
-| C++ | RAII guard struct with destructor on `_context_stack.pop_back()` |
+| C++ | RAII guard struct with destructor on `_context_stack.pop_back()` — **implemented (#86)** |
 | GDScript | manual cleanup (no `try/finally`) — see § GDScript caveat |
 | Erlang | gen_statem handles natively |
 | Go / PHP / Ruby / Lua / C | not currently async-capable; sync dispatch needs the same fix |

--- a/framec/src/frame_c/compiler/codegen/interface_gen.rs
+++ b/framec/src/frame_c/compiler/codegen/interface_gen.rs
@@ -526,32 +526,37 @@ return __result;"#,
                 }
 
                 code.push_str("_context_stack.push_back(std::move(__ctx));\n");
-                // D-PY-1: pop on both paths so a throwing handler can't leak.
-                // try/catch is valid inside a coroutine; `throw;` re-propagates
-                // through the promise. Async: await the kernel so nested
-                // co_awaits work; sync: plain call.
-                code.push_str("try {\n");
+                // Exception Policy (#86, RFC-0044): the context-stack balance
+                // invariant `len_after == len_before` is maintained by an RAII
+                // scope-guard, NOT a catch-and-rethrow. The guard's destructor
+                // pops on every scope exit — normal return AND (if exceptions
+                // are enabled) unwinding — so the previous `try/catch(...){ pop;
+                // throw; }` is unnecessary. Frame handlers are state transitions
+                // and never throw, so that catch path was dead; emitting it
+                // forced a hard link-time dependency on the C++ exception
+                // runtime, which Godot's web (wasm) engine is built WITHOUT
+                // (-fno-exceptions). The guard keeps the same safety while making
+                // framec C++ output compile and link with exceptions disabled.
+                // A method-local struct typed via `decltype(_context_stack)&`
+                // is ODR-safe and needs no shared preamble.
+                code.push_str(
+                    "struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};\n",
+                );
                 if system_is_async {
-                    code.push_str("    co_await __kernel(_context_stack.back()._event);\n");
+                    code.push_str("co_await __kernel(_context_stack.back()._event);\n");
                 } else {
-                    code.push_str("    __kernel(_context_stack.back()._event);\n");
+                    code.push_str("__kernel(_context_stack.back()._event);\n");
                 }
 
+                // __result is captured while the entry is still on the stack;
+                // __ctx_guard pops AFTER the (co_)return value is constructed.
                 let ret_kw = if system_is_async { "co_return" } else { "return" };
                 if returns_value {
-                    code.push_str(&format!("    auto __result = std::any_cast<{}>(std::move(_context_stack.back()._return));\n", return_type_str));
-                    code.push_str("    _context_stack.pop_back();\n");
-                    code.push_str(&format!("    {} __result;\n", ret_kw));
+                    code.push_str(&format!("auto __result = std::any_cast<{}>(std::move(_context_stack.back()._return));\n", return_type_str));
+                    code.push_str(&format!("{} __result;", ret_kw));
                 } else if system_is_async {
-                    code.push_str("    _context_stack.pop_back();\n");
-                    code.push_str("    co_return;\n");
-                } else {
-                    code.push_str("    _context_stack.pop_back();\n");
+                    code.push_str("co_return;");
                 }
-                code.push_str("} catch (...) {\n");
-                code.push_str("    _context_stack.pop_back();\n");
-                code.push_str("    throw;\n");
-                code.push_str("}");
 
                 CodegenNode::NativeBlock { code, span: None }
             }

--- a/framec/tests/cpp_snapshots.rs
+++ b/framec/tests/cpp_snapshots.rs
@@ -164,3 +164,65 @@ fn issue78_float_any_roundtrip_runs() {
         String::from_utf8_lossy(&run.stderr)
     );
 }
+
+/// #86 — C++ core dispatch must be EXCEPTION-FREE so output compiles under
+/// `-fno-exceptions` (the condition Godot's web/wasm engine imposes). The
+/// interface wrapper used to emit `try { __kernel; pop } catch(...) { pop;
+/// throw }`; that dead catch path (Frame handlers never throw) created a hard
+/// link-time dependency on the C++ exception runtime, so a GDExtension that ran
+/// natively failed to link on web (`undefined symbol invoke_ji`). It is now an
+/// RAII scope-guard (destructor pops on every exit). Two locks:
+///
+/// 1. Token assertion (always runs): a basic sync system's C++ output contains
+///    zero `try` / `catch` / `throw`.
+/// 2. Compile gate (skip if no C++ compiler): the same output compiles under
+///    `-std=c++17 -fno-exceptions` — exactly what Godot web requires.
+#[test]
+fn issue86_cpp_dispatch_is_exception_free() {
+    use std::process::Command;
+
+    // A basic sync, non-persist, non-async system — the core dispatch path.
+    let code = compile_fixture("01_linear_fsm", "cpp");
+
+    // (1) Token assertion: no exception machinery in core output. Word-boundary
+    // matched so identifiers like `throwaway` wouldn't false-positive (none
+    // exist, but be precise).
+    for tok in ["try", "catch", "throw"] {
+        let needle_paren = format!("{tok} ");
+        let needle_brace = format!("{tok}(");
+        assert!(
+            !code.contains(&needle_paren) && !code.contains(&needle_brace),
+            "#86: core C++ dispatch must be exception-free, but emitted `{tok}`.\n--- generated source ---\n{code}"
+        );
+    }
+
+    // (2) Compile gate under -fno-exceptions. Uses `16_self_member_lowering`
+    // (the same compile-clean fixture issue69 syntax-checks — a sync system
+    // whose native code is valid C++, unlike 01_linear_fsm whose hand-written
+    // bodies omit trailing semicolons and so only round-trip as snapshots).
+    let cxx = match common::find_tool("g++")
+        .or_else(|| common::find_tool("clang++"))
+        .or_else(|| common::find_tool("c++"))
+    {
+        Some(p) => p,
+        None => {
+            eprintln!("#86 -fno-exceptions gate skipped: no C++ compiler on PATH");
+            return;
+        }
+    };
+    let compile_code = compile_fixture("16_self_member_lowering", "cpp");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("16_self_member_lowering.cpp");
+    std::fs::write(&path, &compile_code).expect("write tempfile");
+    let out = Command::new(&cxx)
+        .args(["-std=c++17", "-fno-exceptions", "-fsyntax-only"])
+        .arg(&path)
+        .output()
+        .expect("c++ process");
+    assert!(
+        out.status.success(),
+        "#86: framec C++ output does not compile under -fno-exceptions (Godot web requirement).\n--- stderr ---\n{}\n--- generated source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        compile_code
+    );
+}

--- a/framec/tests/snapshots/cpp_snapshots__actions.snap
+++ b/framec/tests/snapshots/cpp_snapshots__actions.snap
@@ -176,13 +176,8 @@ public:
         ActionsFrameEvent __e("increment", std::vector<std::any>{n});
         ActionsFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            _context_stack.pop_back();
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
 
     }
 
@@ -190,15 +185,10 @@ public:
         ActionsFrameEvent __e("get_total");
         ActionsFrameContext __ctx(std::move(__e), std::any(int()));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
-            _context_stack.pop_back();
-            return __result;
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
+        auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
+        return __result;
 
     }
 };

--- a/framec/tests/snapshots/cpp_snapshots__consts.snap
+++ b/framec/tests/snapshots/cpp_snapshots__consts.snap
@@ -177,13 +177,8 @@ public:
         ConstsFrameEvent __e("tick");
         ConstsFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            _context_stack.pop_back();
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
 
     }
 
@@ -191,15 +186,10 @@ public:
         ConstsFrameEvent __e("get_count");
         ConstsFrameContext __ctx(std::move(__e), std::any(int()));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
-            _context_stack.pop_back();
-            return __result;
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
+        auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
+        return __result;
 
     }
 };

--- a/framec/tests/snapshots/cpp_snapshots__forward.snap
+++ b/framec/tests/snapshots/cpp_snapshots__forward.snap
@@ -209,13 +209,8 @@ public:
         ForwardFrameEvent __e("run");
         ForwardFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            _context_stack.pop_back();
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
 
     }
 
@@ -223,13 +218,8 @@ public:
         ForwardFrameEvent __e("finish");
         ForwardFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            _context_stack.pop_back();
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
 
     }
 };

--- a/framec/tests/snapshots/cpp_snapshots__hsm.snap
+++ b/framec/tests/snapshots/cpp_snapshots__hsm.snap
@@ -244,13 +244,8 @@ public:
         MiniHsmFrameEvent __e("wake");
         MiniHsmFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            _context_stack.pop_back();
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
 
     }
 
@@ -258,13 +253,8 @@ public:
         MiniHsmFrameEvent __e("sleep");
         MiniHsmFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            _context_stack.pop_back();
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
 
     }
 
@@ -272,13 +262,8 @@ public:
         MiniHsmFrameEvent __e("signal");
         MiniHsmFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            _context_stack.pop_back();
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
 
     }
 };

--- a/framec/tests/snapshots/cpp_snapshots__lifecycle.snap
+++ b/framec/tests/snapshots/cpp_snapshots__lifecycle.snap
@@ -205,13 +205,8 @@ public:
         LifecycleFrameEvent __e("start", std::vector<std::any>{label});
         LifecycleFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            _context_stack.pop_back();
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
 
     }
 
@@ -219,13 +214,8 @@ public:
         LifecycleFrameEvent __e("stop");
         LifecycleFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            _context_stack.pop_back();
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
 
     }
 };

--- a/framec/tests/snapshots/cpp_snapshots__lifecycle_args.snap
+++ b/framec/tests/snapshots/cpp_snapshots__lifecycle_args.snap
@@ -205,13 +205,8 @@ public:
         LifecycleArgsFrameEvent __e("load", std::vector<std::any>{n, label});
         LifecycleArgsFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            _context_stack.pop_back();
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
 
     }
 
@@ -219,15 +214,10 @@ public:
         LifecycleArgsFrameEvent __e("total");
         LifecycleArgsFrameContext __ctx(std::move(__e), std::any(int()));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
-            _context_stack.pop_back();
-            return __result;
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
+        auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
+        return __result;
 
     }
 
@@ -235,15 +225,10 @@ public:
         LifecycleArgsFrameEvent __e("tag");
         LifecycleArgsFrameContext __ctx(std::move(__e), std::any(std::string()));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            auto __result = std::any_cast<std::string>(std::move(_context_stack.back()._return));
-            _context_stack.pop_back();
-            return __result;
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
+        auto __result = std::any_cast<std::string>(std::move(_context_stack.back()._return));
+        return __result;
 
     }
 };

--- a/framec/tests/snapshots/cpp_snapshots__linear_fsm.snap
+++ b/framec/tests/snapshots/cpp_snapshots__linear_fsm.snap
@@ -199,13 +199,8 @@ public:
         LinearFsmFrameEvent __e("start");
         LinearFsmFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            _context_stack.pop_back();
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
 
     }
 
@@ -213,13 +208,8 @@ public:
         LinearFsmFrameEvent __e("progress", std::vector<std::any>{amount});
         LinearFsmFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            _context_stack.pop_back();
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
 
     }
 
@@ -227,13 +217,8 @@ public:
         LinearFsmFrameEvent __e("finish");
         LinearFsmFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            _context_stack.pop_back();
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
 
     }
 };

--- a/framec/tests/snapshots/cpp_snapshots__no_persist.snap
+++ b/framec/tests/snapshots/cpp_snapshots__no_persist.snap
@@ -190,13 +190,8 @@ public:
         NoPersistFrameEvent __e("bump");
         NoPersistFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            _context_stack.pop_back();
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
 
     }
 
@@ -204,13 +199,8 @@ public:
         NoPersistFrameEvent __e("set_cache", std::vector<std::any>{v});
         NoPersistFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            _context_stack.pop_back();
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
 
     }
 
@@ -218,15 +208,10 @@ public:
         NoPersistFrameEvent __e("get_count");
         NoPersistFrameContext __ctx(std::move(__e), std::any(int()));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
-            _context_stack.pop_back();
-            return __result;
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
+        auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
+        return __result;
 
     }
 
@@ -234,15 +219,10 @@ public:
         NoPersistFrameEvent __e("get_cache");
         NoPersistFrameContext __ctx(std::move(__e), std::any(int()));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
-            _context_stack.pop_back();
-            return __result;
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
+        auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
+        return __result;
 
     }
 

--- a/framec/tests/snapshots/cpp_snapshots__persist.snap
+++ b/framec/tests/snapshots/cpp_snapshots__persist.snap
@@ -171,13 +171,8 @@ public:
         CounterFrameEvent __e("increment", std::vector<std::any>{by});
         CounterFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            _context_stack.pop_back();
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
 
     }
 
@@ -185,15 +180,10 @@ public:
         CounterFrameEvent __e("value");
         CounterFrameContext __ctx(std::move(__e), std::any(0));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
-            _context_stack.pop_back();
-            return __result;
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
+        auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
+        return __result;
 
     }
 

--- a/framec/tests/snapshots/cpp_snapshots__pushpop.snap
+++ b/framec/tests/snapshots/cpp_snapshots__pushpop.snap
@@ -201,13 +201,8 @@ public:
         PushPopFrameEvent __e("ping");
         PushPopFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            _context_stack.pop_back();
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
 
     }
 
@@ -215,13 +210,8 @@ public:
         PushPopFrameEvent __e("nest");
         PushPopFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            _context_stack.pop_back();
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
 
     }
 
@@ -229,13 +219,8 @@ public:
         PushPopFrameEvent __e("unnest");
         PushPopFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            _context_stack.pop_back();
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
 
     }
 
@@ -243,13 +228,8 @@ public:
         PushPopFrameEvent __e("leaf");
         PushPopFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            _context_stack.pop_back();
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
 
     }
 };

--- a/framec/tests/snapshots/cpp_snapshots__return_explicit.snap
+++ b/framec/tests/snapshots/cpp_snapshots__return_explicit.snap
@@ -165,15 +165,10 @@ public:
         ReturnExplicitFrameEvent __e("decide", std::vector<std::any>{score});
         ReturnExplicitFrameContext __ctx(std::move(__e), std::any(std::string()));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            auto __result = std::any_cast<std::string>(std::move(_context_stack.back()._return));
-            _context_stack.pop_back();
-            return __result;
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
+        auto __result = std::any_cast<std::string>(std::move(_context_stack.back()._return));
+        return __result;
 
     }
 };

--- a/framec/tests/snapshots/cpp_snapshots__selfcall.snap
+++ b/framec/tests/snapshots/cpp_snapshots__selfcall.snap
@@ -172,13 +172,8 @@ public:
         SelfCallFrameEvent __e("kick");
         SelfCallFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            _context_stack.pop_back();
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
 
     }
 
@@ -186,15 +181,10 @@ public:
         SelfCallFrameEvent __e("report");
         SelfCallFrameContext __ctx(std::move(__e), std::any(int()));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
-            _context_stack.pop_back();
-            return __result;
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
+        auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
+        return __result;
 
     }
 };

--- a/framec/tests/snapshots/cpp_snapshots__state_args.snap
+++ b/framec/tests/snapshots/cpp_snapshots__state_args.snap
@@ -193,13 +193,8 @@ public:
         StateArgsFrameEvent __e("load", std::vector<std::any>{initial});
         StateArgsFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            _context_stack.pop_back();
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
 
     }
 
@@ -207,13 +202,8 @@ public:
         StateArgsFrameEvent __e("adjust", std::vector<std::any>{delta});
         StateArgsFrameContext __ctx(std::move(__e));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            _context_stack.pop_back();
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
 
     }
 
@@ -221,15 +211,10 @@ public:
         StateArgsFrameEvent __e("peek");
         StateArgsFrameContext __ctx(std::move(__e), std::any(int()));
         _context_stack.push_back(std::move(__ctx));
-        try {
-            __kernel(_context_stack.back()._event);
-            auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
-            _context_stack.pop_back();
-            return __result;
-        } catch (...) {
-            _context_stack.pop_back();
-            throw;
-        }
+        struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
+        __kernel(_context_stack.back()._event);
+        auto __result = std::any_cast<int>(std::move(_context_stack.back()._return));
+        return __result;
 
     }
 };


### PR DESCRIPTION
Fixes #86.

## Problem
The C++ backend wrapped every interface-method dispatch in an unconditional `try { __kernel; pop } catch (...) { pop; throw }`. The catch only re-popped `_context_stack` and rethrew — and Frame handlers are state transitions that never throw, so the path was dead. But emitting `try/catch/throw` makes C++ output depend on a C++ exception runtime, which **Godot's web (wasm) engine is built without** (`-fno-exceptions`): a GDExtension that ran natively failed to *link* on web (`undefined symbol invoke_ji`). The reporter proved that stripping the wrappers and building `-fno-exceptions` makes the Asteroids GDExtension load and play in the browser.

## Fix
Replace the try/catch with a method-local **RAII scope-guard** whose destructor pops:
```cpp
struct __CtxGuard { decltype(_context_stack)& s; ~__CtxGuard() { s.pop_back(); } } __ctx_guard{_context_stack};
```
Same balance invariant on every exit path (normal return AND, when exceptions are enabled, unwinding), zero `try/catch/throw`, so framec C++ output compiles and links under `-fno-exceptions`. Implements RFC-0044's C++ recommendation. Applies to sync and async (`co_await`) dispatch; operations don't wrap, so they're unchanged.

## Exception Policy (new)
Added to the language reference: core generated code maintains its invariants with each language's idiomatic scope-cleanup (RAII / `defer` / `finally`), never a mandatory catch-and-rethrow, so it compiles under a target's no-exceptions mode wherever one exists. Exceptions appear **only in opt-in features whose semantics are inherently fallible** — `@@[persist]` (C++ `std::any` probing) and `@@[async]` (E703) — each documented as requiring host exception support. RFC-0044's C++ row marked implemented.

## Gate
`issue86_cpp_dispatch_is_exception_free` (cpp_snapshots.rs): asserts core C++ output has zero `try`/`catch`/`throw` **and** compiles under `-std=c++17 -fno-exceptions` — the exact Godot-web condition.

## Validation
- `cargo test` green; clippy `-D warnings` + fmt clean; doc-sample gate 118/118.
- Generated C++ compiles **and runs** under `-fno-exceptions` (verified end-to-end).
- C++ matrix **328/0**; Swift **320/0**; other 15 backends unchanged. Snapshot churn is C++-only and purely the guard swap.

## Scope & follow-ups
Core C++ dispatch only, per the agreed plan. Filed: **#87** (C++ persist no-throw `any_cast`), **#88** (C++ async exception dependency), **#89** (Swift `defer` hardening — the optional Swift part was reverted from this PR because it tripped a pre-existing async-stdout test flake; the codegen itself was verified correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)