### PR TITLE
fix(go): cross-system interface calls use the exported PascalCase method name (#112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **Go: cross-system interface calls now use the exported (PascalCase) method
+  name (#112).** Go exports interface methods by capitalizing the first letter
+  (`tick` → `Tick`), but a cross-system call `@@:self.field.method()` emitted the
+  raw lowercase name (`s.field.tick(...)`), referencing a method that doesn't
+  exist — the generated Go didn't compile. Root cause: the Go per-handler context
+  was built with an empty `domain_field_types` map, so the call was never
+  recognized as a cross-system (embed) call. framec now threads the field→type map
+  into the Go handler context and capitalizes the method at embed call sites,
+  using the same shared `capitalize_first` as the definition rename so the two
+  can't drift. Go-only.
+
 ## [4.6.0] - 2026-06-19
 
 ### Added

--- a/framec/src/frame_c/compiler/codegen/backends/go.rs
+++ b/framec/src/frame_c/compiler/codegen/backends/go.rs
@@ -11,6 +11,7 @@
 
 use crate::frame_c::compiler::codegen::ast::*;
 use crate::frame_c::compiler::codegen::backend::*;
+use crate::frame_c::compiler::codegen::codegen_utils::capitalize_first;
 use crate::frame_c::visitors::TargetLanguage;
 
 /// Go backend for code generation
@@ -710,15 +711,6 @@ impl GoBackend {
             field.name,
             type_str
         )
-    }
-}
-
-/// Capitalize the first letter of a string (for Go export visibility)
-fn capitalize_first(s: &str) -> String {
-    let mut chars = s.chars();
-    match chars.next() {
-        None => String::new(),
-        Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
     }
 }
 

--- a/framec/src/frame_c/compiler/codegen/codegen_utils.rs
+++ b/framec/src/frame_c/compiler/codegen/codegen_utils.rs
@@ -430,6 +430,19 @@ pub(crate) fn to_snake_case(s: &str) -> String {
     crate::frame_c::compiler::name::to_snake_case(s)
 }
 
+/// Uppercase the first character (rest verbatim). This is the Go
+/// backend's export rename for public method names (`tick` → `Tick`,
+/// `get_lives` → `Get_lives`). It is shared so the method *definition*
+/// (go.rs) and a cross-system *call site* (`@@:self.field.method()`,
+/// `context_self.rs`) use the identical mapping and can't drift (#112).
+pub(crate) fn capitalize_first(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+    }
+}
+
 // ─── String-aware literal replace ────────────────────────────────────
 //
 // Used by codegen branches that need to rewrite tokens inside generated

--- a/framec/src/frame_c/compiler/codegen/frame_expansion/context_self.rs
+++ b/framec/src/frame_c/compiler/codegen/frame_expansion/context_self.rs
@@ -12,7 +12,7 @@
 //!   emitted separately by `emit_handler_body_via_statements` so
 //!   it lands at a statement boundary.
 
-use super::super::codegen_utils::{to_snake_case, HandlerContext};
+use super::super::codegen_utils::{capitalize_first, to_snake_case, HandlerContext};
 use super::expand_expression;
 use super::utility::strip_outer_parens;
 use crate::frame_c::compiler::native_region_scanner::{RegionSpan, SegmentMetadata};
@@ -166,7 +166,18 @@ pub(super) fn expand_context_self_field_call(
         }
         // PHP: every object method call uses `->`.
         TargetLanguage::Php => format!("$this->{field}->{method}{args}"),
-        TargetLanguage::Go => format!("s.{field}.{method}{args}"),
+        // Go exports interface methods by capitalizing the first letter
+        // (`tick` → `Tick`). A cross-system (embed) call must use that same
+        // exported spelling, or it references an undefined method (#112). A
+        // non-embed scalar-field call targets a native Go method whose name
+        // framec does not control, so it stays verbatim.
+        TargetLanguage::Go => {
+            if is_embed {
+                format!("s.{field}.{}{args}", capitalize_first(method))
+            } else {
+                format!("s.{field}.{method}{args}")
+            }
+        }
         TargetLanguage::Python3
         | TargetLanguage::GDScript
         | TargetLanguage::Ruby

--- a/framec/src/frame_c/compiler/codegen/state_dispatch.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch.rs
@@ -1221,6 +1221,7 @@ fn generate_per_handler_method_for_lang(
             handler_state_var_types,
             state_hsm_parents,
             state_param_types,
+            domain_field_types,
         ),
         TargetLanguage::Java => generate_java_handler_method(
             system_name,

--- a/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/go.rs
+++ b/framec/src/frame_c/compiler/codegen/state_dispatch/handler_methods/go.rs
@@ -41,6 +41,7 @@ pub(crate) fn generate_go_handler_method(
     handler_state_var_types: &std::collections::HashMap<String, String>,
     state_hsm_parents: &std::collections::HashMap<String, String>,
     state_param_types: &std::collections::HashMap<(String, String), String>,
+    domain_field_types: &std::collections::HashMap<String, String>,
 ) -> CodegenNode {
     let method_name = handler_method_name(state_name, handler);
     let lang = TargetLanguage::Go;
@@ -64,7 +65,11 @@ pub(crate) fn generate_go_handler_method(
         state_param_types: std::collections::HashMap::new(),
         state_enter_param_types: std::collections::HashMap::new(),
         state_exit_param_types: std::collections::HashMap::new(),
-        domain_field_types: std::collections::HashMap::new(),
+        // #112: thread the real field→type map so `@@:self.field.method()`
+        // is recognized as a cross-system call and the exported (capitalized)
+        // method name is emitted. Was `HashMap::new()`, which forced is_embed
+        // false → the raw lowercase name → undefined-method compile error.
+        domain_field_types: domain_field_types.clone(),
     };
 
     let mut body = String::new();


### PR DESCRIPTION
Fixes #112.

## Problem
Go exports interface methods by capitalizing the first letter (`tick` → `Tick`, `get_lives` → `Get_lives`), but a cross-system call `@@:self.field.method()` was emitted with the **raw lowercase** name (`s.field.tick(...)`). That references a method that doesn't exist, so the generated Go doesn't compile:
```
s.ship.tick undefined (type *Ship has no field or method tick, but does have method Tick)
```

## Root cause
`generate_go_handler_method` (`state_dispatch/handler_methods/go.rs`) built its `HandlerContext` with a hardcoded **empty** `domain_field_types` map. The embed check `ctx.domain_field_types.get(field)` therefore always returned `None`, so `is_embed` was always `false`, and the call fell to the raw-name branch in `expand_context_self_field_call`. C and C++ already thread the real field→type map (cpp.rs:67); Go was the gap.

## Fix
- Thread the real `domain_field_types` map into the Go handler context (mirrors C++).
- Capitalize the method at Go **embed** call sites in `context_self.rs` (non-embed scalar-field calls stay verbatim — framec doesn't control those names).
- Hoist `capitalize_first` into shared `codegen_utils` so the **definition** rename (go.rs) and the **call site** use the identical mapping and can't drift again — the def/call drift *was* the bug.

## Verification
- The issue's repro now `go build`s **and** `go run`s (was a compile error); call sites emit `s.ship.Tick(dt)` / `s.ship.Get_lives()`.
- **Go codegen is byte-identical to 4.6.0 across all 334 Go fixtures** — the fix only changes cross-system call output, and the corpus has **zero** such fixtures (the coverage gap that let this ship). So zero regression risk on existing fixtures.
- Lib **1017/0**; Go snapshots 13/13 (no regen); clippy + fmt clean.
- Docker matrix not run — the daemon is down in this environment; `make test-go` fails identically on `main` (control), confirming it's environmental, not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)