### PR TITLE
fix(cpp): exception-free async — RAII gate-guard + R3 E703 fallback (#88)

### DIFF
--- a/docs/frame_language.md
+++ b/docs/frame_language.md
@@ -1285,13 +1285,16 @@ opt-in features**, always with the `-fno-exceptions` fallback above:
   persisted systems compile under `-fno-exceptions`. (nlohmann::json self-switches
   its internal throws to `abort` there.)
 - **`@@[async]`** — a concurrent second driver raises **E703** (single-driver
-  violation), surfaced per backend as a thrown error / rejected future. On C++ the
-  coroutine machinery additionally uses `rethrow_exception`; async systems are not
-  yet `-fno-exceptions`-clean (tracked in #88).
+  violation), surfaced per backend as a thrown error / rejected future. On C++
+  this is exception-free too (issue #88): the casing's busy-gate cleanup is an
+  RAII guard, the E703 throw is behind `#if defined(__cpp_exceptions)` with an
+  `abort` fallback, and the coroutine `FrameTask`'s `std::rethrow_exception` is a
+  function call (legal with exceptions off, dead because handlers never throw) —
+  so async C++ systems compile under `-fno-exceptions`.
 
 In short: **exceptions are optional, not the rule.** A plain synchronous,
-non-persisted system generates exception-free code on every backend, and a
-persisted one compiles `-fno-exceptions` too.
+non-persisted system generates exception-free code on every backend; persisted
+and async C++ systems compile `-fno-exceptions` too.
 
 ---
 

--- a/docs/rfcs/rfc-0049.md
+++ b/docs/rfcs/rfc-0049.md
@@ -134,7 +134,7 @@ the more correct handling, and the throw is the compatibility path.
 | Context-stack balance (core dispatch) | Invariant | R4 | RAII / `defer` / `finally`; never catch-rethrow | #86 done (C++, Swift pending in #89) |
 | `any_cast` type-probe (C++ persist save) | **Expected (query)** | R1 | Remove → non-throwing pointer `any_cast<T>(&v)` | #87 |
 | E700 "system not quiescent" (persist save) | **Precondition error** | R2 + R3 | `throw` where available; `abort`-with-message fallback | #87 |
-| E703 single-driver violation (async) | **Contract error** | R2 + R3 | `throw`/rejected-future; fallback to be added | #88 |
+| E703 single-driver violation (async) | **Contract error** | R2 + R3 | `throw`/rejected-future where exceptions exist; C++ casing uses an RAII gate-guard + `#if`-guarded throw / `abort` fallback | #88 done (C++) |
 | nlohmann internal throws (persist) | Library, errors | — | Library self-switches to `abort` under `-fno-exceptions`; no Frame action | n/a |
 
 ## Per-language error mechanism

--- a/framec/src/frame_c/compiler/codegen/system_codegen/casing.rs
+++ b/framec/src/frame_c/compiler/codegen/system_codegen/casing.rs
@@ -724,25 +724,24 @@ fn generate_casing_interface_wrapper(ifm: &InterfaceMethod, lang: TargetLanguage
         TargetLanguage::Cpp => {
             let arg_list: Vec<String> = ifm.params.iter().map(|p| p.name.clone()).collect();
             let arg_str = arg_list.join(", ");
-            // C++ has no `finally`, so wrap the `co_await` in a
-            // try/catch(...) that clears the gate, rethrows. The
-            // happy-path also clears the gate before `co_return`.
-            // `std::runtime_error` for E703 — analogous to the
-            // unchecked-throw on neighbouring backends; thrown from
-            // the casing's coroutine body BEFORE any `co_await`, so
-            // the coroutine never suspends and the FrameTask delivers
-            // the exception to the caller's `await_resume`.
+            // RFC-0049: the busy/in_flight gate cleanup uses an RAII
+            // scope-guard (resets both on scope exit — co_return AND, when
+            // exceptions are enabled, unwind), not a try/catch(...)+rethrow.
+            // The guard captures member pointers (`bool*`/`std::string*`) so
+            // it needs no casing type name. The E703 busy violation is a
+            // proper precondition error (R2): `throw` where exceptions exist,
+            // `abort`-with-message fallback under `-fno-exceptions` (R3). The
+            // `if (this->busy)` check runs BEFORE the guard is armed, so an
+            // E703 rejection never resets a gate it didn't set.
             //
-            // Coroutine + try/catch: the body that contains `co_await`
-            // is fine inside a try block in modern C++ (g++ 11+ /
-            // clang 14+). The catch(...)+throw idiom is the canonical
-            // "finally" emulation.
+            // This makes the async casing compile under `-fno-exceptions`:
+            // the FrameTask's `std::rethrow_exception` is a function call
+            // (legal with exceptions off; dead because Frame handlers never
+            // throw), so the wrapper's `throw`/`try` were the only blockers.
             let has_return = !matches!(ifm.return_type, None | Some(FrameType::Unknown));
             let success_block = if has_return {
                 format!(
                     "auto __result = co_await this->machine.{name}({args});\n\
-                     this->in_flight.clear();\n\
-                     this->busy = false;\n\
                      co_return __result;",
                     name = ifm.name,
                     args = arg_str
@@ -750,8 +749,6 @@ fn generate_casing_interface_wrapper(ifm: &InterfaceMethod, lang: TargetLanguage
             } else {
                 format!(
                     "co_await this->machine.{name}({args});\n\
-                     this->in_flight.clear();\n\
-                     this->busy = false;\n\
                      co_return;",
                     name = ifm.name,
                     args = arg_str
@@ -759,21 +756,21 @@ fn generate_casing_interface_wrapper(ifm: &InterfaceMethod, lang: TargetLanguage
             };
             format!(
                 "if (this->busy) {{\n\
+                 #if defined(__cpp_exceptions) || defined(__EXCEPTIONS)\n\
                  \x20   throw std::runtime_error(\n\
                  \x20       \"E703: system busy: cannot enter '{name}' while '\" + this->in_flight + \"' is in flight\"\n\
                  \x20   );\n\
+                 #else\n\
+                 \x20   std::fprintf(stderr, \"E703: system busy: cannot enter '{name}' while '%s' is in flight\\n\", this->in_flight.c_str());\n\
+                 \x20   std::abort();\n\
+                 #endif\n\
                  }}\n\
                  this->busy = true;\n\
                  this->in_flight = \"{name}\";\n\
-                 try {{\n\
-                 \x20   {success}\n\
-                 }} catch (...) {{\n\
-                 \x20   this->in_flight.clear();\n\
-                 \x20   this->busy = false;\n\
-                 \x20   throw;\n\
-                 }}",
+                 struct __E703Guard {{ bool* __b; std::string* __f; ~__E703Guard() {{ __f->clear(); *__b = false; }} }} __e703_guard{{&this->busy, &this->in_flight}};\n\
+                 {success}",
                 name = ifm.name,
-                success = success_block.replace('\n', "\n    ")
+                success = success_block
             )
         }
         TargetLanguage::GDScript => {

--- a/framec/tests/cpp_snapshots.rs
+++ b/framec/tests/cpp_snapshots.rs
@@ -303,3 +303,79 @@ fn issue87_persist_compiles_no_exceptions() {
         code
     );
 }
+
+/// #88 / RFC-0049 — an `@@[async]` C++ system must also compile under
+/// `-fno-exceptions`. The RFC-0043 casing wrapped the busy-gate cleanup in
+/// `try { co_await … } catch(...) { …; throw; }` and threw E703 unconditionally
+/// — `throw`/`try` keywords that `-fno-exceptions` rejects. The cleanup is now
+/// an RAII busy-guard (resets `busy`/`in_flight` on `co_return` AND unwind) and
+/// the E703 precondition throw is behind `#if defined(__cpp_exceptions)` with an
+/// `abort` fallback (R2+R3). The FrameTask's `std::rethrow_exception` is a
+/// function call — legal with exceptions off, dead because handlers never throw.
+///
+/// 1. Token assertion (always runs): the casing emits the `__E703Guard` RAII
+///    guard (proves the try/catch was replaced).
+/// 2. Compile gate (skip unless a C++20 + `-fno-exceptions` compiler is on
+///    PATH — coroutines need C++20, which the macOS system clang predates):
+///    the async fixture compiles under `-std=c++20 -fno-exceptions`.
+#[test]
+fn issue88_async_compiles_no_exceptions() {
+    use std::process::Command;
+
+    let code = compile_fixture("19_async_noexcept", "cpp");
+
+    // (1) Token assertion: the RAII busy-guard replaced the try/catch cleanup.
+    assert!(
+        code.contains("__E703Guard"),
+        "#88: async casing must use the RAII busy-guard (not try/catch) for the \
+         gate cleanup, but no __E703Guard was emitted.\n--- generated source ---\n{code}"
+    );
+
+    let cxx = match common::find_tool("g++")
+        .or_else(|| common::find_tool("clang++"))
+        .or_else(|| common::find_tool("c++"))
+    {
+        Some(p) => p,
+        None => {
+            eprintln!("#88 async -fno-exceptions gate skipped: no C++ compiler on PATH");
+            return;
+        }
+    };
+    // Coroutines require C++20; the macOS system clang predates it. Probe with a
+    // trivial coroutine and skip cleanly where C++20 isn't supported (the gate
+    // then runs on CI's newer g++).
+    let probe = tempfile::tempdir().expect("tempdir");
+    let probe_src = probe.path().join("coro.cpp");
+    std::fs::write(
+        &probe_src,
+        "#include <coroutine>\nstruct T{struct promise_type{T get_return_object(){return{};}\
+         std::suspend_never initial_suspend(){return{};}std::suspend_never final_suspend()noexcept{return{};}\
+         void return_void(){}void unhandled_exception(){}};};\nint main(){return 0;}\n",
+    )
+    .expect("write probe");
+    let probe_ok = Command::new(&cxx)
+        .args(["-std=c++20", "-fsyntax-only"])
+        .arg(&probe_src)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if !probe_ok {
+        eprintln!("#88 async -fno-exceptions gate skipped: no C++20 coroutine support");
+        return;
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("19_async_noexcept.cpp");
+    std::fs::write(&path, &code).expect("write tempfile");
+    let out = Command::new(&cxx)
+        .args(["-std=c++20", "-fno-exceptions", "-fsyntax-only"])
+        .arg(&path)
+        .output()
+        .expect("c++ process");
+    assert!(
+        out.status.success(),
+        "#88: async C++ does not compile under -fno-exceptions (residual unguarded exception in the casing).\n--- stderr ---\n{}\n--- generated source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        code
+    );
+}

--- a/framec/tests/fixtures/cpp/19_async_noexcept.frm
+++ b/framec/tests/fixtures/cpp/19_async_noexcept.frm
@@ -1,0 +1,23 @@
+// Gate fixture for the C++ target (#88 / RFC-0049) — an `@@[async]` system
+// whose generated casing + coroutine machinery must compile under BOTH default
+// and -fno-exceptions. The async casing used to wrap the busy-gate cleanup in
+// exception-handling keywords plus an unconditional E703 throw; both are
+// rejected with exceptions disabled. They are now an RAII busy-guard (cleanup
+// on co_return AND unwind) and an #if-guarded E703 throw with an abort fallback
+// (RFC-0049 R2+R3). The FrameTask's std::rethrow_exception is a function call
+// (legal with exceptions off, dead because handlers never throw), so the
+// wrapper was the only blocker.
+//
+// Self-contained (no embedded systems / driver), so the only thing that can
+// make -fno-exceptions reject it is a residual unguarded exception keyword in
+// the async casing.
+
+@@[async]
+@@system Async19 {
+    interface:
+        async work(n: int): int
+    machine:
+        $S {
+            work(n: int): int { @@:(n) }
+        }
+}


### PR DESCRIPTION
Fixes #88.

Originally scoped as "document the async exception dependency," but with RFC-0049's R3 fallback in hand it became fully fixable: **async C++ systems now compile under `-fno-exceptions`** too.

## Root cause (the issue overstated it)
The only `-fno-exceptions` blocker was the RFC-0043 **casing**, which wrapped the busy-gate cleanup in `try { co_await … } catch(...) { …; throw; }` and threw E703 unconditionally — `throw`/`try` *keywords*. The FrameTask's `std::rethrow_exception` is a *function call* (legal with exceptions off, dead because handlers never throw), so it was never a blocker.

## Fix (RFC-0049)
- **Busy-gate cleanup → RAII scope-guard** (resets `busy`/`in_flight` in its destructor — on `co_return` AND unwind), the same treatment #86 gave the interface wrapper. Captures `bool*`/`std::string*` so it needs no casing type name. Timing is equivalent (a coroutine local's destructor runs at `co_return`, before the caller resumes; no `co_await` sits between the inner await and `co_return`, so the single-driver window is unchanged).
- **E703** is a precondition error (R2): `throw` behind `#if defined(__cpp_exceptions)`, `abort`-with-message fallback under `-fno-exceptions` (R3). The `if (busy)` check runs before the guard is armed.

## Validation
- `cargo test` 822/0; clippy `-D warnings` + fmt clean; doc gate 118/118; no snapshot churn (corpus is sync).
- Generated async compiles **both** default and `-fno-exceptions` (g++ `-std=c++23`, matrix toolchain). New gate `issue88_async_compiles_no_exceptions` (token + `-std=c++20 -fno-exceptions` compile, skip without a C++20 compiler).
- **Behavior unchanged with exceptions** — ran the async behavioral fixtures `async_concurrent_entry_e703` (the gate), `async_cpp_throw_after_partial_await` (the exception-unwind path), `async_cpp_nested_throw_propagation`, `async_distinct_instances_parallel`: **all PASS**.
- cpp matrix clean except the `100`–`110` `@@fsm` regex fixtures — an *unmerged* RFC-0042 feature that fails on `main` identically; untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)