### PR TITLE
fix(dart): public factory .create constructor so systems are constructible cross-library (#108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dart: the generated system's parameter-taking constructor is now public
+  (#108).** Dart construction previously went through `static {Sys} _create(...)`,
+  whose leading underscore makes it **library-private** — a system generated into
+  its own file could not be instantiated from a separate host library (the public
+  no-arg `{Sys}()` left `late` domain fields uninitialized → `LateInitializationError`).
+  framec now emits a public **factory constructor** `factory {Sys}.create(...)`.
+  This is the idiomatic Dart form and — unlike a `static create` method — coexists
+  with a user interface method named `create`. Call sites (`@@Sys(...)` instantiation
+  and the `@@[create(name)]` alias) updated to `{Sys}.create(...)`. Dart-only; every
+  other backend's factory was already cross-module-callable.
+
 ## [4.6.0] - 2026-06-19
 
 ### Added

--- a/framec/src/frame_c/compiler/assembler/mod.rs
+++ b/framec/src/frame_c/compiler/assembler/mod.rs
@@ -833,9 +833,10 @@ pub(crate) fn generate_constructor(name: &str, args: &str, lang: TargetLanguage)
             }
         }
         TargetLanguage::Dart => {
-            // RFC-0017 Phase A4: Dart factory expansion uses `Counter._create(args)`.
-            // Bare `Counter()` is reserved for `@@!Counter()`.
-            format!("{}._create({})", name, args)
+            // RFC-0017 Phase A4: Dart factory expansion uses the public
+            // `Counter.create(args)` factory constructor (#108 — `_create`
+            // was library-private). Bare `Counter()` is reserved for `@@!Counter()`.
+            format!("{}.create({})", name, args)
         }
         TargetLanguage::GDScript => {
             // RFC-0017 Phase A4: GDScript factory expansion uses

--- a/framec/src/frame_c/compiler/codegen/backends/dart.rs
+++ b/framec/src/frame_c/compiler/codegen/backends/dart.rs
@@ -200,7 +200,8 @@ impl LanguageBackend for DartBackend {
                 super_call,
             } => {
                 // RFC-0017 Phase A4: split into bare ctor +
-                // `_frame_init` member + static `_create` factory.
+                // `_frame_init` member + public `factory .create`
+                // constructor (#108; was a library-private `static _create`).
                 // Replaces the prior D7 `_no_init` named ctor.
                 //
                 // Framework helper classes keep the original single-ctor
@@ -300,11 +301,17 @@ impl LanguageBackend for DartBackend {
                 }
                 result.push_str(&format!("{}}}\n", ctx.get_indent()));
 
-                // Emit `static Counter _create(<params>)` — factory
+                // Emit `factory Counter.create(<params>)` — the public
+                // construction entry point (#108). A `static _create` would be
+                // library-private in Dart (leading `_`), so a system generated
+                // into its own file could not be constructed from a separate
+                // host library. A named *factory constructor* is public,
+                // idiomatic, and — unlike a `static create` method — coexists
+                // with a user interface method named `create`.
                 result.push('\n');
                 let create_params = self.emit_params(params);
                 result.push_str(&format!(
-                    "{}static {} _create({}) {{\n",
+                    "{}factory {}.create({}) {{\n",
                     ctx.get_indent(),
                     class_name,
                     create_params

--- a/framec/src/frame_c/compiler/codegen/system_codegen.rs
+++ b/framec/src/frame_c/compiler/codegen/system_codegen.rs
@@ -189,8 +189,9 @@ pub fn generate_system_shared(
                 methods.push(generate_static_factory_alias(
                     system,
                     factory_name,
+                    // #108: delegate to the public `.create` factory constructor.
                     &format!(
-                        "return {}._create({});",
+                        "return {}.create({});",
                         system.name,
                         params_arg_list(system)
                     ),

--- a/framec/src/frame_c/compiler/codegen/system_codegen/expand_system.rs
+++ b/framec/src/frame_c/compiler/codegen/system_codegen/expand_system.rs
@@ -140,7 +140,7 @@ mod tests {
             (TargetLanguage::Rust, "Counter::__create(7)"),
             (TargetLanguage::C, "Counter_create(7)"),
             (TargetLanguage::Go, "CreateCounter(7)"),
-            (TargetLanguage::Dart, "Counter._create(7)"),
+            (TargetLanguage::Dart, "Counter.create(7)"),
             (TargetLanguage::JavaScript, "Counter._create(7)"),
             (TargetLanguage::TypeScript, "Counter._create(7)"),
             (TargetLanguage::Ruby, "Counter._create(7)"),

--- a/framec/tests/snapshots/dart_snapshots__actions.snap
+++ b/framec/tests/snapshots/dart_snapshots__actions.snap
@@ -81,7 +81,7 @@ class Actions {
         _context_stack.removeLast();
     }
 
-    static Actions _create() {
+    factory Actions.create() {
         final c = Actions();
         c._frame_init();
         return c;

--- a/framec/tests/snapshots/dart_snapshots__consts.snap
+++ b/framec/tests/snapshots/dart_snapshots__consts.snap
@@ -85,7 +85,7 @@ class Consts {
         _context_stack.removeLast();
     }
 
-    static Consts _create([int step = 5, int limit = 20]) {
+    factory Consts.create([int step = 5, int limit = 20]) {
         final c = Consts();
         c._frame_init(step, limit);
         return c;

--- a/framec/tests/snapshots/dart_snapshots__forward.snap
+++ b/framec/tests/snapshots/dart_snapshots__forward.snap
@@ -82,7 +82,7 @@ class Forward {
         _context_stack.removeLast();
     }
 
-    static Forward _create() {
+    factory Forward.create() {
         final c = Forward();
         c._frame_init();
         return c;

--- a/framec/tests/snapshots/dart_snapshots__hsm.snap
+++ b/framec/tests/snapshots/dart_snapshots__hsm.snap
@@ -83,7 +83,7 @@ class MiniHsm {
         _context_stack.removeLast();
     }
 
-    static MiniHsm _create() {
+    factory MiniHsm.create() {
         final c = MiniHsm();
         c._frame_init();
         return c;

--- a/framec/tests/snapshots/dart_snapshots__lifecycle.snap
+++ b/framec/tests/snapshots/dart_snapshots__lifecycle.snap
@@ -83,7 +83,7 @@ class Lifecycle {
         _context_stack.removeLast();
     }
 
-    static Lifecycle _create() {
+    factory Lifecycle.create() {
         final c = Lifecycle();
         c._frame_init();
         return c;

--- a/framec/tests/snapshots/dart_snapshots__lifecycle_args.snap
+++ b/framec/tests/snapshots/dart_snapshots__lifecycle_args.snap
@@ -82,7 +82,7 @@ class LifecycleArgs {
         _context_stack.removeLast();
     }
 
-    static LifecycleArgs _create() {
+    factory LifecycleArgs.create() {
         final c = LifecycleArgs();
         c._frame_init();
         return c;

--- a/framec/tests/snapshots/dart_snapshots__linear_fsm.snap
+++ b/framec/tests/snapshots/dart_snapshots__linear_fsm.snap
@@ -81,7 +81,7 @@ class LinearFsm {
         _context_stack.removeLast();
     }
 
-    static LinearFsm _create() {
+    factory LinearFsm.create() {
         final c = LinearFsm();
         c._frame_init();
         return c;

--- a/framec/tests/snapshots/dart_snapshots__no_persist.snap
+++ b/framec/tests/snapshots/dart_snapshots__no_persist.snap
@@ -82,7 +82,7 @@ class NoPersist {
         _context_stack.removeLast();
     }
 
-    static NoPersist _create() {
+    factory NoPersist.create() {
         final c = NoPersist();
         c._frame_init();
         return c;

--- a/framec/tests/snapshots/dart_snapshots__persist.snap
+++ b/framec/tests/snapshots/dart_snapshots__persist.snap
@@ -81,7 +81,7 @@ class Counter {
         _context_stack.removeLast();
     }
 
-    static Counter _create() {
+    factory Counter.create() {
         final c = Counter();
         c._frame_init();
         return c;

--- a/framec/tests/snapshots/dart_snapshots__pushpop.snap
+++ b/framec/tests/snapshots/dart_snapshots__pushpop.snap
@@ -82,7 +82,7 @@ class PushPop {
         _context_stack.removeLast();
     }
 
-    static PushPop _create() {
+    factory PushPop.create() {
         final c = PushPop();
         c._frame_init();
         return c;

--- a/framec/tests/snapshots/dart_snapshots__return_explicit.snap
+++ b/framec/tests/snapshots/dart_snapshots__return_explicit.snap
@@ -80,7 +80,7 @@ class ReturnExplicit {
         _context_stack.removeLast();
     }
 
-    static ReturnExplicit _create() {
+    factory ReturnExplicit.create() {
         final c = ReturnExplicit();
         c._frame_init();
         return c;

--- a/framec/tests/snapshots/dart_snapshots__selfcall.snap
+++ b/framec/tests/snapshots/dart_snapshots__selfcall.snap
@@ -81,7 +81,7 @@ class SelfCall {
         _context_stack.removeLast();
     }
 
-    static SelfCall _create() {
+    factory SelfCall.create() {
         final c = SelfCall();
         c._frame_init();
         return c;

--- a/framec/tests/snapshots/dart_snapshots__state_args.snap
+++ b/framec/tests/snapshots/dart_snapshots__state_args.snap
@@ -80,7 +80,7 @@ class StateArgs {
         _context_stack.removeLast();
     }
 
-    static StateArgs _create() {
+    factory StateArgs.create() {
         final c = StateArgs();
         c._frame_init();
         return c;


### PR DESCRIPTION
Fixes #108.

## Problem
The Dart backend emitted the only parameter-taking construction entry as `static {Sys} _create(...)`. A leading `_` is **enforced library-private** in Dart, so a system generated into its own file could not be instantiated from a separate host library — the public no-arg `{Sys}()` constructor leaves `late` domain fields uninitialized (`LateInitializationError`). This blocks the standard "generated FSM file + separate hand-written host" layout (the frame-games ports).

Dart-only: every other backend's factory (`__create` / `_create` / `Foo_create` / `module:create`) is already reachable across modules — Python's `_create` works because `_` there is convention, not enforced privacy.

## Fix
Emit a **public factory constructor** `factory {Sys}.create(...)`:
```dart
factory Game.create(Object host) {
  final c = Game();
  c._frame_init(host);
  return c;
}
```
Chosen over a plain `static create` because `dart analyze` confirms a static `create` **collides** with a user interface method named `create` (`conflicting_static_and_instance`); the factory constructor coexists with it and is the idiomatic Dart form. Call site `{Sys}.create(...)` is identical either way.

Updated together:
- `backends/dart.rs` — the canonical definition → `factory {Sys}.create(...)`
- `assembler/mod.rs` — `@@Sys(...)` instantiation → `{Sys}.create(...)`
- `system_codegen.rs` — `@@[create(name)]` alias delegates to `.create(...)`
- `expand_system.rs` test + 13 regenerated `dart_snapshots__*.snap`

## Verification
- `dart run` of a **separate** host library constructing via `Game.create(...)` → OK; `dart analyze` clean (no errors).
- Lib **1017/0**, all snapshots (Dart 13/13), clippy + fmt clean.
- **Dart matrix 346/0** (every Dart fixture: embeds, persist restore, cross-system).

🤖 Generated with [Claude Code](https://claude.com/claude-code)