### PR TITLE
fix(cpp): emit nlohmann/json.hpp include for persisted systems (#94)

### DIFF
--- a/framec/src/frame_c/compiler/pipeline/compiler.rs
+++ b/framec/src/frame_c/compiler/pipeline/compiler.rs
@@ -1347,7 +1347,18 @@ pub(crate) fn do_assemble(c: &mut PipelineCtx) -> CompileResult {
     let strict_import_errors = std::mem::take(&mut c.strict_import_errors);
     let module_warnings = std::mem::take(&mut c.module_warnings);
     let backend = get_backend(config.target);
-    let runtime_imports = backend.runtime_imports();
+    let mut runtime_imports = backend.runtime_imports();
+    // #94: the C++ persist codegen emits `nlohmann::json` throughout
+    // save/restore, but `runtime_imports()` is a fixed per-backend list with no
+    // system context, so it can't know whether persistence is enabled. Emit the
+    // include here — where the system ASTs are in scope — but ONLY for C++ with
+    // at least one persisted system, so non-persisted systems don't take a hard
+    // dependency on the (header-only) JSON library. Verbatim `#include` line,
+    // matching the other C++ runtime imports.
+    if config.target == TargetLanguage::Cpp && system_asts.iter().any(|s| s.persist_attr.is_some())
+    {
+        runtime_imports.push("#include <nlohmann/json.hpp>".to_string());
+    }
 
     // Stage 7: Assemble final output (native pass-through + system substitution + system instantiations)
     // Runtime imports are emitted first (before any native prolog) to fix import ordering.

--- a/framec/tests/cpp_snapshots.rs
+++ b/framec/tests/cpp_snapshots.rs
@@ -379,3 +379,29 @@ fn issue88_async_compiles_no_exceptions() {
         code
     );
 }
+
+/// #94 — the C++ persist codegen uses `nlohmann::json` throughout save/restore,
+/// so the generated file MUST `#include <nlohmann/json.hpp>` or persisted
+/// systems don't compile standalone. The include is emitted only for persisted
+/// systems (it's a hard dependency non-persisted systems shouldn't take).
+/// Token-only (no compiler needed) — the standalone `-fno-exceptions` compile is
+/// covered by `issue87_persist_compiles_no_exceptions` (fixture 18 deliberately
+/// no longer self-includes nlohmann).
+#[test]
+fn issue94_persist_emits_nlohmann_include() {
+    // Persisted system → include present.
+    let persist = compile_fixture("18_persist_noexcept", "cpp");
+    assert!(
+        persist.contains("#include <nlohmann/json.hpp>"),
+        "#94: a persisted C++ system must emit `#include <nlohmann/json.hpp>` \
+         (it uses nlohmann::json), but none was emitted.\n--- generated source ---\n{persist}"
+    );
+
+    // Non-persisted system → no nlohmann dependency forced.
+    let plain = compile_fixture("01_linear_fsm", "cpp");
+    assert!(
+        !plain.contains("nlohmann"),
+        "#94: a NON-persisted C++ system must not be forced to depend on nlohmann, \
+         but the output references it.\n--- generated source ---\n{plain}"
+    );
+}

--- a/framec/tests/fixtures/cpp/18_persist_noexcept.frm
+++ b/framec/tests/fixtures/cpp/18_persist_noexcept.frm
@@ -10,8 +10,10 @@
 // Everything here is valid C++ apart from its Frame constructs, so the only
 // thing that can make `-fno-exceptions` reject the emitted .cpp is a residual
 // unguarded `try`/`catch`/`throw` in the persist codegen.
-
-#include <nlohmann/json.hpp>
+//
+// No `#include <nlohmann/json.hpp>` here on purpose: framec emits it for
+// persisted C++ systems (#94), so this fixture also proves the output compiles
+// STANDALONE.
 
 @@[persist(std::string)]
 @@[save(save_state)]

--- a/framec/tests/snapshots/cpp_snapshots__no_persist.snap
+++ b/framec/tests/snapshots/cpp_snapshots__no_persist.snap
@@ -11,6 +11,7 @@ expression: "compile_fixture(\"12_no_persist\", \"cpp\")"
 #include <stdexcept>
 #include <cstdlib>
 #include <cstdio>
+#include <nlohmann/json.hpp>
 
 class NoPersistFrameEvent {
 public:

--- a/framec/tests/snapshots/cpp_snapshots__persist.snap
+++ b/framec/tests/snapshots/cpp_snapshots__persist.snap
@@ -11,6 +11,7 @@ expression: "compile_fixture(\"03_persist\", \"cpp\")"
 #include <stdexcept>
 #include <cstdlib>
 #include <cstdio>
+#include <nlohmann/json.hpp>
 
 class CounterFrameEvent {
 public:


### PR DESCRIPTION
Fixes #94.

## Problem
The C++ persist codegen uses `nlohmann::json` throughout `save_state`/`restore_state`, but the generated file never `#include`d it — so a `@@[persist]` C++ system didn't compile standalone (the consumer had to add the include by hand). Found while validating #87.

## Fix
`runtime_imports()` is a fixed per-backend list with no system context, so it can't know persistence is on. Emit the include in `do_assemble` (where the system ASTs are in scope), gated on `target == Cpp && any system has persist_attr` — so non-persisted systems don't take a hard dependency on the header-only library.

## Validation
- The reporter's exact repro now emits the include and compiles **standalone** under both default and `-fno-exceptions` (completes #87 — persisted C++ is fully self-contained).
- `cargo test` 823/0; clippy `-D warnings` + fmt clean.
- The #87 gate fixture 18 no longer self-includes nlohmann, so `issue87_persist_compiles_no_exceptions` now also proves the standalone compile; new `issue94_persist_emits_nlohmann_include` token-asserts the include is present for a persisted system and absent for a non-persisted one.
- cpp snapshot churn is exactly one `#include <nlohmann/json.hpp>` line on the two persisted fixtures (`03_persist`, `12_no_persist` — the latter is a persisted system using the field-level `@@[no_persist]` attribute). cpp matrix: all non-`@@fsm` fixtures pass (the 100–115 failures are the unmerged-RFC-0042 `@@fsm` fixtures, fail on main identically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)