### PR TITLE
fix(swift): exception-safe context-stack cleanup via defer (#89, RFC-0049 R4)

### DIFF
--- a/docs/frame_language.md
+++ b/docs/frame_language.md
@@ -1264,9 +1264,9 @@ catch-and-rethrow**:
 | Family | Backends | Cleanup |
 |--------|----------|---------|
 | RAII (destructor / `Drop`) | C++, Rust | scope-guard pops on scope exit |
-| Scope-exit defer | Go | `defer { pop }` |
+| Scope-exit defer | Swift, Go | `defer { pop }` |
 | `try`/`finally` (always present) | Java, C#, Kotlin, Dart, TypeScript, JavaScript, PHP, Python, Ruby | `finally` pops |
-| Unconditional pop | Swift, C, GDScript | single post-dispatch pop (exception-free) |
+| Unconditional pop | C, GDScript | single post-dispatch pop (no exceptions exist) |
 
 Because the cleanup never depends on a thrown-and-caught exception, **core
 generated code compiles under a target's no-exceptions mode wherever one exists**

--- a/framec/src/frame_c/compiler/codegen/interface_gen.rs
+++ b/framec/src/frame_c/compiler/codegen/interface_gen.rs
@@ -735,16 +735,21 @@ return __result;"#,
                     code.push_str(&format!("let __ctx = {}(event: __e)\n", context_class));
                 }
 
+                // Exception Policy (RFC-0049 R4): pop via `defer` so the
+                // context-stack balance invariant holds on every exit path —
+                // including a throwing handler — Swift's idiomatic scope-exit
+                // cleanup (the family member alongside C++ RAII, Go `defer`,
+                // managed `try/finally`). The prior unconditional post-kernel
+                // pop was exception-free but exception-UNSAFE (a throw skipped
+                // it, leaking a stale context entry).
                 code.push_str("_context_stack.append(__ctx)\n");
+                code.push_str("defer { _context_stack.removeLast() }\n");
                 code.push_str("__kernel(_context_stack[_context_stack.count - 1]._event)\n");
 
                 if has_return && return_type_str != "void" && return_type_str != "Any" && return_type_str != "Any?" {
                     let swift_type = swift_map_type(&return_type_str);
                     code.push_str(&format!("let __result = _context_stack[_context_stack.count - 1]._return as! {}\n", swift_type));
-                    code.push_str("_context_stack.removeLast()\n");
                     code.push_str("return __result");
-                } else {
-                    code.push_str("_context_stack.removeLast()");
                 }
 
                 CodegenNode::NativeBlock { code, span: None }

--- a/framec/tests/snapshots/swift_snapshots__actions.snap
+++ b/framec/tests/snapshots/swift_snapshots__actions.snap
@@ -153,17 +153,17 @@ public class Actions {
         let __e = ActionsFrameEvent(message: "increment", parameters: [n])
         let __ctx = ActionsFrameContext(event: __e)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
-        _context_stack.removeLast()
     }
 
     public func get_total() -> Int {
         let __e = ActionsFrameEvent(message: "get_total", parameters: [])
         let __ctx = ActionsFrameContext(event: __e, defaultReturn: 0)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
         let __result = _context_stack[_context_stack.count - 1]._return as! Int
-        _context_stack.removeLast()
         return __result
     }
 

--- a/framec/tests/snapshots/swift_snapshots__consts.snap
+++ b/framec/tests/snapshots/swift_snapshots__consts.snap
@@ -157,17 +157,17 @@ public class Consts {
         let __e = ConstsFrameEvent(message: "tick", parameters: [])
         let __ctx = ConstsFrameContext(event: __e)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
-        _context_stack.removeLast()
     }
 
     public func get_count() -> Int {
         let __e = ConstsFrameEvent(message: "get_count", parameters: [])
         let __ctx = ConstsFrameContext(event: __e, defaultReturn: 0)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
         let __result = _context_stack[_context_stack.count - 1]._return as! Int
-        _context_stack.removeLast()
         return __result
     }
 

--- a/framec/tests/snapshots/swift_snapshots__forward.snap
+++ b/framec/tests/snapshots/swift_snapshots__forward.snap
@@ -160,16 +160,16 @@ public class Forward {
         let __e = ForwardFrameEvent(message: "run", parameters: [])
         let __ctx = ForwardFrameContext(event: __e)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
-        _context_stack.removeLast()
     }
 
     public func finish() {
         let __e = ForwardFrameEvent(message: "finish", parameters: [])
         let __ctx = ForwardFrameContext(event: __e)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
-        _context_stack.removeLast()
     }
 
     private func _state_Start(_ __e: ForwardFrameEvent, _ compartment: ForwardCompartment) {

--- a/framec/tests/snapshots/swift_snapshots__hsm.snap
+++ b/framec/tests/snapshots/swift_snapshots__hsm.snap
@@ -161,24 +161,24 @@ public class MiniHsm {
         let __e = MiniHsmFrameEvent(message: "wake", parameters: [])
         let __ctx = MiniHsmFrameContext(event: __e)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
-        _context_stack.removeLast()
     }
 
     public func sleep() {
         let __e = MiniHsmFrameEvent(message: "sleep", parameters: [])
         let __ctx = MiniHsmFrameContext(event: __e)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
-        _context_stack.removeLast()
     }
 
     public func signal() {
         let __e = MiniHsmFrameEvent(message: "signal", parameters: [])
         let __ctx = MiniHsmFrameContext(event: __e)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
-        _context_stack.removeLast()
     }
 
     private func _state_Live(_ __e: MiniHsmFrameEvent, _ compartment: MiniHsmCompartment) {

--- a/framec/tests/snapshots/swift_snapshots__lifecycle.snap
+++ b/framec/tests/snapshots/swift_snapshots__lifecycle.snap
@@ -158,16 +158,16 @@ public class Lifecycle {
         let __e = LifecycleFrameEvent(message: "start", parameters: [label])
         let __ctx = LifecycleFrameContext(event: __e)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
-        _context_stack.removeLast()
     }
 
     public func stop() {
         let __e = LifecycleFrameEvent(message: "stop", parameters: [])
         let __ctx = LifecycleFrameContext(event: __e)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
-        _context_stack.removeLast()
     }
 
     private func _state_Idle(_ __e: LifecycleFrameEvent, _ compartment: LifecycleCompartment) {

--- a/framec/tests/snapshots/swift_snapshots__lifecycle_args.snap
+++ b/framec/tests/snapshots/swift_snapshots__lifecycle_args.snap
@@ -157,17 +157,17 @@ public class LifecycleArgs {
         let __e = LifecycleArgsFrameEvent(message: "load", parameters: [n, label])
         let __ctx = LifecycleArgsFrameContext(event: __e)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
-        _context_stack.removeLast()
     }
 
     public func total() -> Int {
         let __e = LifecycleArgsFrameEvent(message: "total", parameters: [])
         let __ctx = LifecycleArgsFrameContext(event: __e, defaultReturn: 0)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
         let __result = _context_stack[_context_stack.count - 1]._return as! Int
-        _context_stack.removeLast()
         return __result
     }
 
@@ -175,9 +175,9 @@ public class LifecycleArgs {
         let __e = LifecycleArgsFrameEvent(message: "tag", parameters: [])
         let __ctx = LifecycleArgsFrameContext(event: __e, defaultReturn: "")
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
         let __result = _context_stack[_context_stack.count - 1]._return as! String
-        _context_stack.removeLast()
         return __result
     }
 

--- a/framec/tests/snapshots/swift_snapshots__linear_fsm.snap
+++ b/framec/tests/snapshots/swift_snapshots__linear_fsm.snap
@@ -159,24 +159,24 @@ public class LinearFsm {
         let __e = LinearFsmFrameEvent(message: "start", parameters: [])
         let __ctx = LinearFsmFrameContext(event: __e)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
-        _context_stack.removeLast()
     }
 
     public func progress(_ amount: Int) {
         let __e = LinearFsmFrameEvent(message: "progress", parameters: [amount])
         let __ctx = LinearFsmFrameContext(event: __e)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
-        _context_stack.removeLast()
     }
 
     public func finish() {
         let __e = LinearFsmFrameEvent(message: "finish", parameters: [])
         let __ctx = LinearFsmFrameContext(event: __e)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
-        _context_stack.removeLast()
     }
 
     private func _state_Idle(_ __e: LinearFsmFrameEvent, _ compartment: LinearFsmCompartment) {

--- a/framec/tests/snapshots/swift_snapshots__no_persist.snap
+++ b/framec/tests/snapshots/swift_snapshots__no_persist.snap
@@ -154,25 +154,25 @@ public class NoPersist {
         let __e = NoPersistFrameEvent(message: "bump", parameters: [])
         let __ctx = NoPersistFrameContext(event: __e)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
-        _context_stack.removeLast()
     }
 
     public func set_cache(_ v: Int) {
         let __e = NoPersistFrameEvent(message: "set_cache", parameters: [v])
         let __ctx = NoPersistFrameContext(event: __e)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
-        _context_stack.removeLast()
     }
 
     public func get_count() -> Int {
         let __e = NoPersistFrameEvent(message: "get_count", parameters: [])
         let __ctx = NoPersistFrameContext(event: __e, defaultReturn: 0)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
         let __result = _context_stack[_context_stack.count - 1]._return as! Int
-        _context_stack.removeLast()
         return __result
     }
 
@@ -180,9 +180,9 @@ public class NoPersist {
         let __e = NoPersistFrameEvent(message: "get_cache", parameters: [])
         let __ctx = NoPersistFrameContext(event: __e, defaultReturn: 0)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
         let __result = _context_stack[_context_stack.count - 1]._return as! Int
-        _context_stack.removeLast()
         return __result
     }
 

--- a/framec/tests/snapshots/swift_snapshots__persist.snap
+++ b/framec/tests/snapshots/swift_snapshots__persist.snap
@@ -153,17 +153,17 @@ public class Counter {
         let __e = CounterFrameEvent(message: "increment", parameters: [by])
         let __ctx = CounterFrameContext(event: __e)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
-        _context_stack.removeLast()
     }
 
     public func value() -> Int {
         let __e = CounterFrameEvent(message: "value", parameters: [])
         let __ctx = CounterFrameContext(event: __e, defaultReturn: 0)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
         let __result = _context_stack[_context_stack.count - 1]._return as! Int
-        _context_stack.removeLast()
         return __result
     }
 

--- a/framec/tests/snapshots/swift_snapshots__pushpop.snap
+++ b/framec/tests/snapshots/swift_snapshots__pushpop.snap
@@ -157,32 +157,32 @@ public class PushPop {
         let __e = PushPopFrameEvent(message: "ping", parameters: [])
         let __ctx = PushPopFrameContext(event: __e)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
-        _context_stack.removeLast()
     }
 
     public func nest() {
         let __e = PushPopFrameEvent(message: "nest", parameters: [])
         let __ctx = PushPopFrameContext(event: __e)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
-        _context_stack.removeLast()
     }
 
     public func unnest() {
         let __e = PushPopFrameEvent(message: "unnest", parameters: [])
         let __ctx = PushPopFrameContext(event: __e)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
-        _context_stack.removeLast()
     }
 
     public func leaf() {
         let __e = PushPopFrameEvent(message: "leaf", parameters: [])
         let __ctx = PushPopFrameContext(event: __e)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
-        _context_stack.removeLast()
     }
 
     private func _state_Idle(_ __e: PushPopFrameEvent, _ compartment: PushPopCompartment) {

--- a/framec/tests/snapshots/swift_snapshots__return_explicit.snap
+++ b/framec/tests/snapshots/swift_snapshots__return_explicit.snap
@@ -152,9 +152,9 @@ public class ReturnExplicit {
         let __e = ReturnExplicitFrameEvent(message: "decide", parameters: [score])
         let __ctx = ReturnExplicitFrameContext(event: __e, defaultReturn: "")
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
         let __result = _context_stack[_context_stack.count - 1]._return as! String
-        _context_stack.removeLast()
         return __result
     }
 

--- a/framec/tests/snapshots/swift_snapshots__selfcall.snap
+++ b/framec/tests/snapshots/swift_snapshots__selfcall.snap
@@ -153,17 +153,17 @@ public class SelfCall {
         let __e = SelfCallFrameEvent(message: "kick", parameters: [])
         let __ctx = SelfCallFrameContext(event: __e)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
-        _context_stack.removeLast()
     }
 
     public func report() -> Int {
         let __e = SelfCallFrameEvent(message: "report", parameters: [])
         let __ctx = SelfCallFrameContext(event: __e, defaultReturn: 0)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
         let __result = _context_stack[_context_stack.count - 1]._return as! Int
-        _context_stack.removeLast()
         return __result
     }
 

--- a/framec/tests/snapshots/swift_snapshots__state_args.snap
+++ b/framec/tests/snapshots/swift_snapshots__state_args.snap
@@ -155,25 +155,25 @@ public class StateArgs {
         let __e = StateArgsFrameEvent(message: "load", parameters: [initial])
         let __ctx = StateArgsFrameContext(event: __e)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
-        _context_stack.removeLast()
     }
 
     public func adjust(_ delta: Int) {
         let __e = StateArgsFrameEvent(message: "adjust", parameters: [delta])
         let __ctx = StateArgsFrameContext(event: __e)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
-        _context_stack.removeLast()
     }
 
     public func peek() -> Int {
         let __e = StateArgsFrameEvent(message: "peek", parameters: [])
         let __ctx = StateArgsFrameContext(event: __e, defaultReturn: 0)
         _context_stack.append(__ctx)
+        defer { _context_stack.removeLast() }
         __kernel(_context_stack[_context_stack.count - 1]._event)
         let __result = _context_stack[_context_stack.count - 1]._return as! Int
-        _context_stack.removeLast()
         return __result
     }
 


### PR DESCRIPTION
Fixes #89.

## What
Swift's interface dispatch popped the context stack with an unconditional post-kernel `removeLast()` — exception-free but exception-**unsafe**: a throwing handler skipped it, leaking a stale context-stack entry. It now uses `defer { _context_stack.removeLast() }` — the idiomatic scope-exit cleanup that runs on every path including unwind, matching C++ RAII (#86), Go `defer`, and managed `try/finally` (RFC-0049 R4). The Exception Policy table moves Swift to the `defer` family.

## The flake story (corrected)
This change was correct in #86 but reverted there because it tripped a flake on `async_sync_op_bypass_gate`. Stress-testing now showed that was **not** the stdout-buffering issue it was mis-filed as (test-env #11) — it's a latent **async race** in the fixture: `get_count()` read `count` before `slow_work` incremented it (`Fatal error: during: 0`, ~1/60), and the `defer` timing shift lost it more often. Fixed deterministically in **framec-test-env#17** (a handshake). The `defer` codegen itself was always correct.

## Validation
- `cargo test` 822/0; clippy `-D warnings` + fmt clean; doc gate 118/118; 13 swift snapshots reblessed (mechanical `removeLast`→`defer`).
- With test-env#17: fixture passes **100/100** under the matrix harness invocation and **3× clean** full swift legs (320 passed; only the unmerged-RFC-0042 `@@fsm` 100–110 fixtures fail, unrelated).

**Merge order:** land framec-test-env#17 first so the fixture is deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)