### PR TITLE
fix(c): float/double args on pop$ via _Generic value dispatch (#83, RFC-0048)

### DIFF
--- a/docs/rfcs/rfc-0048.md
+++ b/docs/rfcs/rfc-0048.md
@@ -1,0 +1,147 @@
+---
+title: "RFC-0048: Self-describing argument marshalling for type-blind push sites"
+nav_exclude: true
+---
+
+# RFC-0048 — Self-describing argument marshalling for type-blind push sites
+
+- **Status:** Accepted — implemented for C via `_Generic` (2026-06-14, issue #83)
+- **Author:** Mark Truluck <mark.truluck@cogiton.com>
+- **Created:** 2026-06-14
+- **Builds on:** RFC-0020 (runtime kernel), RFC-0008 (modal stack / `pop$`), #81 (C heap-boxed doubles)
+- **Relates to:** the C argument marshalling in
+  `framec/src/frame_c/compiler/codegen/frame_expansion/{transition,pop_transition}.rs`
+  and `framec/src/frame_c/compiler/codegen/runtime/c.rs`
+
+The key words **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY**
+are to be interpreted as described in RFC 2119.
+
+## Summary
+
+Frame passes state/enter/exit arguments through per-backend containers. On
+**self-describing** backends — dynamic languages (a Python `float` is a real
+float object) and type-erased managed languages (`std::any`, `Object`, `Any`,
+`interface{}`, `Box<dyn Any>`) — the value carries its own runtime type, so the
+*reader* recovers it without the *writer* needing to know the declared type.
+
+**C is the lone backend whose container slot (`void*`) is not self-describing.**
+A `void*` carries no type tag, and the correct representation of a value depends
+on its type: a `double` MUST be heap-boxed (#81 — it neither fits nor round-trips
+as an integer), while ints, strings, and pointers travel directly in the slot.
+The C reader (`$>` / `<$` / handler-param binding) chooses its unmarshal from the
+**declared** parameter type, so the writer MUST produce the matching
+representation — which means the writer needs the type too.
+
+For a **normal** transition `-> $State(args)` the target state is statically
+known, so framec looks up the declared param types and marshals each value
+correctly (the `state_param_types` / `state_enter_param_types` plumbing from #81).
+But for a **`pop$`** transition the popped target state is whatever sits on the
+runtime modal stack — **statically unknowable**. The type-blind push there fell
+back to `(void*)(intptr_t)(value)`, which is correct for ints/strings/pointers
+but **truncates a `double`** (and the typed reader then dereferences the
+truncated integer as if it were a heap box — a crash). This is **issue #83**.
+
+This RFC establishes the general principle and its C realization.
+
+## Rationale: issue #83
+
+`-> (3.25) pop$` followed by a restored `$>(x: float)`:
+
+- **Before:** the pop site pushed `(void*)(intptr_t)(3.25)` → the slot holds the
+  integer `3` cast to a pointer. The handler reads `unpack_double(slot)`, which
+  dereferences `(double*)3` → **segfault / garbage**. Floats on `pop$` were
+  effectively unsupported on C (every other backend handled them fine).
+- **After:** the value round-trips exactly (`3.25`), and the output compiles
+  under `-std=c11 -fno-exceptions` (so it remains usable as a Godot-web
+  GDExtension, cf. #86).
+
+Only **C**, only **`pop$`**, only **floating-point** args were affected — because
+C is the only non-self-describing slot, `pop$` is the only push whose target type
+is unknown, and `double`/`float` is the only supported type whose representation
+diverges from the `intptr_t`/pointer default (structs-by-value also diverge but
+are already unsupported as C args).
+
+## Principle
+
+> At a push site where the declared target type is statically unavailable, the
+> writer MUST NOT guess a representation. Instead it MUST defer
+> representation-selection to a mechanism that knows the value's type — either
+> the target language's own static type dispatch over the value, or a
+> self-describing (tagged) slot. The reader's representation is thereby always
+> matched without the writer knowing the declared type.
+
+This generalizes beyond C: any future low-level backend whose argument container
+is not self-describing (an older C dialect, an embedded or register-level target,
+a language with only monomorphic typed containers) will hit the same wall and
+SHOULD adopt the same principle.
+
+## C design (implemented): `_Generic` value dispatch
+
+C11 `_Generic` selects an expression by the **static type of a value**. framec
+emits a per-system macro that dispatches the push on the *value's* type — exactly
+the type information the type-blind site lacks about the *target* — and the value
+and the declared param agree in any correct program, so the representation the
+macro produces is the one the reader expects:
+
+```c
+#define Sys_ARG_IS_FLOAT(v) _Generic((v), double:1, float:1, long double:1, default:0)
+#define Sys_ARG_DBL(v)      _Generic((v), double:(v), float:(v), long double:(double)0, default:(double)0)
+#define Sys_ARG_WORD(v)     _Generic((v), double:(void*)0, float:(void*)0, long double:(void*)0, default:(void*)(intptr_t)(v))
+#define Sys_ARG_PUSH(vec, v) ( Sys_ARG_IS_FLOAT(v) \
+    ? Sys_FrameVec_push_owned((vec), Sys_pack_double(Sys_ARG_DBL(v))) \
+    : Sys_FrameVec_push((vec), Sys_ARG_WORD(v)) )
+```
+
+Correctness notes:
+
+- **Floating-point → owned heap box** (`pack_double`, #81): the vec frees it on
+  destroy and deep-copies it on compartment copy. Everything else → the
+  `intptr_t`/pointer slot, stored un-owned (the caller owns strings; ints aren't
+  pointers).
+- **Every `_Generic` branch is a valid expression for any argument type.** The
+  float branches use the raw value `(v)` (never an invalid `(double)pointer`
+  cast); the default casts through `intptr_t`, valid for both ints and pointers.
+  This sidesteps the `_Generic` gotcha that *all* branches — not just the selected
+  one — are type-checked.
+- **The argument is evaluated exactly once.** A `_Generic` controlling expression
+  is not evaluated (only its type is used), and the compile-time-constant ternary
+  drops the dead arm, so the live value expression is evaluated once in the
+  selected branch.
+- **No representation change, no reader change.** The macro produces the *same*
+  bare `void*` representation the typed marshal already produces for that type, so
+  the existing `$>`/`<$` readers (which unmarshal by declared type) are untouched,
+  and a slot pushed by `pop$` is indistinguishable from one pushed by a normal
+  transition.
+
+Applied at the two type-blind C sites in `pop_transition.rs`: `pop$` **enter-args**
+(`-> (args) pop$`) and `pop$` **exit-args** (`(args) -> pop$`).
+
+## Alternatives considered
+
+- **Tagged-union slot** (`struct { uint8_t tag; union {...}; }`) — a hand-rolled
+  `std::any` for C. More general (works for languages without `_Generic`) but a
+  cross-cutting representation change rippling through every read/copy/persist
+  site. Rejected for C as unnecessary: `_Generic` achieves the same result with
+  zero representation change. **Retained as the recommended path for a future
+  non-`_Generic` low-level backend.**
+- **Type inference in framec** — infer the value's type for the common cases
+  (field refs, literals) and marshal directly. Partial (fails on arbitrary native
+  expressions), and redundant with what the C compiler already knows via
+  `_Generic`. Rejected.
+- **Diagnostic only** (warn/error on float `pop$` args) — the honest stopgap, but
+  strictly worse than a fix that makes the feature work. Superseded.
+
+## Future work
+
+`_Generic` value-dispatch could also *replace* the `state_param_types` /
+`state_enter_param_types` lookup plumbing for **normal** transitions (#81): since
+the macro derives the marshal from the value, framec would no longer need to
+thread declared types to the C push sites at all. Out of scope here (the typed
+path works and is well-tested); noted as a consolidation opportunity.
+
+## Drawbacks
+
+- C11-specific. A pre-C11 target would need the tagged-union alternative. framec's
+  C output already requires C11 (e.g. the `_Static`-free `Sys_strdup_` shim and the
+  `-std=c11` compile gates), so this is not a new constraint.
+- Slightly larger emitted runtime (four macro lines per system).

--- a/framec/src/frame_c/compiler/codegen/frame_expansion/pop_transition.rs
+++ b/framec/src/frame_c/compiler/codegen/frame_expansion/pop_transition.rs
@@ -103,7 +103,14 @@ pub(super) fn generate_pop_transition(
                 }
                 TargetLanguage::Rust => {}
                 TargetLanguage::C => {
-                    code.push_str(&format!("{}{}_FrameVec_push(self->__compartment->exit_args, (void*)(intptr_t)({}));\n", indent, ctx.system_name, value));
+                    // Value-dispatched push (#83, RFC-0048): floating-point
+                    // exit-args heap-box, everything else takes the int/ptr
+                    // slot — matching the `<$` read side without a declared-
+                    // type lookup. See `{sys}_ARG_PUSH` in runtime/c.rs.
+                    code.push_str(&format!(
+                        "{}{}_ARG_PUSH(self->__compartment->exit_args, {});\n",
+                        indent, ctx.system_name, value
+                    ));
                 }
                 TargetLanguage::Cpp => {
                     code.push_str(&format!(
@@ -233,14 +240,15 @@ pub(super) fn generate_pop_transition(
                 TargetLanguage::Rust => {}
                 TargetLanguage::C => {
                     // The popped target state is runtime-determined, so the
-                    // declared enter-param type is statically unknowable —
-                    // this push keeps the historical intptr_t fallback.
-                    // Float/double pop-args are therefore UNSUPPORTED on C
-                    // (the typed read would deref a non-box, #81): tracked
-                    // as a follow-up; do not silently route through
-                    // pack_double here without a type to key on.
+                    // declared enter-param type is statically unknowable.
+                    // `{sys}_ARG_PUSH` (#83, RFC-0048) dispatches on the
+                    // VALUE's static C type via `_Generic`: floating-point
+                    // values heap-box (owned, like the typed marshal),
+                    // everything else takes the intptr_t/pointer slot — so a
+                    // float pop-arg round-trips through the `$>` read instead
+                    // of being truncated by the old intptr_t fallback.
                     code.push_str(&format!(
-                        "{}{}_FrameVec_push(__saved->enter_args, (void*)(intptr_t)({}));\n",
+                        "{}{}_ARG_PUSH(__saved->enter_args, {});\n",
                         indent, ctx.system_name, value
                     ));
                 }

--- a/framec/src/frame_c/compiler/codegen/runtime/c.rs
+++ b/framec/src/frame_c/compiler/codegen/runtime/c.rs
@@ -467,6 +467,45 @@ fn generate_c_runtime_types(system: &SystemAst) -> String {
     code.push_str("}\n\n");
 
     // ============================================================================
+    // Type-blind argument push (#83, RFC-0048)
+    // ============================================================================
+    // At a `pop$` site the popped target state is runtime-determined, so the
+    // declared `$>` / `<$` parameter type is statically unknowable — unlike a
+    // normal `-> $State(args)` transition, where framec looks the type up and
+    // marshals each value accordingly. A C `void*` slot is not self-describing
+    // (it carries no type tag), so a type-blind push can't pick the right
+    // representation: a `double` MUST heap-box (#81), everything else takes the
+    // `intptr_t`/pointer slot. `_Generic` resolves this by dispatching on the
+    // VALUE's static C type instead of the (unknown) declared type — the value
+    // and the declared param agree in a correct program, so the representation
+    // matches what the `$>`/`<$` read side expects. Floating-point values box
+    // (owned, so the vec frees/deep-copies them); everything else is stored
+    // directly. Every `_Generic` branch is a valid expression for ANY argument
+    // type (the float branches use the raw value; the default casts through
+    // `intptr_t`, valid for both ints and pointers), and the controlling
+    // expression is never evaluated — so the argument is evaluated exactly once,
+    // in the selected branch of the taken ternary arm.
+    code.push_str(&format!(
+        "// ============================================================================\n"
+    ));
+    code.push_str(&format!(
+        "#define {sys}_ARG_IS_FLOAT(v) _Generic((v), double:1, float:1, long double:1, default:0)\n",
+        sys = sys
+    ));
+    code.push_str(&format!(
+        "#define {sys}_ARG_DBL(v) _Generic((v), double:(v), float:(v), long double:(double)0, default:(double)0)\n",
+        sys = sys
+    ));
+    code.push_str(&format!(
+        "#define {sys}_ARG_WORD(v) _Generic((v), double:(void*)0, float:(void*)0, long double:(void*)0, default:(void*)(intptr_t)(v))\n",
+        sys = sys
+    ));
+    code.push_str(&format!(
+        "#define {sys}_ARG_PUSH(vec, v) ( {sys}_ARG_IS_FLOAT(v) \\\n    ? {sys}_FrameVec_push_owned((vec), {sys}_pack_double({sys}_ARG_DBL(v))) \\\n    : {sys}_FrameVec_push((vec), {sys}_ARG_WORD(v)) )\n\n",
+        sys = sys
+    ));
+
+    // ============================================================================
     // Persist dispatcher — type-ignorant codegen
     // ============================================================================
     // framec mangles each field's declared C type to a symbol suffix

--- a/framec/tests/c_snapshots.rs
+++ b/framec/tests/c_snapshots.rs
@@ -210,3 +210,99 @@ fn issue81_float_roundtrip_runs_wasm32() {
         String::from_utf8_lossy(&run.stderr)
     );
 }
+
+/// RUNTIME gate for the C backend (#83 / RFC-0048) — float args on a `pop$`
+/// transition, compiled AND executed. At a `pop$` the popped target state is
+/// runtime-determined, so the declared `$>`/`<$` param type is statically
+/// unknown; the old codegen pushed pop-args via `(void*)(intptr_t)(value)`,
+/// which truncates a float and leaves the typed reader dereferencing a non-box
+/// (crash). `{sys}_ARG_PUSH` now dispatches on the value's static type via
+/// `_Generic`. The fixture exercises BOTH type-blind sites (enter-args and
+/// exit-args on `pop$`) and asserts the values; only execution catches this
+/// class. Compiled `-fno-exceptions` so the fix stays Godot-web-clean (#86).
+///
+/// Skipped (not failed) when no C compiler is on PATH.
+#[test]
+fn issue83_pop_float_args_runs() {
+    use std::process::Command;
+    let cc = match common::find_tool("gcc")
+        .or_else(|| common::find_tool("clang"))
+        .or_else(|| common::find_tool("cc"))
+    {
+        Some(p) => p,
+        None => {
+            eprintln!("#83 c runtime gate skipped: no C compiler on PATH");
+            return;
+        }
+    };
+    let code = compile_fixture("18_pop_float_args", "c");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("18_pop_float_args.c");
+    let bin = dir.path().join("rt");
+    std::fs::write(&src, &code).expect("write tempfile");
+    let build = Command::new(&cc)
+        .args(["-std=c11", "-fno-exceptions", "-o"])
+        .arg(&bin)
+        .arg(&src)
+        .output()
+        .expect("cc process");
+    assert!(
+        build.status.success(),
+        "#83: pop-float-args fixture failed to compile.\n--- stderr ---\n{}\n--- generated source ---\n{}",
+        String::from_utf8_lossy(&build.stderr),
+        code
+    );
+    let run = Command::new(&bin).output().expect("run process");
+    assert!(
+        run.status.success(),
+        "#83: pop-float-args fixture FAILED AT RUNTIME (float pop-arg truncated / non-box deref).\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+}
+
+/// wasm32 RUNTIME gate for #83 — same `pop$` float-args fixture under
+/// Emscripten (32-bit pointers) + node, the configuration the old `void*`
+/// bit-pun corrupted. Skipped when emcc or node is absent (RFC-0034).
+#[test]
+fn issue83_pop_float_args_runs_wasm32() {
+    use std::process::Command;
+    let emcc = match common::find_tool("emcc") {
+        Some(p) => p,
+        None => {
+            eprintln!("#83 wasm32 runtime gate skipped: emcc not on PATH");
+            return;
+        }
+    };
+    let node = match common::find_tool("node") {
+        Some(p) => p,
+        None => {
+            eprintln!("#83 wasm32 runtime gate skipped: node not on PATH");
+            return;
+        }
+    };
+    let code = compile_fixture("18_pop_float_args", "c");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("18_pop_float_args.c");
+    let js = dir.path().join("rt.js");
+    std::fs::write(&src, &code).expect("write tempfile");
+    let build = Command::new(&emcc)
+        .args(["-std=c11", "-o"])
+        .arg(&js)
+        .arg(&src)
+        .output()
+        .expect("emcc process");
+    assert!(
+        build.status.success(),
+        "#83: pop-float-args fixture failed to compile for wasm32.\n--- stderr ---\n{}\n--- generated source ---\n{}",
+        String::from_utf8_lossy(&build.stderr),
+        code
+    );
+    let run = Command::new(&node).arg(&js).output().expect("node process");
+    assert!(
+        run.status.success(),
+        "#83: pop-float-args fixture FAILED AT RUNTIME ON wasm32.\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+}

--- a/framec/tests/fixtures/c/18_pop_float_args.frm
+++ b/framec/tests/fixtures/c/18_pop_float_args.frm
@@ -1,0 +1,52 @@
+// Runtime gate fixture for the C target (#83 / RFC-0048) — float args on a
+// `pop$` transition, executed (not just compiled).
+//
+// At a `pop$` the popped target state is runtime-determined, so the declared
+// `$>` / `<$` param type is statically unknown. The old C codegen pushed
+// pop-args via `(void*)(intptr_t)(value)`, which truncates a float and leaves
+// the typed reader dereferencing a non-box (crash). `{sys}_ARG_PUSH` now
+// dispatches on the VALUE's static type via `_Generic`, so float pop-args
+// heap-box and round-trip. Covers BOTH type-blind sites:
+//   - enter-args:  `-> (3.25) pop$`  → restored `$Idle.$>(x: float)`
+//   - exit-args:   `(2.5) -> pop$`   → leaving  `$Work.<$(y: float)`
+// Dyadic fractions (exact in float and double) so `==` is sound while any
+// integer truncation still fails.
+
+#include <stdio.h>
+#include <stdlib.h>
+
+@@[main]
+@@system PopArgs {
+    interface:
+        go()
+        finish()
+        peek_enter(): float
+        peek_exit(): float
+    machine:
+        $Idle {
+            $>(x: float) { @@:self.enter_seen = x; }
+            go() { push$ -> $Work }
+            peek_enter(): float { @@:(@@:self.enter_seen) }
+            peek_exit(): float { @@:(@@:self.exit_seen) }
+        }
+        $Work {
+            <$(y: float) { @@:self.exit_seen = y; }
+            finish() { (2.5) -> (3.25) pop$ }
+        }
+    domain:
+        enter_seen: float = 0.0
+        exit_seen: float = 0.0
+}
+
+int main() {
+    PopArgs* p = @@PopArgs();
+    PopArgs_go(p);
+    PopArgs_finish(p);
+    double e = PopArgs_peek_enter(p);
+    double x = PopArgs_peek_exit(p);
+    if (e != 3.25) { printf("FAIL pop enter-arg: %f\n", e); return 1; }
+    if (x != 2.5)  { printf("FAIL pop exit-arg: %f\n", x); return 1; }
+    printf("PASS: 18_pop_float_args enter=%f exit=%f\n", e, x);
+    PopArgs_destroy(p);
+    return 0;
+}

--- a/framec/tests/snapshots/c_snapshots__actions.snap
+++ b/framec/tests/snapshots/c_snapshots__actions.snap
@@ -257,6 +257,14 @@ static inline double Actions_unpack_double(void* p) {
 }
 
 // ============================================================================
+#define Actions_ARG_IS_FLOAT(v) _Generic((v), double:1, float:1, long double:1, default:0)
+#define Actions_ARG_DBL(v) _Generic((v), double:(v), float:(v), long double:(double)0, default:(double)0)
+#define Actions_ARG_WORD(v) _Generic((v), double:(void*)0, float:(void*)0, long double:(void*)0, default:(void*)(intptr_t)(v))
+#define Actions_ARG_PUSH(vec, v) ( Actions_ARG_IS_FLOAT(v) \
+    ? Actions_FrameVec_push_owned((vec), Actions_pack_double(Actions_ARG_DBL(v))) \
+    : Actions_FrameVec_push((vec), Actions_ARG_WORD(v)) )
+
+// ============================================================================
 // Actions_FrameEvent - Event routing object
 // ============================================================================
 

--- a/framec/tests/snapshots/c_snapshots__consts.snap
+++ b/framec/tests/snapshots/c_snapshots__consts.snap
@@ -257,6 +257,14 @@ static inline double Consts_unpack_double(void* p) {
 }
 
 // ============================================================================
+#define Consts_ARG_IS_FLOAT(v) _Generic((v), double:1, float:1, long double:1, default:0)
+#define Consts_ARG_DBL(v) _Generic((v), double:(v), float:(v), long double:(double)0, default:(double)0)
+#define Consts_ARG_WORD(v) _Generic((v), double:(void*)0, float:(void*)0, long double:(void*)0, default:(void*)(intptr_t)(v))
+#define Consts_ARG_PUSH(vec, v) ( Consts_ARG_IS_FLOAT(v) \
+    ? Consts_FrameVec_push_owned((vec), Consts_pack_double(Consts_ARG_DBL(v))) \
+    : Consts_FrameVec_push((vec), Consts_ARG_WORD(v)) )
+
+// ============================================================================
 // Consts_FrameEvent - Event routing object
 // ============================================================================
 

--- a/framec/tests/snapshots/c_snapshots__forward.snap
+++ b/framec/tests/snapshots/c_snapshots__forward.snap
@@ -257,6 +257,14 @@ static inline double Forward_unpack_double(void* p) {
 }
 
 // ============================================================================
+#define Forward_ARG_IS_FLOAT(v) _Generic((v), double:1, float:1, long double:1, default:0)
+#define Forward_ARG_DBL(v) _Generic((v), double:(v), float:(v), long double:(double)0, default:(double)0)
+#define Forward_ARG_WORD(v) _Generic((v), double:(void*)0, float:(void*)0, long double:(void*)0, default:(void*)(intptr_t)(v))
+#define Forward_ARG_PUSH(vec, v) ( Forward_ARG_IS_FLOAT(v) \
+    ? Forward_FrameVec_push_owned((vec), Forward_pack_double(Forward_ARG_DBL(v))) \
+    : Forward_FrameVec_push((vec), Forward_ARG_WORD(v)) )
+
+// ============================================================================
 // Forward_FrameEvent - Event routing object
 // ============================================================================
 

--- a/framec/tests/snapshots/c_snapshots__hsm.snap
+++ b/framec/tests/snapshots/c_snapshots__hsm.snap
@@ -257,6 +257,14 @@ static inline double MiniHsm_unpack_double(void* p) {
 }
 
 // ============================================================================
+#define MiniHsm_ARG_IS_FLOAT(v) _Generic((v), double:1, float:1, long double:1, default:0)
+#define MiniHsm_ARG_DBL(v) _Generic((v), double:(v), float:(v), long double:(double)0, default:(double)0)
+#define MiniHsm_ARG_WORD(v) _Generic((v), double:(void*)0, float:(void*)0, long double:(void*)0, default:(void*)(intptr_t)(v))
+#define MiniHsm_ARG_PUSH(vec, v) ( MiniHsm_ARG_IS_FLOAT(v) \
+    ? MiniHsm_FrameVec_push_owned((vec), MiniHsm_pack_double(MiniHsm_ARG_DBL(v))) \
+    : MiniHsm_FrameVec_push((vec), MiniHsm_ARG_WORD(v)) )
+
+// ============================================================================
 // MiniHsm_FrameEvent - Event routing object
 // ============================================================================
 

--- a/framec/tests/snapshots/c_snapshots__lifecycle.snap
+++ b/framec/tests/snapshots/c_snapshots__lifecycle.snap
@@ -257,6 +257,14 @@ static inline double Lifecycle_unpack_double(void* p) {
 }
 
 // ============================================================================
+#define Lifecycle_ARG_IS_FLOAT(v) _Generic((v), double:1, float:1, long double:1, default:0)
+#define Lifecycle_ARG_DBL(v) _Generic((v), double:(v), float:(v), long double:(double)0, default:(double)0)
+#define Lifecycle_ARG_WORD(v) _Generic((v), double:(void*)0, float:(void*)0, long double:(void*)0, default:(void*)(intptr_t)(v))
+#define Lifecycle_ARG_PUSH(vec, v) ( Lifecycle_ARG_IS_FLOAT(v) \
+    ? Lifecycle_FrameVec_push_owned((vec), Lifecycle_pack_double(Lifecycle_ARG_DBL(v))) \
+    : Lifecycle_FrameVec_push((vec), Lifecycle_ARG_WORD(v)) )
+
+// ============================================================================
 // Lifecycle_FrameEvent - Event routing object
 // ============================================================================
 

--- a/framec/tests/snapshots/c_snapshots__lifecycle_args.snap
+++ b/framec/tests/snapshots/c_snapshots__lifecycle_args.snap
@@ -257,6 +257,14 @@ static inline double LifecycleArgs_unpack_double(void* p) {
 }
 
 // ============================================================================
+#define LifecycleArgs_ARG_IS_FLOAT(v) _Generic((v), double:1, float:1, long double:1, default:0)
+#define LifecycleArgs_ARG_DBL(v) _Generic((v), double:(v), float:(v), long double:(double)0, default:(double)0)
+#define LifecycleArgs_ARG_WORD(v) _Generic((v), double:(void*)0, float:(void*)0, long double:(void*)0, default:(void*)(intptr_t)(v))
+#define LifecycleArgs_ARG_PUSH(vec, v) ( LifecycleArgs_ARG_IS_FLOAT(v) \
+    ? LifecycleArgs_FrameVec_push_owned((vec), LifecycleArgs_pack_double(LifecycleArgs_ARG_DBL(v))) \
+    : LifecycleArgs_FrameVec_push((vec), LifecycleArgs_ARG_WORD(v)) )
+
+// ============================================================================
 // LifecycleArgs_FrameEvent - Event routing object
 // ============================================================================
 

--- a/framec/tests/snapshots/c_snapshots__linear_fsm.snap
+++ b/framec/tests/snapshots/c_snapshots__linear_fsm.snap
@@ -257,6 +257,14 @@ static inline double LinearFsm_unpack_double(void* p) {
 }
 
 // ============================================================================
+#define LinearFsm_ARG_IS_FLOAT(v) _Generic((v), double:1, float:1, long double:1, default:0)
+#define LinearFsm_ARG_DBL(v) _Generic((v), double:(v), float:(v), long double:(double)0, default:(double)0)
+#define LinearFsm_ARG_WORD(v) _Generic((v), double:(void*)0, float:(void*)0, long double:(void*)0, default:(void*)(intptr_t)(v))
+#define LinearFsm_ARG_PUSH(vec, v) ( LinearFsm_ARG_IS_FLOAT(v) \
+    ? LinearFsm_FrameVec_push_owned((vec), LinearFsm_pack_double(LinearFsm_ARG_DBL(v))) \
+    : LinearFsm_FrameVec_push((vec), LinearFsm_ARG_WORD(v)) )
+
+// ============================================================================
 // LinearFsm_FrameEvent - Event routing object
 // ============================================================================
 

--- a/framec/tests/snapshots/c_snapshots__no_persist.snap
+++ b/framec/tests/snapshots/c_snapshots__no_persist.snap
@@ -257,6 +257,14 @@ static inline double NoPersist_unpack_double(void* p) {
 }
 
 // ============================================================================
+#define NoPersist_ARG_IS_FLOAT(v) _Generic((v), double:1, float:1, long double:1, default:0)
+#define NoPersist_ARG_DBL(v) _Generic((v), double:(v), float:(v), long double:(double)0, default:(double)0)
+#define NoPersist_ARG_WORD(v) _Generic((v), double:(void*)0, float:(void*)0, long double:(void*)0, default:(void*)(intptr_t)(v))
+#define NoPersist_ARG_PUSH(vec, v) ( NoPersist_ARG_IS_FLOAT(v) \
+    ? NoPersist_FrameVec_push_owned((vec), NoPersist_pack_double(NoPersist_ARG_DBL(v))) \
+    : NoPersist_FrameVec_push((vec), NoPersist_ARG_WORD(v)) )
+
+// ============================================================================
 // NoPersist_persist_pack_*  /  NoPersist_persist_unpack_*  — persist dispatcher
 // ============================================================================
 

--- a/framec/tests/snapshots/c_snapshots__persist.snap
+++ b/framec/tests/snapshots/c_snapshots__persist.snap
@@ -257,6 +257,14 @@ static inline double Counter_unpack_double(void* p) {
 }
 
 // ============================================================================
+#define Counter_ARG_IS_FLOAT(v) _Generic((v), double:1, float:1, long double:1, default:0)
+#define Counter_ARG_DBL(v) _Generic((v), double:(v), float:(v), long double:(double)0, default:(double)0)
+#define Counter_ARG_WORD(v) _Generic((v), double:(void*)0, float:(void*)0, long double:(void*)0, default:(void*)(intptr_t)(v))
+#define Counter_ARG_PUSH(vec, v) ( Counter_ARG_IS_FLOAT(v) \
+    ? Counter_FrameVec_push_owned((vec), Counter_pack_double(Counter_ARG_DBL(v))) \
+    : Counter_FrameVec_push((vec), Counter_ARG_WORD(v)) )
+
+// ============================================================================
 // Counter_persist_pack_*  /  Counter_persist_unpack_*  — persist dispatcher
 // ============================================================================
 

--- a/framec/tests/snapshots/c_snapshots__pushpop.snap
+++ b/framec/tests/snapshots/c_snapshots__pushpop.snap
@@ -257,6 +257,14 @@ static inline double PushPop_unpack_double(void* p) {
 }
 
 // ============================================================================
+#define PushPop_ARG_IS_FLOAT(v) _Generic((v), double:1, float:1, long double:1, default:0)
+#define PushPop_ARG_DBL(v) _Generic((v), double:(v), float:(v), long double:(double)0, default:(double)0)
+#define PushPop_ARG_WORD(v) _Generic((v), double:(void*)0, float:(void*)0, long double:(void*)0, default:(void*)(intptr_t)(v))
+#define PushPop_ARG_PUSH(vec, v) ( PushPop_ARG_IS_FLOAT(v) \
+    ? PushPop_FrameVec_push_owned((vec), PushPop_pack_double(PushPop_ARG_DBL(v))) \
+    : PushPop_FrameVec_push((vec), PushPop_ARG_WORD(v)) )
+
+// ============================================================================
 // PushPop_FrameEvent - Event routing object
 // ============================================================================
 

--- a/framec/tests/snapshots/c_snapshots__return_explicit.snap
+++ b/framec/tests/snapshots/c_snapshots__return_explicit.snap
@@ -257,6 +257,14 @@ static inline double ReturnExplicit_unpack_double(void* p) {
 }
 
 // ============================================================================
+#define ReturnExplicit_ARG_IS_FLOAT(v) _Generic((v), double:1, float:1, long double:1, default:0)
+#define ReturnExplicit_ARG_DBL(v) _Generic((v), double:(v), float:(v), long double:(double)0, default:(double)0)
+#define ReturnExplicit_ARG_WORD(v) _Generic((v), double:(void*)0, float:(void*)0, long double:(void*)0, default:(void*)(intptr_t)(v))
+#define ReturnExplicit_ARG_PUSH(vec, v) ( ReturnExplicit_ARG_IS_FLOAT(v) \
+    ? ReturnExplicit_FrameVec_push_owned((vec), ReturnExplicit_pack_double(ReturnExplicit_ARG_DBL(v))) \
+    : ReturnExplicit_FrameVec_push((vec), ReturnExplicit_ARG_WORD(v)) )
+
+// ============================================================================
 // ReturnExplicit_FrameEvent - Event routing object
 // ============================================================================
 

--- a/framec/tests/snapshots/c_snapshots__selfcall.snap
+++ b/framec/tests/snapshots/c_snapshots__selfcall.snap
@@ -257,6 +257,14 @@ static inline double SelfCall_unpack_double(void* p) {
 }
 
 // ============================================================================
+#define SelfCall_ARG_IS_FLOAT(v) _Generic((v), double:1, float:1, long double:1, default:0)
+#define SelfCall_ARG_DBL(v) _Generic((v), double:(v), float:(v), long double:(double)0, default:(double)0)
+#define SelfCall_ARG_WORD(v) _Generic((v), double:(void*)0, float:(void*)0, long double:(void*)0, default:(void*)(intptr_t)(v))
+#define SelfCall_ARG_PUSH(vec, v) ( SelfCall_ARG_IS_FLOAT(v) \
+    ? SelfCall_FrameVec_push_owned((vec), SelfCall_pack_double(SelfCall_ARG_DBL(v))) \
+    : SelfCall_FrameVec_push((vec), SelfCall_ARG_WORD(v)) )
+
+// ============================================================================
 // SelfCall_FrameEvent - Event routing object
 // ============================================================================
 

--- a/framec/tests/snapshots/c_snapshots__state_args.snap
+++ b/framec/tests/snapshots/c_snapshots__state_args.snap
@@ -257,6 +257,14 @@ static inline double StateArgs_unpack_double(void* p) {
 }
 
 // ============================================================================
+#define StateArgs_ARG_IS_FLOAT(v) _Generic((v), double:1, float:1, long double:1, default:0)
+#define StateArgs_ARG_DBL(v) _Generic((v), double:(v), float:(v), long double:(double)0, default:(double)0)
+#define StateArgs_ARG_WORD(v) _Generic((v), double:(void*)0, float:(void*)0, long double:(void*)0, default:(void*)(intptr_t)(v))
+#define StateArgs_ARG_PUSH(vec, v) ( StateArgs_ARG_IS_FLOAT(v) \
+    ? StateArgs_FrameVec_push_owned((vec), StateArgs_pack_double(StateArgs_ARG_DBL(v))) \
+    : StateArgs_FrameVec_push((vec), StateArgs_ARG_WORD(v)) )
+
+// ============================================================================
 // StateArgs_FrameEvent - Event routing object
 // ============================================================================
 


### PR DESCRIPTION
Fixes #83.

## Problem
At a `pop$` the popped target state is runtime-determined, so the declared `$>`/`<$` param type is statically unknown. C's `void*` arg slot is **not self-describing**, and a `double` MUST heap-box (#81) while ints/strings/pointers travel directly — so the old type-blind push `(void*)(intptr_t)(value)` truncated floats, and the typed reader then dereferenced the truncated integer as a heap box (**crash**). C was the only backend affected: every other backend's arg container is self-describing (a Python float object; `std::any`/`Object`/`Any`/`interface{}`/`Box<dyn Any>`), so the writer never needs the type.

## Fix
A per-system `{sys}_ARG_PUSH` macro dispatches on the **value's** static C type via C11 `_Generic` — the type info the type-blind site lacks about the *target*, but which the value and the declared param share in any correct program:
```c
#define Sys_ARG_PUSH(vec, v) ( Sys_ARG_IS_FLOAT(v) \
    ? Sys_FrameVec_push_owned((vec), Sys_pack_double(Sys_ARG_DBL(v))) \
    : Sys_FrameVec_push((vec), Sys_ARG_WORD(v)) )
```
Floating-point → owned heap box (like the typed marshal); everything else → the intptr_t/pointer slot. Every `_Generic` branch is valid for any arg type (float branches use the raw value; default casts through `intptr_t`), the controlling expression is unevaluated, and the compile-time-constant ternary drops the dead arm → **the argument is evaluated exactly once** and the representation matches the reader. No representation change, no reader change — a pop-pushed slot is identical to a normal-transition slot. Applied at both type-blind C sites: pop$ **enter-args** and pop$ **exit-args**.

## RFC-0048
Records the general principle (defer representation-selection to the language's value-type dispatch, or a self-describing tagged slot) for **future non-self-describing backends** — older C dialects, embedded/register targets, monomorphic-container languages — with #83 as the motivating rationale and a tagged-union alternative retained for a hypothetical pre-`_Generic` target.

## Validation
- `cargo test` 820/0; clippy `-D warnings` + fmt clean.
- Snapshot churn is the macro block only (verified per fixture; `linear_fsm` with no pop confirms it's purely the added runtime macro).
- New gates `issue83_pop_float_args_runs` (+ wasm32) compile AND execute fixture 18 (float **enter- and exit-args** on pop$) under `-std=c11 -fno-exceptions` — only execution catches this class (old code crashed on a non-box deref).
- C matrix **332/0**; phase-19 (pushpop) fuzz **PASS**. Output stays `-fno-exceptions`-clean (Godot web, #86).

🤖 Generated with [Claude Code](https://claude.com/claude-code)