### PR TITLE
docs(rfc): RFC-0042.1 — borrowed scan-at-offset for @@fsm

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -56,7 +56,8 @@ numbers are not re-used.
 | [0039](rfc-0039.md) | Parser as composed Frame state machines | Accepted | builds on [0035](rfc-0035.md) |
 | [0040](rfc-0040.md) | Re-introduce `@@import` as analysis-only cross-file resolution | Draft | amends [0024](rfc-0024.md) (analysis half only); builds on [0012](rfc-0012.md), [0015](rfc-0015.md) |
 | [0041](rfc-0041.md) | Web persistence — storage-bound save/load for browser targets (`@@[web_persist]`) | Draft | builds on [0012](rfc-0012.md), [0015](rfc-0015.md), [0016](rfc-0016.md) |
-| [0042](rfc-0042.md) | `@@fsm` — finite-state recognizer construct | Draft | new construct; runtime model independent of [0020](rfc-0020.md); depends on [0050](rfc-0050.md) for action-body statement grammar |
+| [0042](rfc-0042.md) | `@@fsm` — finite-state recognizer construct | Draft | new construct; runtime model independent of [0020](rfc-0020.md); depends on [0050](rfc-0050.md) for action-body statement grammar; amended by [0042.1](rfc-0042-1.md) |
+| [0042.1](rfc-0042-1.md) | Borrowed scan-at-offset — `@@fsm` as a reusable recognizer primitive | Draft (proposed) | amends [0042](rfc-0042.md) Principle 9 / §11.3; promotes single-shot borrowed scan out of deferred streaming |
 | [0043](rfc-0043.md) | `@@[async]` — single-driver gate via layered casing/machine | Accepted; shipped in 4.4.0 | builds on [0015](rfc-0015.md), [0017](rfc-0017.md), [0020](rfc-0020.md) |
 | [0044](rfc-0044.md) | Kernel context-stack must clean up on exception | Draft | builds on [0020](rfc-0020.md), surfaced by [0043](rfc-0043.md) |
 | [0045](rfc-0045.md) | Reserve `@@:system`; relocate state name to `@@:system.state.name` | Accepted; implemented | builds on [0006](rfc-0006.md), [0013](rfc-0013.md); breaking (pre-public-beta) |

--- a/docs/rfcs/rfc-0042-1.md
+++ b/docs/rfcs/rfc-0042-1.md
@@ -1,0 +1,203 @@
+---
+title: "RFC-0042.1: Borrowed scan-at-offset — @@fsm as a reusable recognizer primitive"
+nav_exclude: true
+---
+
+# RFC-0042.1: Borrowed scan-at-offset — `@@fsm` as a reusable recognizer primitive
+
+- **Status:** Draft (proposed)
+- **Author:** Mark Truluck <mark.truluck@cogiton.com>
+- **Created:** 2026-06-17
+- **Amends:** [RFC-0042](rfc-0042.md) — Principle 9 (construction-driven
+  execution) and §11.3 (streaming / incremental drive)
+- **Motivated by:** dogfooding `@@fsm` on framec's own lexical leaf scanners
+  (`prolog_scanner`, `lex_number`, `lex_string`, `scan_identifier` on branch
+  `dogfood-fsm-scanners`).
+
+## Summary
+
+RFC-0042 §3.1 / Principle 9 fix the v0.1 invocation model: an `@@fsm` is
+**constructed with its full input** and runs to completion at construction. The
+generated recognizer owns its input — on the Rust backend, `new(src: Vec<char>)`
+— and always scans **from offset 0**.
+
+That model is correct for *recognize one complete thing* (validate a date,
+classify a token stream). It is the wrong shape for the other half of what
+`@@fsm` advertises — **byte-level scanning and lexical analysis** (RFC-0042 §1) —
+where the host already holds the whole input in memory and wants to recognize a
+**prefix starting at a moving cursor**, calling the same recognizer once per
+token. With the construction model the host must hand the recognizer
+`buffer[cursor..]` as a fresh owned buffer on every call, **copying the remaining
+tail each time**. For *N* tokens over an *n*-byte buffer that is O(n²) input
+marshalling — not because the DFA rescans (each scan is forward-once, O(token)),
+but because the **API has no way to scan in place at an offset**.
+
+This RFC adds a second, **non-owning** entry point: scan a **borrowed buffer
+from a start offset**, returning the recognition outcome (accepted, end cursor,
+captures, return value) **without owning or copying the input**. The DFA, the
+regular-language guarantee, and the construction form are all unchanged; this is
+purely an additional way to *drive* the same automaton. It is the minimum that
+makes `@@fsm` usable as a lexer primitive.
+
+It is explicitly **narrower than RFC-0042 §11.3 streaming**, and resolves the
+part of §11.3 that does not require suspended state (see §4).
+
+## Motivation — the dogfood finding
+
+Turning `@@fsm` inward on framec's own scanners (the goal: replace hand-written
+regular leaf recognizers with `@@fsm`) exposed the IO-model gap immediately.
+
+Three of the four leaf recognizers — number, string, identifier — are **methods
+of the lexer**, called **once per token** as the cursor advances through the
+source. The generated recognizer takes an owned buffer and scans from 0:
+
+```rust
+pub fn new(src: Vec<char>) -> Self   // owns the whole input; scans from index 0
+```
+
+To use it at cursor `N`, the wrapper has no choice but:
+
+```rust
+let m = NumberScan::new(source[N..].iter().map(|&b| b as char).collect());
+//                      └─────────── allocates + copies the entire tail ───────────┘
+```
+
+Every token copies an O(tail) slice into a fresh `Vec`. The recognizer is fine;
+the **marshalling is quadratic**, and it is forced by the construction API.
+
+(framec's own inputs are small, so the absolute cost is negligible *there* — but
+baking a quadratic pattern into a hot lexer path purely to satisfy the IO model
+is the wrong trade, and any real-world lexer / scanner use of `@@fsm` over a
+large buffer would pay it. The one-shot leaf — `prolog_scanner`, run once per
+file — is unaffected and switches cleanly today.)
+
+The construct that advertises "byte-level scanning... lexical analysis" should be
+directly usable as a scan-at-cursor primitive. It is not, yet. This RFC closes
+that.
+
+## 1. The two drive models
+
+| | Construction (v0.1, RFC-0042 §3.1) | Borrowed scan-at-offset (this RFC) |
+|---|---|---|
+| Input ownership | Owns an input buffer | Borrows the host's buffer |
+| Start position | Always 0 | Caller-supplied offset |
+| Cost to call at cursor N | Copy `buf[N..]` → O(tail) | Zero-copy — O(token) |
+| Result | Instance fields (`accepted`, `cursor`, …) | Same outcome, returned by value |
+| Suspended state across calls | None | None |
+| Use case | Recognize one complete input | Lexer / scanner primitive over a held buffer |
+
+Both drive the **same compiled DFA**. The borrowed form is not a new automaton,
+a new regex surface, or a new alphabet — it is a second calling convention.
+
+## 2. Proposed surface
+
+A non-owning recognition entry point that takes `(buffer, start)` and returns the
+outcome. The exact spelling is per-backend idiom; the contract is uniform.
+
+**Rust (illustrative):**
+
+```rust
+pub struct Outcome {
+    pub accepted: bool,
+    pub end: usize,             // absolute offset one past the last consumed symbol
+    pub reject_position: usize, // absolute offset of failure; == start..end on accept
+    pub return_value: T,        // the declared return type
+    // captures addressable as on the construction form
+}
+
+impl NumberScan {
+    /// Recognize a prefix of `src` beginning at `start`. Does not own or copy
+    /// `src`; scans forward and stops at the first non-matching symbol.
+    pub fn scan_at(src: &[u8], start: usize) -> Outcome { … }
+}
+```
+
+- `end` and `reject_position` are **absolute offsets into the borrowed buffer**,
+  so the host advances its cursor with `cursor = outcome.end` directly — no
+  rebasing.
+- The match is a **prefix** match at `start` (anchored at the cursor, not a
+  search). This is exactly the construction form's semantics, relocated to an
+  arbitrary start.
+- No instance is retained; nothing is suspended. Each call is independent and
+  side-effect-free with respect to the buffer.
+- `char` alphabet: the borrowed view is the target's native code-point sequence;
+  `bytes`: the raw byte slice; `token`: the host's token slice. No alphabet
+  change from §6.1.
+
+The construction form (`new(...)`) is **unchanged** and remains the default; this
+is additive.
+
+## 3. Codegen impact
+
+The DFA executor RFC-0042 already emits is written against an indexable input
+and a cursor. The borrowed form is the **same loop** with:
+
+- the input bound to a borrowed slice instead of an owned field, and
+- the cursor seeded from `start` instead of `0`,
+
+returning the outcome by value instead of writing instance fields. No second
+automaton is built; the per-backend delta is a thin entry point over the
+existing match loop. Embedding actions, captures, transitions, and Mode C are
+unaffected (Mode C inner fsms are driven at the outer cursor exactly as today —
+§8.3 — which the borrowed form makes cheaper, not different).
+
+## 4. Relationship to RFC-0042 §11.3 (streaming)
+
+RFC-0042 §11.3 defers "streaming / incremental drive (`step()`, `run()`,
+`finish()`)" to a dedicated streaming RFC. That problem is **harder**: input
+arrives **over time** (e.g. from a socket), the host **pauses recognition
+between deliveries**, and the fsm must **carry suspended automaton state** across
+calls and report "need more input."
+
+This RFC is deliberately **not** that. Here the **whole input is already
+present** in a buffer the host holds; there is no partial delivery, no
+suspension, and no `finish()`. A `scan_at` call runs to completion (accept or
+reject) on each invocation, exactly like construction — it just starts at an
+offset over borrowed memory.
+
+The split:
+
+- **RFC-0042.1 (this):** borrowed, in-place, single-shot prefix scan at an
+  offset. No suspended state. Resolves the "incremental drive over a fully-present
+  buffer" need — the lexer-primitive case.
+- **RFC-0042 §11.3 (still deferred):** true streaming with suspension across
+  partial deliveries (`step()`/`finish()`, `stream<T>` input §11.4, `@@:emit`
+  §11.10). Unchanged by this RFC.
+
+## 5. Amendments to RFC-0042
+
+- **Principle 9** gains a clause: construction-driven execution remains the
+  default, **and** a non-owning borrowed scan-at-offset entry point is available
+  for recognizers used as scan primitives over a host-held buffer (this RFC).
+  Streaming with suspended state stays deferred (§11.3).
+- **§11.3** is narrowed: the borrowed, single-shot scan-at-offset half is
+  promoted out of "deferred" into this RFC; the suspend/resume streaming half
+  remains in §11.3 pending the streaming RFC.
+
+## 6. Out of scope
+
+- Suspended/resumable recognition across partial input deliveries (§11.3).
+- The `stream<T>` input type (§11.4) and `@@:emit` (§11.10).
+- Search (unanchored find-anywhere) semantics — `scan_at` is a prefix match at
+  the cursor, matching the construction form. A scanning host advances the cursor
+  itself.
+- Persistence of an in-flight recognizer (§11.8) — `scan_at` retains no instance,
+  so the question does not arise.
+
+## 7. Open questions
+
+1. **Spelling.** Free function `scan_at(src, start)` vs. an associated
+   constructor returning a lightweight handle vs. a borrowing `new`. Leaning to a
+   free function / associated function returning `Outcome` by value, since no
+   instance is retained.
+2. **Outcome vs. instance fields.** Whether `scan_at` returns a dedicated
+   `Outcome` value or writes the existing observable fields on a borrowed
+   instance. By-value `Outcome` is cleaner for a stateless call and avoids a
+   mutable instance; captures must ride along in it.
+3. **Capture exposure.** Construction-form captures are addressed within the
+   body; the borrowed form must surface them in the returned `Outcome` for the
+   host. Shape TBD (named-field struct vs. accessor).
+4. **`bytes` alphabet on the Rust backend.** The construction form generates
+   `Vec<char>` for `bytes` (values 0–255); the borrowed form should take `&[u8]`
+   directly to be genuinely zero-copy for byte scanners — worth aligning the
+   `bytes` representation while here.

--- a/docs/rfcs/rfc-0042.md
+++ b/docs/rfcs/rfc-0042.md
@@ -7,6 +7,9 @@ nav_exclude: true
 
 - **Status**: Draft
 - **Author**: Mark Truluck
+- **Amended by**: [RFC-0042.1](rfc-0042-1.md) (borrowed scan-at-offset — a
+  non-owning, zero-copy drive form for recognizers used as scan primitives;
+  narrows the deferred §11.3).
 - **Scope**: Defines `@@fsm` as a recognizer construct in the Frame language.
 - **Profile placement**: F0 (table) or F1 (bare/switch).
 - **Composition**: Composes with `@@system` via Modes A and B; composes with other `@@fsm` declarations via Mode C.
@@ -966,6 +969,13 @@ v0.1 fsms consume their input at construction time and run to completion. Some a
 - A persisted DFA-state representation across calls.
 
 This is a substantial extension. Defer to a dedicated streaming RFC.
+
+> **Narrowed by [RFC-0042.1](rfc-0042-1.md).** The *suspend/resume across
+> partial deliveries* half above (the in-flight state, `step()`/`finish()`,
+> persisted DFA-state) remains deferred here. The simpler **single-shot
+> scan-at-offset over a fully-present, borrowed buffer** — recognition starting
+> at a host cursor with no suspended state, the lexer-primitive case — is
+> specified by RFC-0042.1 and is *not* part of this deferred item.
 
 ### 11.4 `stream<T>` input type
 


### PR DESCRIPTION
Adds **RFC-0042.1**, an amendment to RFC-0042 (`@@fsm`).

## Why
`@@fsm` v0.1 (RFC-0042 Principle 9) constructs a recognizer with its *full* input and scans from offset 0; the generated API owns the buffer (Rust: `new(Vec<char>)`). That fits "recognize one complete thing," but not the **lexer-primitive** role the construct also advertises ("byte-level scanning… lexical analysis"): to scan the next token at a moving cursor over a host-held buffer, the caller must copy `buf[cursor..]` into a fresh buffer on **every** call → O(n²) input marshalling. The DFA doesn't rescan (each scan is forward-once, O(token)); the **API** forces the copy.

Surfaced by dogfooding `@@fsm` on framec's own lexical leaves — `lex_number`/`lex_string`/`scan_identifier` are per-token hot-path methods (branch `dogfood-fsm-scanners`). The one-shot leaf (`prolog_scanner`, once per file) is unaffected and switches cleanly today.

## What it specifies
A second, **non-owning** drive form: scan a **borrowed buffer from a start offset**, returning the outcome (accepted, absolute end cursor, captures, return value) by value — **zero copy, no suspended state**. Same compiled DFA, same regular-language guarantee, construction form unchanged (additive).

## Key boundary
Explicitly **narrower than RFC-0042 §11.3 streaming** (suspend/resume across partial network deliveries, `step()`/`finish()`, in-flight state) — that stays deferred. This RFC promotes only the *single-shot, fully-present, borrowed-buffer* half out of §11.3's deferral.

## Cross-refs (bidirectional)
- New `docs/rfcs/rfc-0042-1.md`
- RFC-0042 header gains "Amended by"; §11.3 gains a "Narrowed by" note
- RFC index row added

Docs-only. Doc-sample gate: 118/118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)