### PR TITLE
fix(cpp): exception-free persist + RFC-0049 exception philosophy (#87)

### DIFF
--- a/docs/frame_language.md
+++ b/docs/frame_language.md
@@ -1240,6 +1240,22 @@ Both `@@:self` and `@@:system` are syntactic prefixes. Bare forms are errors (E6
 
 ## Exception Policy
 
+> Rationale and the full normative rules are in
+> [RFC-0049](rfcs/rfc-0049.md). This section is the summary.
+
+Two principles govern when generated code may use exceptions:
+
+1. **Exceptional vs. expected.** Generated code MAY signal genuine *errors* and
+   broken *preconditions* with the target's idiomatic error mechanism. It MUST
+   NOT use any error mechanism — least of all exceptions — for *expected control
+   flow*, most commonly type discovery (use a non-throwing query like the
+   pointer `std::any_cast<T>(&v)`, `is_number()`, or a type tag).
+2. **One semantic, per-target mechanism, with a fallback.** Where the idiom is a
+   thrown exception and the target can compile exceptions out (notably C++
+   `-fno-exceptions`, required by Godot web), generated code provides a
+   compile-time fallback (`#if defined(__cpp_exceptions)` → `throw`, else
+   `abort`/null-guard) so output stays compilable without an exception runtime.
+
 Frame-generated code maintains its runtime invariants — most importantly the
 context-stack balance `len_after == len_before` around every dispatch — using
 **each language's idiomatic scope-cleanup construct, never a mandatory
@@ -1258,19 +1274,24 @@ generated code compiles under a target's no-exceptions mode wherever one exists*
 GDExtensions (issue #86). Frame event handlers are state transitions and do not
 throw, so there is nothing for a `catch` to handle on the normal path.
 
-Exceptions appear **only in opt-in features whose semantics are inherently
-fallible**, and each is documented as requiring host exception support:
+Remaining exception use is confined to **proper error/precondition signalling in
+opt-in features**, always with the `-fno-exceptions` fallback above:
 
+- **`@@[persist]`** — exception-free for the common path (issue #87). The C++
+  save side probes `std::any` with the non-throwing pointer `any_cast<T>(&v)` (no
+  type-discovery-by-catch). The only throws are the **E700** "system not
+  quiescent" precondition guard and tolerant typed restore, both behind
+  `#if defined(__cpp_exceptions)` with an `abort`/null-guard fallback — so
+  persisted systems compile under `-fno-exceptions`. (nlohmann::json self-switches
+  its internal throws to `abort` there.)
 - **`@@[async]`** — a concurrent second driver raises **E703** (single-driver
   violation), surfaced per backend as a thrown error / rejected future. On C++ the
-  coroutine machinery additionally uses `rethrow_exception`. Async systems are not
-  exception-free.
-- **`@@[persist]`** — the C++ save/load path probes `std::any` slot types, which
-  today uses `try { any_cast } catch`. (Convertible to no-throw pointer-form
-  `any_cast<T>(&v)`; tracked separately.)
+  coroutine machinery additionally uses `rethrow_exception`; async systems are not
+  yet `-fno-exceptions`-clean (tracked in #88).
 
 In short: **exceptions are optional, not the rule.** A plain synchronous,
-non-persisted system generates exception-free code on every backend.
+non-persisted system generates exception-free code on every backend, and a
+persisted one compiles `-fno-exceptions` too.
 
 ---
 

--- a/docs/rfcs/rfc-0049.md
+++ b/docs/rfcs/rfc-0049.md
@@ -1,0 +1,168 @@
+---
+title: "RFC-0049: Exception philosophy — errors vs. queries, and the cross-language fallback contract"
+nav_exclude: true
+---
+
+# RFC-0049 — Exception philosophy
+
+- **Status:** Accepted — 2026-06-14
+- **Author:** Mark Truluck <mark.truluck@cogiton.com>
+- **Builds on:** RFC-0043 (async layered casing / E703), RFC-0044 (context-stack
+  cleanup), #86 (the user-facing "Exception Policy" section in
+  `docs/frame_language.md`)
+- **First applications:** #86 (C++ core dispatch → RAII), #87 (full
+  `-fno-exceptions` persist), #88 (async exception dependency)
+
+The key words **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY**
+are to be interpreted as described in RFC 2119.
+
+## Summary
+
+Frame transpiles one source to seventeen target languages whose error-handling
+mechanisms differ fundamentally: some throw exceptions (Java, C#, C++, Python,
+…), some return error values (Rust `Result`, Go `error`), some have nothing
+(C). A recurring question — "may generated code use exceptions, and where?" —
+keeps surfacing per feature (async E703, persist, the context stack). This RFC
+gives the durable answer as **two orthogonal axes**, so the per-feature
+decisions stop being ad hoc:
+
+1. **Exceptional vs. Expected.** Generated code MAY use a language's error
+   mechanism to signal *genuine errors and broken contracts*. It MUST NOT use
+   any error mechanism — least of all exceptions — for *expected control flow*,
+   most commonly type discovery. The latter is a query, and queries never throw.
+2. **One semantic, per-target mechanism, with a fallback.** Frame expresses a
+   portable *semantic* ("this error is signaled"). Each backend emits it in its
+   native *mechanism*. Where that mechanism is a thrown exception **and** the
+   target can compile exceptions out (notably C++ `-fno-exceptions`, required by
+   Godot web), the generated code MUST provide a fallback so the output stays
+   compilable and well-defined without an exception runtime.
+
+This is the rationale behind the user-facing Exception Policy summary in the
+language reference; that section is the "what," this RFC is the "why."
+
+## Motivation
+
+"Exceptions aren't evil, but they're easy to use improperly." The improper uses
+are well known and language-agnostic:
+
+- **Exceptions as control flow.** `try { x = cast<int>(v); } catch { try cast<double>… }`
+  uses a thrown-and-caught exception to *discover a type*. Nothing has failed —
+  the value is some valid type — so this is branching, not error handling. Every
+  mature serializer rejects it (see Prior art).
+- **Exceptions with no fallback in a transpiler.** A generated `throw` that the
+  target may compile out (C++ `-fno-exceptions`) makes the output uncompilable
+  or undefined there, even though the *semantic* (signal an error) has a perfectly
+  good non-exception expression (`abort`, an error return, a `Result`).
+
+Both are silent: the first compiles and "works" while abusing the runtime; the
+second compiles fine *until* a downstream consumer turns exceptions off. Frame's
+multi-target nature makes the second especially sharp — it routinely emits the
+same semantic into a language that has no exceptions at all.
+
+## Prior art
+
+The dividing line this RFC draws is the one real serialization frameworks
+already draw:
+
+| Framework | Errors (corrupt blob, type mismatch, missing key) | Expected queries (which type? key present?) |
+|---|---|---|
+| nlohmann::json (C++) | `parse()`/`.get<T>()`/`.at()` **throw** | `.contains()`, `.is_number()`, `.value(k,def)`, non-throwing `find()`, pointer `any_cast<T>(&)` — **no throw** |
+| Jackson / `ObjectInputStream` (Java) | throw `IOException` / `InvalidClassException` | reflective `has`/`is` queries — no throw |
+| `System.Text.Json` (C#) | throw `JsonException` | `TryGetProperty`, `ValueKind` — no throw |
+| `pickle` / `json` (Python) | raise `UnpicklingError` / `JSONDecodeError` | `in`, `isinstance` — no raise |
+| serde (Rust) | `from_str() -> Result<T, Error>` — **values, no exceptions** | pattern match / `is_*` — no panic |
+| `encoding/json` (Go) | `Unmarshal() -> error` — **values, no exceptions** | type switch — no panic |
+
+Two conclusions: (a) errors are signaled — by exceptions *where the language
+uses them*, by error values where it doesn't; (b) **no** framework, throwing or
+not, uses its error channel for routine type discovery. Frame adopts both.
+
+## The policy
+
+### R1 — No error mechanism for expected control flow (MUST NOT)
+
+Generated code MUST NOT use exceptions (or `Result`/error-returns/panics) to
+express expected branching, including **type discovery**. Use the language's
+non-throwing query: the pointer form `std::any_cast<T>(&v)` (returns null), JSON
+`is_number()` / `contains()`, a stored type tag, or a discriminated union.
+
+### R2 — Errors and broken contracts MAY be signaled idiomatically (MAY)
+
+Generated code MAY signal a genuine error or precondition violation using the
+target's idiomatic error mechanism — throw on exception-based targets, `Result`
+on Rust, `error` return on Go, return code / `abort` on C.
+
+### R3 — Throws MUST have a no-exceptions fallback (MUST)
+
+Where R2's mechanism is a thrown exception **and** the target supports compiling
+exceptions out, the generated code MUST also emit a fallback that keeps the
+output compilable and well-defined without the exception runtime. The fallback
+is selected at the *target's* compile time (e.g. `#if defined(__cpp_exceptions)`
+in C++), so exception-enabled builds are **unchanged**:
+
+```cpp
+#if defined(__cpp_exceptions) || defined(__EXCEPTIONS)
+    throw std::runtime_error("E700: system not quiescent");
+#else
+    std::fprintf(stderr, "E700: system not quiescent\n");
+    std::abort();
+#endif
+```
+
+### R4 — Invariants are maintained without exceptions (MUST)
+
+Core runtime invariants (e.g. the kernel's context-stack balance) MUST be
+maintained with each language's scope-cleanup idiom (RAII / `defer` / `finally`),
+never a mandatory catch-and-rethrow. See #86 / RFC-0044. This keeps *core*
+dispatch exception-free on every backend independent of any feature.
+
+### Precondition errors vs. data errors
+
+A useful refinement for choosing the fallback. A **data error** (corrupt blob,
+version skew) is recoverable in principle → `Result`/throw/error-return that a
+caller can handle. A **precondition violation** (the program called an operation
+in an illegal state — e.g. `save()` mid-dispatch, E700) is a *programmer bug* →
+fail-fast (`assert`/`abort`/`panic`) is the canonical handling; the softer throw
+is kept only where it is the existing, catchable behavior. R3's `abort` fallback
+is therefore not a downgrade for preconditions — for E700/E703 it is arguably
+the more correct handling, and the throw is the compatibility path.
+
+## Classification of Frame's exception uses
+
+| Use | Kind | Rule | Treatment | Status |
+|---|---|---|---|---|
+| Context-stack balance (core dispatch) | Invariant | R4 | RAII / `defer` / `finally`; never catch-rethrow | #86 done (C++, Swift pending in #89) |
+| `any_cast` type-probe (C++ persist save) | **Expected (query)** | R1 | Remove → non-throwing pointer `any_cast<T>(&v)` | #87 |
+| E700 "system not quiescent" (persist save) | **Precondition error** | R2 + R3 | `throw` where available; `abort`-with-message fallback | #87 |
+| E703 single-driver violation (async) | **Contract error** | R2 + R3 | `throw`/rejected-future; fallback to be added | #88 |
+| nlohmann internal throws (persist) | Library, errors | — | Library self-switches to `abort` under `-fno-exceptions`; no Frame action | n/a |
+
+## Per-language error mechanism
+
+The portable semantic "signal this error" lowers per target:
+
+| Mechanism family | Targets | Form |
+|---|---|---|
+| Thrown exception (+ R3 fallback where compilable-out) | C++, Java, C#, Kotlin, Swift, Dart, Python, Ruby, PHP, TS, JS | `throw` / `raise`; C++ adds the `#if __cpp_exceptions` fallback |
+| Error value | Rust (`Result`), Go (`error`) | returned, never thrown |
+| Fail-fast / code | C, GDScript, Lua | `abort` / return code / `push_error` |
+| Process model | Erlang | `gen_statem` reply / crash-and-supervise |
+
+## Drawbacks and alternatives
+
+- **`#if` dual-path adds source.** A few guarded lines per throw site. Accepted:
+  exception-enabled builds are byte-identical, and the fallback is the price of
+  cross-target compilability.
+- **Alternative: forbid all generated throws.** Rejected — it would force an
+  error-value channel into exception-idiomatic languages, fighting their grain
+  for no benefit, and contradicts how those languages' own serializers work.
+- **Alternative: ignore `-fno-exceptions`.** Rejected — it blocks real targets
+  (Godot web, #86), and "compiles only with the exception runtime" is exactly the
+  silent trap R3 removes.
+
+## Relationship to other documents
+
+- The **Exception Policy** section of `docs/frame_language.md` is the normative
+  user-facing summary; it cites this RFC for rationale.
+- **RFC-0044** is the mechanism for R4 (context-stack cleanup) per backend.
+- **RFC-0043** introduced E703, now classified here under R2 + R3.

--- a/framec/src/frame_c/compiler/codegen/backends/cpp.rs
+++ b/framec/src/frame_c/compiler/codegen/backends/cpp.rs
@@ -939,6 +939,12 @@ impl LanguageBackend for CppBackend {
             // Required for `std::runtime_error` thrown by the RFC-0043
             // casing's E703 gate.
             "#include <stdexcept>".to_string(),
+            // RFC-0049 R3: the `-fno-exceptions` fallback for proper-error
+            // throws (persist's E700 quiescence guard) uses `std::abort`
+            // (<cstdlib>) + `std::fprintf` (<cstdio>) under `#if !defined
+            // exceptions`. Harmless on exception-enabled builds.
+            "#include <cstdlib>".to_string(),
+            "#include <cstdio>".to_string(),
         ]
     }
 

--- a/framec/src/frame_c/compiler/codegen/interface_gen/persist/cpp.rs
+++ b/framec/src/frame_c/compiler/codegen/interface_gen/persist/cpp.rs
@@ -116,8 +116,19 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
 
     // save_state
     let mut save_body = String::new();
+    // E700 is a PRECONDITION violation (save() called mid-dispatch) — a proper
+    // use of an exception (RFC-0049 R2), not control flow. Keep the throw where
+    // exceptions exist (exception-enabled builds are byte-identical) and add the
+    // R3 fallback for `-fno-exceptions` (Godot web): a fail-fast abort, which is
+    // arguably the more correct handling for a programmer-error precondition.
     save_body.push_str(
-        "if (!_context_stack.empty()) throw std::runtime_error(\"E700: system not quiescent\");\n",
+        "if (!_context_stack.empty()) {\n\
+         #if defined(__cpp_exceptions) || defined(__EXCEPTIONS)\n\
+         throw std::runtime_error(\"E700: system not quiescent\");\n\
+         #else\n\
+         std::fprintf(stderr, \"E700: system not quiescent\\n\"); std::abort();\n\
+         #endif\n\
+         }\n",
     );
 
     save_body.push_str(&format!(
@@ -131,8 +142,11 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
     save_body.push_str("    for (auto& [k, v] : c->state_vars) {\n");
     for (_state, var_name, var_type) in &all_state_vars {
         let cpp_type = cpp_map_type(var_type);
+        // RFC-0049 R1: type discovery is a QUERY, not an error — use the
+        // non-throwing pointer `any_cast<T>(&v)` (returns null on mismatch)
+        // instead of catching a thrown exception to probe the type.
         save_body.push_str(&format!(
-            "        if (k == \"{}\") {{ try {{ __sv[k] = std::any_cast<{}>(v); }} catch(...) {{}} }}\n",
+            "        if (k == \"{}\") {{ if (auto* __p = std::any_cast<{}>(&v)) __sv[k] = *__p; }}\n",
             var_name, cpp_type
         ));
     }
@@ -148,18 +162,18 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
         for (i, t) in types.iter().enumerate() {
             if t.is_empty() {
                 save_body.push_str(&format!(
-                    "        if (c->state_args.size() > {i}) {{ try {{ __sa.push_back(std::any_cast<int>(c->state_args[{i}])); }} catch(...) {{ try {{ __sa.push_back(std::any_cast<double>(c->state_args[{i}])); }} catch(...) {{ __sa.push_back(nullptr); }} }} }}\n"
+                    "        if (c->state_args.size() > {i}) {{ if (auto* __p = std::any_cast<int>(&c->state_args[{i}])) __sa.push_back(*__p); else if (auto* __p = std::any_cast<double>(&c->state_args[{i}])) __sa.push_back(*__p); else __sa.push_back(nullptr); }}\n"
                 ));
             } else {
                 save_body.push_str(&format!(
-                    "        if (c->state_args.size() > {i}) {{ try {{ __sa.push_back(nlohmann::json(std::any_cast<{t}>(c->state_args[{i}]))); }} catch(...) {{ __sa.push_back(nullptr); }} }}\n"
+                    "        if (c->state_args.size() > {i}) {{ if (auto* __p = std::any_cast<{t}>(&c->state_args[{i}])) __sa.push_back(nlohmann::json(*__p)); else __sa.push_back(nullptr); }}\n"
                 ));
             }
         }
         save_body.push_str("    } else \n");
     }
     save_body.push_str("    {\n");
-    save_body.push_str("        for (const auto& v : c->state_args) { try { __sa.push_back(std::any_cast<int>(v)); } catch(...) { try { __sa.push_back(std::any_cast<double>(v)); } catch(...) { __sa.push_back(nullptr); } } }\n");
+    save_body.push_str("        for (const auto& v : c->state_args) { if (auto* __p = std::any_cast<int>(&v)) __sa.push_back(*__p); else if (auto* __p = std::any_cast<double>(&v)) __sa.push_back(*__p); else __sa.push_back(nullptr); }\n");
     save_body.push_str("    }\n");
     save_body.push_str("    }\n");
     save_body.push_str("    __cj[\"state_args\"] = __sa;\n");
@@ -173,18 +187,18 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
         for (i, t) in types.iter().enumerate() {
             if t.is_empty() {
                 save_body.push_str(&format!(
-                    "        if (c->enter_args.size() > {i}) {{ try {{ __ea.push_back(std::any_cast<int>(c->enter_args[{i}])); }} catch(...) {{ try {{ __ea.push_back(std::any_cast<double>(c->enter_args[{i}])); }} catch(...) {{ __ea.push_back(nullptr); }} }} }}\n"
+                    "        if (c->enter_args.size() > {i}) {{ if (auto* __p = std::any_cast<int>(&c->enter_args[{i}])) __ea.push_back(*__p); else if (auto* __p = std::any_cast<double>(&c->enter_args[{i}])) __ea.push_back(*__p); else __ea.push_back(nullptr); }}\n"
                 ));
             } else {
                 save_body.push_str(&format!(
-                    "        if (c->enter_args.size() > {i}) {{ try {{ __ea.push_back(nlohmann::json(std::any_cast<{t}>(c->enter_args[{i}]))); }} catch(...) {{ __ea.push_back(nullptr); }} }}\n"
+                    "        if (c->enter_args.size() > {i}) {{ if (auto* __p = std::any_cast<{t}>(&c->enter_args[{i}])) __ea.push_back(nlohmann::json(*__p)); else __ea.push_back(nullptr); }}\n"
                 ));
             }
         }
         save_body.push_str("    } else\n");
     }
     save_body.push_str("    {\n");
-    save_body.push_str("        for (const auto& v : c->enter_args) { try { __ea.push_back(std::any_cast<int>(v)); } catch(...) { try { __ea.push_back(std::any_cast<double>(v)); } catch(...) { __ea.push_back(nullptr); } } }\n");
+    save_body.push_str("        for (const auto& v : c->enter_args) { if (auto* __p = std::any_cast<int>(&v)) __ea.push_back(*__p); else if (auto* __p = std::any_cast<double>(&v)) __ea.push_back(*__p); else __ea.push_back(nullptr); }\n");
     save_body.push_str("    }\n");
     save_body.push_str("    }\n");
     save_body.push_str("    __cj[\"enter_args\"] = __ea;\n");
@@ -267,7 +281,13 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
                 ));
             } else {
                 restore_body.push_str(&format!(
-                    "            if (__sa.size() > {i}) {{ try {{ c->state_args.push_back(std::any(__sa[{i}].get<{t}>())); }} catch(...) {{ }} }}\n"
+                    "            if (__sa.size() > {i}) {{\n\
+                     #if defined(__cpp_exceptions) || defined(__EXCEPTIONS)\n\
+                     try {{ c->state_args.push_back(std::any(__sa[{i}].get<{t}>())); }} catch(...) {{ }}\n\
+                     #else\n\
+                     if (!__sa[{i}].is_null()) c->state_args.push_back(std::any(__sa[{i}].get<{t}>()));\n\
+                     #endif\n\
+                     }}\n"
                 ));
             }
         }
@@ -295,7 +315,13 @@ pub(in crate::frame_c::compiler::codegen::interface_gen) fn generate(
                 ));
             } else {
                 restore_body.push_str(&format!(
-                    "            if (__ea.size() > {i}) {{ try {{ c->enter_args.push_back(std::any(__ea[{i}].get<{t}>())); }} catch(...) {{ }} }}\n"
+                    "            if (__ea.size() > {i}) {{\n\
+                     #if defined(__cpp_exceptions) || defined(__EXCEPTIONS)\n\
+                     try {{ c->enter_args.push_back(std::any(__ea[{i}].get<{t}>())); }} catch(...) {{ }}\n\
+                     #else\n\
+                     if (!__ea[{i}].is_null()) c->enter_args.push_back(std::any(__ea[{i}].get<{t}>()));\n\
+                     #endif\n\
+                     }}\n"
                 ));
             }
         }

--- a/framec/tests/cpp_snapshots.rs
+++ b/framec/tests/cpp_snapshots.rs
@@ -226,3 +226,80 @@ fn issue86_cpp_dispatch_is_exception_free() {
         compile_code
     );
 }
+
+/// #87 / RFC-0049 — a PERSISTED C++ system must also compile under
+/// `-fno-exceptions`, so persisted GDExtensions work on Godot web. Two framec
+/// exception uses lived in the persist path: the `any_cast` `try/catch` type
+/// PROBE (RFC-0049 R1: a query misusing exceptions as control flow) and the
+/// E700 quiescence `throw` (R2: a proper precondition error). The probe is now
+/// the non-throwing pointer `any_cast<T>(&v)`; the E700 throw and the tolerant
+/// typed restore keep `throw`/`try` only behind
+/// `#if defined(__cpp_exceptions)`, with an `abort`/null-guard fallback (R3).
+///
+/// 1. Token assertion (always runs): the save path uses the pointer-form
+///    `any_cast<...>(&` (proves the R1 probe was de-thrown).
+/// 2. Compile gate (skip if no C++ compiler / no nlohmann): the persist fixture
+///    — which self-includes `<nlohmann/json.hpp>` — compiles under
+///    `-std=c++17 -fno-exceptions`. nlohmann self-switches its own throws to
+///    `abort` under `-fno-exceptions`, so the only thing that can fail this is a
+///    residual UNGUARDED framec `try`/`catch`/`throw` in the persist codegen.
+#[test]
+fn issue87_persist_compiles_no_exceptions() {
+    use std::process::Command;
+
+    let code = compile_fixture("18_persist_noexcept", "cpp");
+
+    // (1) Token assertion: the save-side probe is the non-throwing pointer form.
+    assert!(
+        code.contains("any_cast<int>(&") || code.contains("any_cast<float>(&"),
+        "#87: persist save must probe std::any with the non-throwing pointer \
+         any_cast<T>(&v) (RFC-0049 R1), but no pointer-form cast was emitted.\n\
+         --- generated source ---\n{code}"
+    );
+
+    // (2) Compile gate under -fno-exceptions.
+    let cxx = match common::find_tool("g++")
+        .or_else(|| common::find_tool("clang++"))
+        .or_else(|| common::find_tool("c++"))
+    {
+        Some(p) => p,
+        None => {
+            eprintln!("#87 -fno-exceptions persist gate skipped: no C++ compiler on PATH");
+            return;
+        }
+    };
+    // nlohmann is a system dep (the matrix's `nlohmann-json3-dev`); skip cleanly
+    // where it isn't installed rather than fail on an unrelated missing header.
+    let probe = tempfile::tempdir().expect("tempdir");
+    let probe_src = probe.path().join("probe.cpp");
+    std::fs::write(
+        &probe_src,
+        "#include <nlohmann/json.hpp>\nint main(){ nlohmann::json j; j[\"x\"]=1; return 0; }\n",
+    )
+    .expect("write probe");
+    let probe_ok = Command::new(&cxx)
+        .args(["-std=c++17", "-fsyntax-only"])
+        .arg(&probe_src)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if !probe_ok {
+        eprintln!("#87 -fno-exceptions persist gate skipped: nlohmann/json.hpp not available");
+        return;
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("18_persist_noexcept.cpp");
+    std::fs::write(&path, &code).expect("write tempfile");
+    let out = Command::new(&cxx)
+        .args(["-std=c++17", "-fno-exceptions", "-fsyntax-only"])
+        .arg(&path)
+        .output()
+        .expect("c++ process");
+    assert!(
+        out.status.success(),
+        "#87: persisted C++ does not compile under -fno-exceptions (residual unguarded exception in the persist codegen).\n--- stderr ---\n{}\n--- generated source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        code
+    );
+}

--- a/framec/tests/fixtures/cpp/18_persist_noexcept.frm
+++ b/framec/tests/fixtures/cpp/18_persist_noexcept.frm
@@ -1,0 +1,34 @@
+// Gate fixture for the C++ target (#87 / RFC-0049) — persisted system whose
+// generated save/load must compile under BOTH default and `-fno-exceptions`
+// (the Godot-web requirement). It exercises every save/restore path the #87
+// change touches: a state-VAR (int), a typed state-ARG (float), and an
+// enter-ARG (int). The save side now probes `std::any` with the non-throwing
+// pointer `any_cast<T>(&v)` (R1, never a catch); the E700 quiescence guard and
+// the tolerant typed restore keep `throw`/`try` only behind
+// `#if defined(__cpp_exceptions)`, with an `abort`/null-guard fallback (R3).
+//
+// Everything here is valid C++ apart from its Frame constructs, so the only
+// thing that can make `-fno-exceptions` reject the emitted .cpp is a residual
+// unguarded `try`/`catch`/`throw` in the persist codegen.
+
+#include <nlohmann/json.hpp>
+
+@@[persist(std::string)]
+@@[save(save_state)]
+@@[load(load_state)]
+@@system Persist18 {
+    interface:
+        setup(n: int, f: float)
+        read(): int
+    machine:
+        $Idle {
+            setup(n: int, f: float) { -> (n) $Active(f) }
+            read(): int { @@:(0) }
+        }
+        $Active(sa: float) {
+            $.local: int = 0
+
+            $>(ea: int) { $.local = ea }
+            read(): int { @@:($.local) }
+        }
+}

--- a/framec/tests/snapshots/cpp_snapshots__actions.snap
+++ b/framec/tests/snapshots/cpp_snapshots__actions.snap
@@ -9,6 +9,8 @@ expression: "compile_fixture(\"10_actions\", \"cpp\")"
 #include <memory>
 #include <functional>
 #include <stdexcept>
+#include <cstdlib>
+#include <cstdio>
 
 class ActionsFrameEvent {
 public:

--- a/framec/tests/snapshots/cpp_snapshots__consts.snap
+++ b/framec/tests/snapshots/cpp_snapshots__consts.snap
@@ -9,6 +9,8 @@ expression: "compile_fixture(\"11_consts\", \"cpp\")"
 #include <memory>
 #include <functional>
 #include <stdexcept>
+#include <cstdlib>
+#include <cstdio>
 
 class ConstsFrameEvent {
 public:

--- a/framec/tests/snapshots/cpp_snapshots__forward.snap
+++ b/framec/tests/snapshots/cpp_snapshots__forward.snap
@@ -9,6 +9,8 @@ expression: "compile_fixture(\"07_forward\", \"cpp\")"
 #include <memory>
 #include <functional>
 #include <stdexcept>
+#include <cstdlib>
+#include <cstdio>
 
 class ForwardFrameEvent {
 public:

--- a/framec/tests/snapshots/cpp_snapshots__hsm.snap
+++ b/framec/tests/snapshots/cpp_snapshots__hsm.snap
@@ -9,6 +9,8 @@ expression: "compile_fixture(\"02_hsm\", \"cpp\")"
 #include <memory>
 #include <functional>
 #include <stdexcept>
+#include <cstdlib>
+#include <cstdio>
 
 class MiniHsmFrameEvent {
 public:

--- a/framec/tests/snapshots/cpp_snapshots__lifecycle.snap
+++ b/framec/tests/snapshots/cpp_snapshots__lifecycle.snap
@@ -9,6 +9,8 @@ expression: "compile_fixture(\"08_lifecycle\", \"cpp\")"
 #include <memory>
 #include <functional>
 #include <stdexcept>
+#include <cstdlib>
+#include <cstdio>
 
 class LifecycleFrameEvent {
 public:

--- a/framec/tests/snapshots/cpp_snapshots__lifecycle_args.snap
+++ b/framec/tests/snapshots/cpp_snapshots__lifecycle_args.snap
@@ -9,6 +9,8 @@ expression: "compile_fixture(\"13_lifecycle_args\", \"cpp\")"
 #include <memory>
 #include <functional>
 #include <stdexcept>
+#include <cstdlib>
+#include <cstdio>
 
 class LifecycleArgsFrameEvent {
 public:

--- a/framec/tests/snapshots/cpp_snapshots__linear_fsm.snap
+++ b/framec/tests/snapshots/cpp_snapshots__linear_fsm.snap
@@ -9,6 +9,8 @@ expression: "compile_fixture(\"01_linear_fsm\", \"cpp\")"
 #include <memory>
 #include <functional>
 #include <stdexcept>
+#include <cstdlib>
+#include <cstdio>
 
 class LinearFsmFrameEvent {
 public:

--- a/framec/tests/snapshots/cpp_snapshots__no_persist.snap
+++ b/framec/tests/snapshots/cpp_snapshots__no_persist.snap
@@ -9,6 +9,8 @@ expression: "compile_fixture(\"12_no_persist\", \"cpp\")"
 #include <memory>
 #include <functional>
 #include <stdexcept>
+#include <cstdlib>
+#include <cstdio>
 
 class NoPersistFrameEvent {
 public:
@@ -227,7 +229,13 @@ public:
     }
 
     std::string snapshot() {
-        if (!_context_stack.empty()) throw std::runtime_error("E700: system not quiescent");
+        if (!_context_stack.empty()) {
+        #if defined(__cpp_exceptions) || defined(__EXCEPTIONS)
+        throw std::runtime_error("E700: system not quiescent");
+        #else
+        std::fprintf(stderr, "E700: system not quiescent\n"); std::abort();
+        #endif
+        }
         std::function<nlohmann::json(const NoPersistCompartment*)> __ser = [&](const NoPersistCompartment* c) -> nlohmann::json {
             if (!c) return nullptr;
             nlohmann::json __cj;
@@ -239,14 +247,14 @@ public:
             nlohmann::json __sa = nlohmann::json::array();
             {
             {
-                for (const auto& v : c->state_args) { try { __sa.push_back(std::any_cast<int>(v)); } catch(...) { try { __sa.push_back(std::any_cast<double>(v)); } catch(...) { __sa.push_back(nullptr); } } }
+                for (const auto& v : c->state_args) { if (auto* __p = std::any_cast<int>(&v)) __sa.push_back(*__p); else if (auto* __p = std::any_cast<double>(&v)) __sa.push_back(*__p); else __sa.push_back(nullptr); }
             }
             }
             __cj["state_args"] = __sa;
             nlohmann::json __ea = nlohmann::json::array();
             {
             {
-                for (const auto& v : c->enter_args) { try { __ea.push_back(std::any_cast<int>(v)); } catch(...) { try { __ea.push_back(std::any_cast<double>(v)); } catch(...) { __ea.push_back(nullptr); } } }
+                for (const auto& v : c->enter_args) { if (auto* __p = std::any_cast<int>(&v)) __ea.push_back(*__p); else if (auto* __p = std::any_cast<double>(&v)) __ea.push_back(*__p); else __ea.push_back(nullptr); }
             }
             }
             __cj["enter_args"] = __ea;

--- a/framec/tests/snapshots/cpp_snapshots__persist.snap
+++ b/framec/tests/snapshots/cpp_snapshots__persist.snap
@@ -9,6 +9,8 @@ expression: "compile_fixture(\"03_persist\", \"cpp\")"
 #include <memory>
 #include <functional>
 #include <stdexcept>
+#include <cstdlib>
+#include <cstdio>
 
 class CounterFrameEvent {
 public:
@@ -188,7 +190,13 @@ public:
     }
 
     std::string snapshot() {
-        if (!_context_stack.empty()) throw std::runtime_error("E700: system not quiescent");
+        if (!_context_stack.empty()) {
+        #if defined(__cpp_exceptions) || defined(__EXCEPTIONS)
+        throw std::runtime_error("E700: system not quiescent");
+        #else
+        std::fprintf(stderr, "E700: system not quiescent\n"); std::abort();
+        #endif
+        }
         std::function<nlohmann::json(const CounterCompartment*)> __ser = [&](const CounterCompartment* c) -> nlohmann::json {
             if (!c) return nullptr;
             nlohmann::json __cj;
@@ -200,14 +208,14 @@ public:
             nlohmann::json __sa = nlohmann::json::array();
             {
             {
-                for (const auto& v : c->state_args) { try { __sa.push_back(std::any_cast<int>(v)); } catch(...) { try { __sa.push_back(std::any_cast<double>(v)); } catch(...) { __sa.push_back(nullptr); } } }
+                for (const auto& v : c->state_args) { if (auto* __p = std::any_cast<int>(&v)) __sa.push_back(*__p); else if (auto* __p = std::any_cast<double>(&v)) __sa.push_back(*__p); else __sa.push_back(nullptr); }
             }
             }
             __cj["state_args"] = __sa;
             nlohmann::json __ea = nlohmann::json::array();
             {
             {
-                for (const auto& v : c->enter_args) { try { __ea.push_back(std::any_cast<int>(v)); } catch(...) { try { __ea.push_back(std::any_cast<double>(v)); } catch(...) { __ea.push_back(nullptr); } } }
+                for (const auto& v : c->enter_args) { if (auto* __p = std::any_cast<int>(&v)) __ea.push_back(*__p); else if (auto* __p = std::any_cast<double>(&v)) __ea.push_back(*__p); else __ea.push_back(nullptr); }
             }
             }
             __cj["enter_args"] = __ea;

--- a/framec/tests/snapshots/cpp_snapshots__pushpop.snap
+++ b/framec/tests/snapshots/cpp_snapshots__pushpop.snap
@@ -9,6 +9,8 @@ expression: "compile_fixture(\"05_pushpop\", \"cpp\")"
 #include <memory>
 #include <functional>
 #include <stdexcept>
+#include <cstdlib>
+#include <cstdio>
 
 class PushPopFrameEvent {
 public:

--- a/framec/tests/snapshots/cpp_snapshots__return_explicit.snap
+++ b/framec/tests/snapshots/cpp_snapshots__return_explicit.snap
@@ -9,6 +9,8 @@ expression: "compile_fixture(\"09_return_explicit\", \"cpp\")"
 #include <memory>
 #include <functional>
 #include <stdexcept>
+#include <cstdlib>
+#include <cstdio>
 
 class ReturnExplicitFrameEvent {
 public:

--- a/framec/tests/snapshots/cpp_snapshots__selfcall.snap
+++ b/framec/tests/snapshots/cpp_snapshots__selfcall.snap
@@ -9,6 +9,8 @@ expression: "compile_fixture(\"06_selfcall\", \"cpp\")"
 #include <memory>
 #include <functional>
 #include <stdexcept>
+#include <cstdlib>
+#include <cstdio>
 
 class SelfCallFrameEvent {
 public:

--- a/framec/tests/snapshots/cpp_snapshots__state_args.snap
+++ b/framec/tests/snapshots/cpp_snapshots__state_args.snap
@@ -9,6 +9,8 @@ expression: "compile_fixture(\"04_state_args\", \"cpp\")"
 #include <memory>
 #include <functional>
 #include <stdexcept>
+#include <cstdlib>
+#include <cstdio>
 
 class StateArgsFrameEvent {
 public:


### PR DESCRIPTION
Fixes #87.

## What
Persisted C++ systems now compile under `-fno-exceptions` (so persisted GDExtensions work on Godot web, cf. #86). Two framec-emitted exceptions lived in the persist path; **RFC-0049** classifies and treats them by kind:

- **`any_cast` `try/catch` type-probe** (save) → a *query* misusing exceptions as a type switch (RFC-0049 **R1**). Converted to the non-throwing pointer `any_cast<T>(&v)` — the correct idiom with or without `-fno-exceptions`. Behavior-identical, unconditional. (7 sites.)
- **E700 "system not quiescent"** → a genuine *precondition error* (**R2**), a proper exception use. It and the tolerant typed restore keep `throw`/`try` behind `#if defined(__cpp_exceptions)` with an `abort`/null-guard fallback (**R3**) — exception-enabled builds are **byte-identical**, `-fno-exceptions` builds fail fast instead of failing to compile. nlohmann self-switches its own throws to `abort`, so it's not a blocker.

## RFC-0049 (new) — the philosophy
"Errors vs. queries, and the cross-language fallback contract." Two axes: **(1)** exceptions MAY signal genuine errors/preconditions, MUST NOT express expected control flow / type discovery; **(2)** one portable semantic, per-target mechanism, with a `-fno-exceptions` fallback where the idiom is a throw. This is the durable rationale behind #86's user-facing Exception Policy (now updated to cite it), and it classifies E703 (#88) and the context-stack cleanup (#86) too.

## Validation
- `cargo test` 821/0; clippy `-D warnings` + fmt clean; doc-sample gate 118/118.
- New gate `issue87_persist_compiles_no_exceptions`: token-asserts the pointer-form probe + compiles fixture 18 (state-var + float state-arg + int enter-arg) under `-std=c++17 -fno-exceptions` (skips without compiler/nlohmann). Generated persist compiles **both** default and `-fno-exceptions`.
- cpp snapshot churn = +2 includes (`<cstdlib>`/`<cstdio>`, all systems) + the persist rework, verified per-fixture and blessed.
- cpp matrix unchanged on every fixture **except** `100_match_digits` — a newly-added **RFC-0042 `@@fsm`** fixture (an *unmerged* feature) that fails on `main` identically; untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)