### PR TITLE
Release 4.5.0 — @@fsm, @@:self, verbatim passthrough, exception-free C++/Swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [4.5.0] - 2026-06-16
+
+### Added
+
+- **`@@fsm` — finite-state recognizer construct (RFC-0042).** A new top-level
+  construct that compiles a regular-language recognizer to a Pike-VM-backed state
+  machine, emitted on **all 17 target languages at full behavioral parity**. It
+  implements the RE2 regular-expression dialect across the regular-language
+  feature set: literal, character-class, and Unicode `\d`/`\w`/`\s` alphabets
+  (plus `\p{...}` classes via `@@[allow(unicode_classes)]`); `|` ordered choice;
+  greedy **and** lazy quantifiers; edge **and** interior anchors; character-,
+  byte-, and Unicode-aware word boundaries `\b`/`\B`; inline flags `(?i)`/`(?m)`/`(?s)`
+  and scoped `(?ims:…)`/`(?-i:…)`; captures with action blocks; `when`-conditional
+  and stage-reference transition targets; a token alphabet; multi-match (`|`)
+  states; embedding; and Mode-C sub-fsm call-out. Zero-width assertions are
+  evaluated by a dedicated Pike-VM `Assert` opcode wired into every backend. The
+  action-body statement grammar is specified in RFC-0050.
+- **`@@:self` — portable, blessed self-reference (RFC-0046).** Write
+  `@@:self.field`, `@@:self.action()`, and `@@:self.field.method()` (embed calls),
+  including inside return expressions and across systems; framec lowers each to its
+  target's native `self`/`this` idiom on all 17 backends. This replaces the
+  per-language textual self-rewriters with segment-driven lowering.
+
 ### Changed
 
 - **Type annotations now emit verbatim on every backend (#61).** Removed the
@@ -23,6 +46,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   comment leader to the target's native one (`#`/`--`/`%`). Comments pass through
   unchanged like everything else — write your target's own comment syntax
   everywhere. This was the last source transform framec performed.
+- **State variables now require an explicit initializer (#84, `E610`).** The
+  synthesized-default value table was deleted — no magic. A state variable
+  declared without an initializer is now an `E610` error; write the native init
+  value for its declared type, exactly as for a domain field. *Breaking;
+  pre-public-beta, mechanical to fix.*
 
 ### Fixed
 
@@ -40,12 +68,50 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   `Default::default()` in the parameterless `new()` — uncompilable for non-`Default`
   types. For systems with such fields, framec now skips `new()` and builds
   `__create(<params>)` directly with the params in scope (`inner: Inner::__create(p)`).
+- **C: `float`/`double` arguments on `pop$` now marshal correctly (#83, RFC-0048).**
+  C is the only backend whose `void*` argument slots are not self-describing, so a
+  floating-point value pushed for a `pop$` transition was reinterpreted, not
+  converted. A C11 `_Generic` value-dispatch macro (`{sys}_ARG_PUSH`) now boxes
+  each argument by its static type. RFC-0048 generalizes the contract for future
+  low-level targets.
+- **C: doubles are heap-boxed through `void*` slots — pointer-width safe (#81).**
+  A `double` no longer aliases a pointer slot (truncated on wasm32/32-bit targets);
+  it is boxed in an owned allocation, with the ISO-C `strdup` shim for strings.
+- **C: category-driven `void*`-slot marshalling (#72) and pointer-typed embed
+  calls (#73).** Floats unpack by value, structs box; pointer-typed embed calls
+  lower to the free-function family.
+- **Declared-type coercion at every type-erasure write site (#77, #78).** The
+  coercion that re-types a value leaving an untyped compartment slot now also
+  covers the `@@:return(expr)` early-return path, with runtime gates.
+- **C++ and Swift core generated code is now exception-free / exception-safe
+  (RFC-0049; #86, #87, #88, #89).** Per the new Exception Policy, core dispatch
+  maintains its context-stack invariant with each language's idiomatic
+  scope-cleanup rather than a mandatory catch-and-rethrow, so it compiles under a
+  target's no-exceptions mode wherever one exists:
+  - **C++ dispatch (#86):** a method-local RAII scope-guard replaces the
+    `try { … } catch(...) { pop; throw }` wrapper, so output compiles **and links**
+    under `-fno-exceptions` (required by Godot web GDExtensions).
+  - **C++ persist (#87):** no-throw pointer probing `std::any_cast<T>(&v)` replaces
+    `try { any_cast } catch`; the `E700` type-mismatch path is `#if`-fallback to
+    `abort()` when exceptions are off.
+  - **C++ async (#88):** an RAII gate-guard replaces the busy-gate try/catch; the
+    `E703` single-driver violation uses the same `#if`-guarded throw/abort fallback.
+  - **Swift (#89):** context-stack cleanup moved into `defer`, exception-safe (R4).
+- **C++: persisted systems now `#include <nlohmann/json.hpp>` (#94).** Persist
+  codegen emitted `nlohmann::json` without the include, so a persisted system did
+  not compile standalone; the include is now emitted whenever a system persists.
 
 ### Docs
 
 - Per-language guides, the language reference's type-contract and "init values"
   sections, and the portable-float guidance (#62) updated to the verbatim-native
   contract. See [4.5.0 migration](docs/releases/4.5.0-migration.md).
+- New RFCs: **RFC-0042** (`@@fsm`; updated with §1 motivation, §6.10 RE2-compliance
+  matrix, §12 status), **RFC-0046** (`@@:self`), **RFC-0047** (guard-syntax survey
+  placeholder), **RFC-0048** (self-describing argument marshalling), **RFC-0049**
+  (exception philosophy — errors vs. queries, cross-language fallback), and
+  **RFC-0050** (Frame statement syntax). The language reference gains an
+  **Exception Policy** section.
 
 ### CI
 
@@ -55,6 +121,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   mode with the existing Rust/Java representatives. They were previously gated
   only by the nightly full matrix; now they run on every PR alongside
   Python/Rust/Java/Erlang.
+- **The `fsm_typescript` type-check tests now run a real `tsc` in CI.** The harness
+  skips cleanly when no genuine TypeScript is resolvable (instead of misreading an
+  unrelated `tsc` npm package's non-zero exit as a compile error), and CI installs
+  TypeScript so the generated `@@fsm` TypeScript is actually type-checked.
+- **`dotnet` first-run is warmed once before the parallel test step**, removing a
+  NuGet-migration named-mutex race that intermittently failed the `fsm_csharp`
+  tests on cold runners.
 
 ## [4.4.0] - 2026-06-06
 

--- a/docs/releases/4.5.0-migration.md
+++ b/docs/releases/4.5.0-migration.md
@@ -94,6 +94,24 @@ Targets whose native leader is already `//` (Rust, C, C++, C#, Java, Kotlin,
 Swift, Go, Dart, JS, TS, PHP) are unaffected. A `#` in a structural section no
 longer throws `E002` — it passes through verbatim like any native text.
 
+## 4. State variables must declare an initializer (#84, `E610`)
+
+framec used to synthesize a default value for an uninitialized state variable from
+an internal type table. That table is gone — there is no magic default. A state
+variable declared without an initializer is now an `E610` error. Give it the native
+init value for its declared type, the same value you would write for a domain field:
+
+```frame
+# before — relied on the synthesized-default table (Rust target)
+$Idle { $.count: i64 }
+
+# after — initialize explicitly
+$Idle { $.count: i64 = 0 }
+```
+
+This pairs with §2: the value you write is emitted **verbatim**, so use your
+target's native spelling (`0`, `0.0`, `String::from("")`, `std::string("")`, …).
+
 ## Quick check
 
 Compile your tree to each target you ship and let the native compiler flag the

--- a/docs/releases/4.5.0.md
+++ b/docs/releases/4.5.0.md
@@ -7,60 +7,73 @@ has_children: true
 
 # v4.5.0
 
-*Verbatim type & value passthrough — closes the last gap between the documented
-"Frame has no type system" contract and what codegen actually did.*
+*Two new portable constructs — `@@fsm` recognizers and `@@:self` — plus verbatim
+type/value passthrough and exception-free C++/Swift output.*
 
-Frame's contract is that type annotations **and** initializer values pass through
-to the generated code **verbatim** — you write your target language's own type
-names and literals, and framec does not parse, validate, or translate them. This
-release makes the compiler honor that contract uniformly: it removes the residual
-per-backend type-alias tables and the state-variable "portable init" value
-wrapping that still contradicted it, and fixes a float-literal corruption bug that
-those layers were hiding. This release has breaking hard-cuts; all are mechanical
-to fix and Frame is pre-public-beta, so no published program is affected. See the
-[migration guide](4.5.0-migration.md).
+4.5.0 is a feature release with two headline additions and a set of contract and
+portability fixes. `@@fsm` brings a regular-language recognizer construct to all 17
+targets at full parity; `@@:self` makes self-reference portable; verbatim
+passthrough closes the last gap between the "Frame has no type system" contract and
+what codegen did; and C++/Swift core output is now exception-free so it builds where
+exceptions are compiled out (notably Godot web). This release has breaking
+hard-cuts, all mechanical to fix; Frame is pre-public-beta, so no published program
+is affected. See the [migration guide](4.5.0-migration.md).
 
 ## Highlights
 
-- **Type annotations emit verbatim on every backend (#61).** The leftover
-  alias tables — `int`→`i64`, `str`→`String`, `float`→`f64`, etc. — are gone from
-  the Rust pipeline (`rust_system.rs`/`runtime.rs`, the typed-compartment path, and
-  the return-boxing cast shim) and from the `map_type`/`convert_type` functions on
-  the remaining backends. You now write your target's own type names (`i64`,
-  `String`, `Vec<i32>`, `std::string`, `Array`, …) and they reach the generated
-  code unchanged. Machinery types (the generic stacks, untyped event params) are
-  unaffected.
-- **State-variable initializers emit verbatim (#59, #62).** State-var init values
-  now carry raw text and are emitted exactly like domain-field initializers —
-  framec no longer parses them into an AST and re-serializes them. This fixes a
-  real bug where a whole-number float (`$.x: f64 = 0.0`) was truncated to an
-  integer literal (`0`), producing uncompilable Rust (and wrong values on every
-  typed target). The per-target "portable init" wrapping (`""` → `String::from("")`
-  etc.) is removed in the same change — write your target's native init value.
-- **The 17-language differential matrix is green** end-to-end on the verbatim
-  contract (the test corpus and per-language guides were updated to native type
-  names and init values to match).
+- **`@@fsm` — finite-state recognizers, all 17 languages (RFC-0042).** A new
+  top-level construct that compiles a regular-language recognizer to a
+  Pike-VM-backed state machine, emitted at **full behavioral parity on every
+  backend**. It implements the RE2 dialect across the regular-language feature set:
+  literal / character-class / Unicode `\d \w \s` alphabets (and `\p{…}` via
+  `@@[allow(unicode_classes)]`); `|` ordered choice; greedy **and** lazy
+  quantifiers; edge **and** interior anchors; character-, byte-, and Unicode-aware
+  word boundaries `\b`/`\B`; inline flags `(?i)`/`(?m)`/`(?s)` and scoped
+  `(?ims:…)`/`(?-i:…)`; captures with action blocks; `when`-conditional and
+  stage-reference transition targets; a token alphabet; multi-match states;
+  embedding; and Mode-C sub-fsm call-out. The action-body statement grammar is
+  specified in RFC-0050.
+- **`@@:self` — portable, blessed self-reference (RFC-0046).** Write
+  `@@:self.field`, `@@:self.action()`, and `@@:self.field.method()` (embed calls),
+  including inside return expressions and across systems; framec lowers each to its
+  target's native `self`/`this` idiom on all 17 backends. This replaces the
+  per-language textual self-rewriters with segment-driven lowering.
+- **Verbatim type & value passthrough (#61, #59, #62).** The leftover type-alias
+  tables (`int`→`i64`, `str`→`String`, `float`→`f64`, …) and the state-variable
+  "portable init" wrapping (`""` → `String::from("")`) are gone. You write your
+  target's own type names and init values and they reach the generated code
+  unchanged — which also fixes a float-literal corruption bug those layers hid
+  (`$.x: f64 = 0.0` previously emitted `0`). Section comments emit verbatim too.
+- **Exception-free C++/Swift core output (RFC-0049).** Core dispatch maintains its
+  context-stack invariant with each language's idiomatic scope-cleanup (RAII /
+  `defer`) instead of a mandatory catch-and-rethrow, so generated C++ now compiles
+  **and links** under `-fno-exceptions` — unblocking Godot web GDExtensions. The
+  opt-in `@@[persist]` and `@@[async]` features keep a compiled-out throw/abort
+  fallback. Exceptions are optional, not the rule.
 
 ## Breaking changes
 
-See the [migration guide](4.5.0-migration.md) for the canonical→native table and
-worked before/after.
+See the [migration guide](4.5.0-migration.md) for the canonical→native table,
+worked before/after, and the state-var-initializer change.
 
 - **Type annotations are no longer aliased.** A source that wrote a Frame-canonical
   name (`: int`, `: str`, `: float`) and relied on framec mapping it to the
-  target's native type now emits that name **verbatim**. On targets where the
-  canonical name *is* native (`int` in C/Go/Java/C#/Python, `bool` in Rust/C/C++)
-  nothing changes; where it isn't — notably `str` everywhere, and `int`/`float` on
-  Rust — you must write the native name (`String`/`i64`/`f64`, …).
+  target's native type now emits that name **verbatim**. Where the canonical name
+  *is* native nothing changes; where it isn't — notably `str` everywhere, and
+  `int`/`float` on Rust — write the native name (`String`/`i64`/`f64`, …).
 - **State-variable init values are no longer wrapped.** A `String`-typed state var
-  initialized with a bare `""` now emits `""` (a `&str` on Rust) instead of
-  `String::from("")`. Write the native init value: `String::from("")` on Rust,
-  `std::string("")` on C++, `""` on dynamic targets.
+  initialized with a bare `""` now emits `""` instead of `String::from("")`. Write
+  the native init value for the target.
+- **State variables now require an explicit initializer (#84, `E610`).** The
+  synthesized-default value table was removed. A state var declared without an
+  initializer is an `E610` error — give it the native init value for its declared
+  type, exactly as for a domain field.
 
 ## Action required
 
-Sources already written in native type names and native init values generate
-identical output to 4.4.x and need nothing. If you used Frame-canonical aliases or
-relied on portable-init wrapping, rewrite the affected annotations/values to your
-target's native spelling — see the [migration guide](4.5.0-migration.md) for the
-per-target table.
+Sources already written in native type names and native init values, with every
+state variable initialized, generate identical output to 4.4.x and need nothing.
+Otherwise, rewrite the affected annotations/values to your target's native spelling
+and add the missing initializers — see the [migration guide](4.5.0-migration.md) for
+the per-target table. The new `@@fsm` and `@@:self` constructs are additive; no
+existing source needs to adopt them.


### PR DESCRIPTION
Cuts the **4.5.0** release section. Docs-only — no code changes; the workspace version is already `4.5.0` in `Cargo.toml`.

## What this PR does
- Converts CHANGELOG `[Unreleased]` → `[4.5.0] - 2026-06-16` and folds in everything merged since `v4.4.0` that the section was missing.
- Re-frames `docs/releases/4.5.0.md` around the two headline features (it had been written as a verbatim-passthrough-only release).
- Adds the **E610** migration section (§4) to `docs/releases/4.5.0-migration.md`.

## 4.5.0 scope
**Added**
- `@@fsm` — finite-state recognizer construct (RFC-0042): Pike-VM engine, full RE2 dialect, all 17 backends at parity.
- `@@:self` — portable, blessed self-reference (RFC-0046), all 17 backends.

**Changed**
- Verbatim type passthrough (#61), verbatim state-var inits, verbatim section comments (#58).
- **E610 — state variables now require an explicit initializer (#84)** *(breaking; pre-public-beta)*.

**Fixed**
- C `pop$` float args (#83 / RFC-0048); C double heap-boxing (#81); C `void*`-slot marshalling (#72/#73); type-erasure coercion (#77/#78).
- **Exception-free / exception-safe C++ & Swift core (RFC-0049; #86/#87/#88/#89)** — C++ now compiles & links `-fno-exceptions` (Godot web).
- C++ persist `nlohmann/json.hpp` include (#94).

**Docs / CI**
- RFC-0046/0047/0048/0049/0050 + Exception Policy; fsm_typescript real-`tsc` gate; dotnet first-run warm-up.

## Verification
- Pre-commit doc-sample gate: 118/118 samples pass.
- Docs-only; `docs/releases/` is not scanned by the validator (top-level `docs/*.md` only).

## Not in this PR (next steps, gated on review)
- Full 17-language matrix on 4.5.0 main (now includes the @@fsm fixtures merged to test-env).
- Tagging `v4.5.0` (triggers the GitHub Release) — held for explicit go-ahead. crates.io + npm (wasm) publishes are separate manual steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)